### PR TITLE
Timeout promises before search request

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
     command:
     - dst
     - run
+    - --aio-store
+    - postgres
     - --aio-store-postgres-host
     - postgres-dst
     - --aio-store-postgres-username

--- a/internal/app/coroutines/cancelPromise.go
+++ b/internal/app/coroutines/cancelPromise.go
@@ -30,12 +30,6 @@ func CancelPromise(t int64, req *types.Request, res func(int64, *types.Response,
 								Id: req.CancelPromise.Id,
 							},
 						},
-						{
-							Kind: types.StoreReadSubscriptions,
-							ReadSubscriptions: &types.ReadSubscriptionsCommand{
-								PromiseIds: []string{req.CancelPromise.Id},
-							},
-						},
 					},
 				},
 			},
@@ -49,11 +43,8 @@ func CancelPromise(t int64, req *types.Request, res func(int64, *types.Response,
 			}
 
 			util.Assert(completion.Store != nil, "completion must not be nil")
-			util.Assert(len(completion.Store.Results) == 2, "completion must contain two results")
 
 			result := completion.Store.Results[0].ReadPromise
-			records := completion.Store.Results[1].ReadSubscriptions.Records
-
 			util.Assert(result.RowsReturned == 0 || result.RowsReturned == 1, "result must return 0 or 1 rows")
 
 			if result.RowsReturned == 0 {
@@ -73,7 +64,7 @@ func CancelPromise(t int64, req *types.Request, res func(int64, *types.Response,
 
 				if p.State == promise.Pending {
 					if t >= p.Timeout {
-						s.Add(TimeoutPromise(t, p, records, CancelPromise(t, req, res), func(t int64, err error) {
+						s.Add(TimeoutPromise(t, p, CancelPromise(t, req, res), func(t int64, err error) {
 							if err != nil {
 								slog.Error("failed to timeout promise", "req", req, "err", err)
 								res(t, nil, err)
@@ -102,55 +93,41 @@ func CancelPromise(t int64, req *types.Request, res func(int64, *types.Response,
 							}, nil)
 						}))
 					} else {
-						commands := []*types.Command{
-							{
-								Kind: types.StoreUpdatePromise,
-								UpdatePromise: &types.UpdatePromiseCommand{
-									Id:          req.CancelPromise.Id,
-									State:       promise.Canceled,
-									Value:       req.CancelPromise.Value,
-									CompletedOn: t,
-								},
-							},
-							{
-								Kind: types.StoreDeleteTimeout,
-								DeleteTimeout: &types.DeleteTimeoutCommand{
-									Id: req.CancelPromise.Id,
-								},
-							},
-							{
-								Kind: types.StoreDeleteSubscriptions,
-								DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
-									PromiseId: req.CancelPromise.Id,
-								},
-							},
-						}
-
-						for _, record := range records {
-							commands = append(commands, &types.Command{
-								Kind: types.StoreCreateNotification,
-								CreateNotification: &types.CreateNotificationCommand{
-									Id:          record.Id,
-									PromiseId:   record.PromiseId,
-									Url:         record.Url,
-									RetryPolicy: record.RetryPolicy,
-									Time:        t,
-								},
-							})
-						}
-
 						submission := &types.Submission{
 							Kind: types.Store,
 							Store: &types.StoreSubmission{
 								Transaction: &types.Transaction{
-									Commands: commands,
+									Commands: []*types.Command{
+										{
+											Kind: types.StoreUpdatePromise,
+											UpdatePromise: &types.UpdatePromiseCommand{
+												Id:          req.CancelPromise.Id,
+												State:       promise.Canceled,
+												Value:       req.CancelPromise.Value,
+												CompletedOn: t,
+											},
+										},
+										{
+											Kind: types.StoreCreateNotifications,
+											CreateNotifications: &types.CreateNotificationsCommand{
+												PromiseId: req.CancelPromise.Id,
+												Time:      t,
+											},
+										},
+										{
+											Kind: types.StoreDeleteSubscriptions,
+											DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
+												PromiseId: req.CancelPromise.Id,
+											},
+										},
+									},
 								},
 							},
 						}
 
 						c.Yield(submission, func(t int64, completion *types.Completion, err error) {
 							if err != nil {
-								slog.Error("failed to update state", "req", req, "err", err)
+								slog.Error("failed to update promise", "req", req, "err", err)
 								res(t, nil, err)
 								return
 							}

--- a/internal/app/coroutines/completePromise.go
+++ b/internal/app/coroutines/completePromise.go
@@ -32,12 +32,6 @@ func CompletePromise(t int64, req *types.Request, res func(int64, *types.Respons
 								Id: req.CompletePromise.Id,
 							},
 						},
-						{
-							Kind: types.StoreReadSubscriptions,
-							ReadSubscriptions: &types.ReadSubscriptionsCommand{
-								PromiseIds: []string{req.CompletePromise.Id},
-							},
-						},
 					},
 				},
 			},
@@ -51,11 +45,8 @@ func CompletePromise(t int64, req *types.Request, res func(int64, *types.Respons
 			}
 
 			util.Assert(completion.Store != nil, "completion must not be nil")
-			util.Assert(len(completion.Store.Results) == 2, "completion must contain two results")
 
 			result := completion.Store.Results[0].ReadPromise
-			records := completion.Store.Results[1].ReadSubscriptions.Records
-
 			util.Assert(result.RowsReturned == 0 || result.RowsReturned == 1, "result must return 0 or 1 rows")
 
 			if result.RowsReturned == 0 {
@@ -75,7 +66,7 @@ func CompletePromise(t int64, req *types.Request, res func(int64, *types.Respons
 
 				if p.State == promise.Pending {
 					if t >= p.Timeout {
-						s.Add(TimeoutPromise(t, p, records, CompletePromise(t, req, res), func(t int64, err error) {
+						s.Add(TimeoutPromise(t, p, CompletePromise(t, req, res), func(t int64, err error) {
 							if err != nil {
 								slog.Error("failed to timeout promise", "req", req, "err", err)
 								res(t, nil, err)
@@ -104,55 +95,41 @@ func CompletePromise(t int64, req *types.Request, res func(int64, *types.Respons
 							}, nil)
 						}))
 					} else {
-						commands := []*types.Command{
-							{
-								Kind: types.StoreUpdatePromise,
-								UpdatePromise: &types.UpdatePromiseCommand{
-									Id:          req.CompletePromise.Id,
-									State:       req.CompletePromise.State,
-									Value:       req.CompletePromise.Value,
-									CompletedOn: t,
-								},
-							},
-							{
-								Kind: types.StoreDeleteTimeout,
-								DeleteTimeout: &types.DeleteTimeoutCommand{
-									Id: req.CompletePromise.Id,
-								},
-							},
-							{
-								Kind: types.StoreDeleteSubscriptions,
-								DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
-									PromiseId: req.CompletePromise.Id,
-								},
-							},
-						}
-
-						for _, record := range records {
-							commands = append(commands, &types.Command{
-								Kind: types.StoreCreateNotification,
-								CreateNotification: &types.CreateNotificationCommand{
-									Id:          record.Id,
-									PromiseId:   record.PromiseId,
-									Url:         record.Url,
-									RetryPolicy: record.RetryPolicy,
-									Time:        t,
-								},
-							})
-						}
-
 						submission := &types.Submission{
 							Kind: types.Store,
 							Store: &types.StoreSubmission{
 								Transaction: &types.Transaction{
-									Commands: commands,
+									Commands: []*types.Command{
+										{
+											Kind: types.StoreUpdatePromise,
+											UpdatePromise: &types.UpdatePromiseCommand{
+												Id:          req.CompletePromise.Id,
+												State:       req.CompletePromise.State,
+												Value:       req.CompletePromise.Value,
+												CompletedOn: t,
+											},
+										},
+										{
+											Kind: types.StoreCreateNotifications,
+											CreateNotifications: &types.CreateNotificationsCommand{
+												PromiseId: req.CompletePromise.Id,
+												Time:      t,
+											},
+										},
+										{
+											Kind: types.StoreDeleteSubscriptions,
+											DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
+												PromiseId: req.CompletePromise.Id,
+											},
+										},
+									},
 								},
 							},
 						}
 
 						c.Yield(submission, func(t int64, completion *types.Completion, err error) {
 							if err != nil {
-								slog.Error("failed to update state", "req", req, "err", err)
+								slog.Error("failed to update promise", "req", req, "err", err)
 								res(t, nil, err)
 								return
 							}

--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -73,7 +73,7 @@ func CreatePromise(t int64, req *types.Request, res func(int64, *types.Response,
 
 				c.Yield(submission, func(t int64, completion *types.Completion, err error) {
 					if err != nil {
-						slog.Error("failed to update state", "req", req, "err", err)
+						slog.Error("failed to update promise", "req", req, "err", err)
 						res(t, nil, err)
 						return
 					}

--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -66,13 +66,6 @@ func CreatePromise(t int64, req *types.Request, res func(int64, *types.Response,
 										CreatedOn: t,
 									},
 								},
-								{
-									Kind: types.StoreCreateTimeout,
-									CreateTimeout: &types.CreateTimeoutCommand{
-										Id:   req.CreatePromise.Id,
-										Time: req.CreatePromise.Timeout,
-									},
-								},
 							},
 						},
 					},
@@ -125,7 +118,7 @@ func CreatePromise(t int64, req *types.Request, res func(int64, *types.Response,
 				}
 
 				if p.State == promise.Pending && t >= p.Timeout {
-					s.Add(TimeoutPromise(t, p, nil, CreatePromise(t, req, res), func(t int64, err error) {
+					s.Add(TimeoutPromise(t, p, CreatePromise(t, req, res), func(t int64, err error) {
 						if err != nil {
 							slog.Error("failed to timeout promise", "req", req, "err", err)
 							res(t, nil, err)

--- a/internal/app/coroutines/readPromise.go
+++ b/internal/app/coroutines/readPromise.go
@@ -56,7 +56,7 @@ func ReadPromise(t int64, req *types.Request, res func(int64, *types.Response, e
 				}
 
 				if p.State == promise.Pending && t >= p.Timeout {
-					s.Add(TimeoutPromise(t, p, nil, ReadPromise(t, req, res), func(t int64, err error) {
+					s.Add(TimeoutPromise(t, p, ReadPromise(t, req, res), func(t int64, err error) {
 						if err != nil {
 							slog.Error("failed to timeout promise", "req", req, "err", err)
 							res(t, nil, err)

--- a/internal/app/coroutines/resolvePromise.go
+++ b/internal/app/coroutines/resolvePromise.go
@@ -127,7 +127,7 @@ func ResolvePromise(t int64, req *types.Request, res func(int64, *types.Response
 
 						c.Yield(submission, func(t int64, completion *types.Completion, err error) {
 							if err != nil {
-								slog.Error("failed to update state", "req", req, "err", err)
+								slog.Error("failed to update promise", "req", req, "err", err)
 								res(t, nil, err)
 								return
 							}

--- a/internal/app/coroutines/resolvePromise.go
+++ b/internal/app/coroutines/resolvePromise.go
@@ -30,12 +30,6 @@ func ResolvePromise(t int64, req *types.Request, res func(int64, *types.Response
 								Id: req.ResolvePromise.Id,
 							},
 						},
-						{
-							Kind: types.StoreReadSubscriptions,
-							ReadSubscriptions: &types.ReadSubscriptionsCommand{
-								PromiseIds: []string{req.ResolvePromise.Id},
-							},
-						},
 					},
 				},
 			},
@@ -49,11 +43,8 @@ func ResolvePromise(t int64, req *types.Request, res func(int64, *types.Response
 			}
 
 			util.Assert(completion.Store != nil, "completion must not be nil")
-			util.Assert(len(completion.Store.Results) == 2, "completion must contain two results")
 
 			result := completion.Store.Results[0].ReadPromise
-			records := completion.Store.Results[1].ReadSubscriptions.Records
-
 			util.Assert(result.RowsReturned == 0 || result.RowsReturned == 1, "result must return 0 or 1 rows")
 
 			if result.RowsReturned == 0 {
@@ -73,7 +64,7 @@ func ResolvePromise(t int64, req *types.Request, res func(int64, *types.Response
 
 				if p.State == promise.Pending {
 					if t >= p.Timeout {
-						s.Add(TimeoutPromise(t, p, records, ResolvePromise(t, req, res), func(t int64, err error) {
+						s.Add(TimeoutPromise(t, p, ResolvePromise(t, req, res), func(t int64, err error) {
 							if err != nil {
 								slog.Error("failed to timeout promise", "req", req, "err", err)
 								res(t, nil, err)
@@ -102,48 +93,34 @@ func ResolvePromise(t int64, req *types.Request, res func(int64, *types.Response
 							}, nil)
 						}))
 					} else {
-						commands := []*types.Command{
-							{
-								Kind: types.StoreUpdatePromise,
-								UpdatePromise: &types.UpdatePromiseCommand{
-									Id:          req.ResolvePromise.Id,
-									State:       promise.Resolved,
-									Value:       req.ResolvePromise.Value,
-									CompletedOn: t,
-								},
-							},
-							{
-								Kind: types.StoreDeleteTimeout,
-								DeleteTimeout: &types.DeleteTimeoutCommand{
-									Id: req.ResolvePromise.Id,
-								},
-							},
-							{
-								Kind: types.StoreDeleteSubscriptions,
-								DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
-									PromiseId: req.ResolvePromise.Id,
-								},
-							},
-						}
-
-						for _, record := range records {
-							commands = append(commands, &types.Command{
-								Kind: types.StoreCreateNotification,
-								CreateNotification: &types.CreateNotificationCommand{
-									Id:          record.Id,
-									PromiseId:   record.PromiseId,
-									Url:         record.Url,
-									RetryPolicy: record.RetryPolicy,
-									Time:        t,
-								},
-							})
-						}
-
 						submission := &types.Submission{
 							Kind: types.Store,
 							Store: &types.StoreSubmission{
 								Transaction: &types.Transaction{
-									Commands: commands,
+									Commands: []*types.Command{
+										{
+											Kind: types.StoreUpdatePromise,
+											UpdatePromise: &types.UpdatePromiseCommand{
+												Id:          req.ResolvePromise.Id,
+												State:       promise.Resolved,
+												Value:       req.ResolvePromise.Value,
+												CompletedOn: t,
+											},
+										},
+										{
+											Kind: types.StoreCreateNotifications,
+											CreateNotifications: &types.CreateNotificationsCommand{
+												PromiseId: req.ResolvePromise.Id,
+												Time:      t,
+											},
+										},
+										{
+											Kind: types.StoreDeleteSubscriptions,
+											DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
+												PromiseId: req.ResolvePromise.Id,
+											},
+										},
+									},
 								},
 							},
 						}

--- a/internal/app/coroutines/timeoutPromise.go
+++ b/internal/app/coroutines/timeoutPromise.go
@@ -8,113 +8,63 @@ import (
 	"github.com/resonatehq/resonate/internal/kernel/types"
 	"github.com/resonatehq/resonate/internal/util"
 	"github.com/resonatehq/resonate/pkg/promise"
-	"github.com/resonatehq/resonate/pkg/subscription"
 )
 
-func TimeoutPromise(t int64, p *promise.Promise, subscriptions []*subscription.SubscriptionRecord, retry *scheduler.Coroutine, res func(int64, error)) *scheduler.Coroutine {
+func TimeoutPromise(t int64, p *promise.Promise, retry *scheduler.Coroutine, res func(int64, error)) *scheduler.Coroutine {
 	return scheduler.NewCoroutine(fmt.Sprintf("TimeoutPromise(id=%s)", p.Id), "TimeoutPromise", func(s *scheduler.Scheduler, c *scheduler.Coroutine) {
-		if subscriptions != nil {
-			timeoutPromise(s, c, t, p, subscriptions, retry, res)
-		} else {
-			submission := &types.Submission{
-				Kind: types.Store,
-				Store: &types.StoreSubmission{
-					Transaction: &types.Transaction{
-						Commands: []*types.Command{
-							{
-								Kind: types.StoreReadSubscriptions,
-								ReadSubscriptions: &types.ReadSubscriptionsCommand{
-									PromiseIds: []string{p.Id},
+		submission := &types.Submission{
+			Kind: types.Store,
+			Store: &types.StoreSubmission{
+				Transaction: &types.Transaction{
+					Commands: []*types.Command{
+						{
+							Kind: types.StoreUpdatePromise,
+							UpdatePromise: &types.UpdatePromiseCommand{
+								Id:    p.Id,
+								State: promise.Timedout,
+								Value: promise.Value{
+									Headers: map[string]string{},
+									Ikey:    nil,
+									Data:    []byte{},
 								},
+								CompletedOn: p.Timeout,
+							},
+						},
+						{
+							Kind: types.StoreCreateNotifications,
+							CreateNotifications: &types.CreateNotificationsCommand{
+								PromiseId: p.Id,
+								Time:      t,
+							},
+						},
+						{
+							Kind: types.StoreDeleteSubscriptions,
+							DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
+								PromiseId: p.Id,
 							},
 						},
 					},
 				},
+			},
+		}
+
+		c.Yield(submission, func(t int64, completion *types.Completion, err error) {
+			if err != nil {
+				slog.Error("failed to update promise", "id", p.Id, "err", err)
+				res(t, err)
+				return
 			}
 
-			c.Yield(submission, func(t int64, completion *types.Completion, err error) {
-				if err != nil {
-					slog.Error("failed to read subscriptions", "id", p.Id, "err", err)
-					res(t, err)
-					return
-				}
+			util.Assert(completion.Store != nil, "completion must not be nil")
 
-				util.Assert(completion.Store != nil, "completion must not be nil")
-				subscriptions := completion.Store.Results[0].ReadSubscriptions.Records
+			result := completion.Store.Results[0].UpdatePromise
+			util.Assert(result.RowsAffected == 0 || result.RowsAffected == 1, "result must return 0 or 1 rows")
 
-				timeoutPromise(s, c, t, p, subscriptions, retry, res)
-			})
-		}
-	})
-}
-
-func timeoutPromise(s *scheduler.Scheduler, c *scheduler.Coroutine, t int64, p *promise.Promise, subscriptions []*subscription.SubscriptionRecord, retry *scheduler.Coroutine, res func(int64, error)) {
-	commands := []*types.Command{
-		{
-			Kind: types.StoreUpdatePromise,
-			UpdatePromise: &types.UpdatePromiseCommand{
-				Id:    p.Id,
-				State: promise.Timedout,
-				Value: promise.Value{
-					Headers: map[string]string{},
-					Ikey:    nil,
-					Data:    []byte{},
-				},
-				CompletedOn: p.Timeout,
-			},
-		},
-		{
-			Kind: types.StoreDeleteTimeout,
-			DeleteTimeout: &types.DeleteTimeoutCommand{
-				Id: p.Id,
-			},
-		},
-		{
-			Kind: types.StoreDeleteSubscriptions,
-			DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
-				PromiseId: p.Id,
-			},
-		},
-	}
-
-	for _, record := range subscriptions {
-		commands = append(commands, &types.Command{
-			Kind: types.StoreCreateNotification,
-			CreateNotification: &types.CreateNotificationCommand{
-				Id:          record.Id,
-				PromiseId:   record.PromiseId,
-				Url:         record.Url,
-				RetryPolicy: record.RetryPolicy,
-				Time:        t,
-			},
+			if result.RowsAffected == 1 {
+				res(t, nil)
+			} else {
+				s.Add(retry)
+			}
 		})
-	}
-
-	submission := &types.Submission{
-		Kind: types.Store,
-		Store: &types.StoreSubmission{
-			Transaction: &types.Transaction{
-				Commands: commands,
-			},
-		},
-	}
-
-	c.Yield(submission, func(t int64, completion *types.Completion, err error) {
-		if err != nil {
-			slog.Error("failed to update state", "id", p.Id, "err", err)
-			res(t, err)
-			return
-		}
-
-		util.Assert(completion.Store != nil, "completion must not be nil")
-
-		result := completion.Store.Results[0].UpdatePromise
-		util.Assert(result.RowsAffected == 0 || result.RowsAffected == 1, "result must return 0 or 1 rows")
-
-		if result.RowsAffected == 1 {
-			res(t, nil)
-		} else {
-			s.Add(retry)
-		}
 	})
 }

--- a/internal/app/coroutines/timeoutPromises.go
+++ b/internal/app/coroutines/timeoutPromises.go
@@ -8,8 +8,6 @@ import (
 	"github.com/resonatehq/resonate/internal/kernel/system"
 	"github.com/resonatehq/resonate/internal/kernel/types"
 	"github.com/resonatehq/resonate/internal/util"
-	"github.com/resonatehq/resonate/pkg/promise"
-	"github.com/resonatehq/resonate/pkg/timeout"
 )
 
 func TimeoutPromises(t int64, config *system.Config) *scheduler.Coroutine {
@@ -20,9 +18,21 @@ func TimeoutPromises(t int64, config *system.Config) *scheduler.Coroutine {
 				Transaction: &types.Transaction{
 					Commands: []*types.Command{
 						{
-							Kind: types.StoreReadTimeouts,
-							ReadTimeouts: &types.ReadTimeoutsCommand{
-								N: config.TimeoutCacheSize,
+							Kind: types.StoreTimeoutCreateNotifications,
+							TimeoutCreateNotifications: &types.TimeoutCreateNotificationsCommand{
+								Time: t,
+							},
+						},
+						{
+							Kind: types.StoreTimeoutDeleteSubscriptions,
+							TimeoutDeleteSubscriptions: &types.TimeoutDeleteSubscriptionsCommand{
+								Time: t,
+							},
+						},
+						{
+							Kind: types.StoreTimeoutPromises,
+							TimeoutPromises: &types.TimeoutPromisesCommand{
+								Time: t,
 							},
 						},
 					},
@@ -37,101 +47,15 @@ func TimeoutPromises(t int64, config *system.Config) *scheduler.Coroutine {
 			}
 
 			util.Assert(completion.Store != nil, "completion must not be nil")
+			util.Assert(len(completion.Store.Results) == 3, "completion must have three results")
 
-			records := completion.Store.Results[0].ReadTimeouts.Records
-			timeouts := []*timeout.TimeoutRecord{}
-			promiseIds := []string{}
+			notifications := completion.Store.Results[0].TimeoutCreateNotifications.RowsAffected
+			subscriptions := completion.Store.Results[1].TimeoutDeleteSubscriptions.RowsAffected
+			promises := completion.Store.Results[2].TimeoutPromises.RowsAffected
 
-			for _, record := range records {
-				if t >= record.Time {
-					timeouts = append(timeouts, record)
-					promiseIds = append(promiseIds, record.Id)
-				}
-			}
-
-			if len(promiseIds) > 0 {
-				submission := &types.Submission{
-					Kind: types.Store,
-					Store: &types.StoreSubmission{
-						Transaction: &types.Transaction{
-							Commands: []*types.Command{
-								{
-									Kind: types.StoreReadSubscriptions,
-									ReadSubscriptions: &types.ReadSubscriptionsCommand{
-										PromiseIds: promiseIds,
-									},
-								},
-							},
-						},
-					},
-				}
-
-				c.Yield(submission, func(t int64, completion *types.Completion, err error) {
-					if err != nil {
-						slog.Error("failed to read subscriptions", "err", err)
-						return
-					}
-
-					util.Assert(completion.Store != nil, "completion must not be nil")
-
-					records := completion.Store.Results[0].ReadSubscriptions.Records
-					commands := []*types.Command{}
-
-					for _, timeout := range timeouts {
-						commands = append(commands, &types.Command{
-							Kind: types.StoreUpdatePromise,
-							UpdatePromise: &types.UpdatePromiseCommand{
-								Id:    timeout.Id,
-								State: promise.Timedout,
-								Value: promise.Value{
-									Headers: map[string]string{},
-									Ikey:    nil,
-									Data:    []byte{},
-								},
-								CompletedOn: timeout.Time,
-							},
-						}, &types.Command{
-							Kind: types.StoreDeleteTimeout,
-							DeleteTimeout: &types.DeleteTimeoutCommand{
-								Id: timeout.Id,
-							},
-						}, &types.Command{
-							Kind: types.StoreDeleteSubscriptions,
-							DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
-								PromiseId: timeout.Id,
-							},
-						})
-					}
-
-					for _, record := range records {
-						commands = append(commands, &types.Command{
-							Kind: types.StoreCreateNotification,
-							CreateNotification: &types.CreateNotificationCommand{
-								Id:          record.Id,
-								PromiseId:   record.PromiseId,
-								Url:         record.Url,
-								RetryPolicy: record.RetryPolicy,
-								Time:        t,
-							},
-						})
-					}
-
-					submission := &types.Submission{
-						Kind: types.Store,
-						Store: &types.StoreSubmission{
-							Transaction: &types.Transaction{
-								Commands: commands,
-							},
-						},
-					}
-
-					c.Yield(submission, func(t int64, completion *types.Completion, err error) {
-						if err != nil {
-							slog.Error("failed to update state", "err", err)
-							return
-						}
-					})
-				})
+			util.Assert(notifications == subscriptions, "must create the same number of notifications as subscriptions deleted")
+			if promises == 0 {
+				util.Assert(subscriptions == 0 && notifications == 0, "must not create notifications when no promises timed out")
 			}
 		})
 	})

--- a/internal/app/subsystems/aio/store/test/util.go
+++ b/internal/app/subsystems/aio/store/test/util.go
@@ -1690,7 +1690,7 @@ var TestCases = []*testCase{
 		expected: []*types.Result{
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
@@ -1721,13 +1721,13 @@ var TestCases = []*testCase{
 		expected: []*types.Result{
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 0,
 				},
 			},
@@ -1756,13 +1756,13 @@ var TestCases = []*testCase{
 		expected: []*types.Result{
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
 			{
 				Kind: types.StoreDeleteSubscription,
-				DeleteSubscription: &types.AlterSubscriptionResult{
+				DeleteSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
@@ -1791,7 +1791,7 @@ var TestCases = []*testCase{
 		expected: []*types.Result{
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
@@ -1851,19 +1851,19 @@ var TestCases = []*testCase{
 		expected: []*types.Result{
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
 			{
 				Kind: types.StoreCreateSubscription,
-				CreateSubscription: &types.AlterSubscriptionResult{
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
@@ -1896,172 +1896,310 @@ var TestCases = []*testCase{
 		},
 	},
 	{
-		name: "CreateNotification",
+		name: "TimeoutPromises",
 		commands: []*types.Command{
 			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "foo",
+					Timeout: 2,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
 					Id:          "foo",
 					PromiseId:   "foo",
 					Url:         "https://foo.com",
-					Time:        0,
-					RetryPolicy: []byte("{}"),
-				},
-			},
-		},
-		expected: []*types.Result{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
-					RowsAffected: 1,
-				},
-			},
-		},
-	},
-	{
-		name: "CreateNotificationTwice",
-		commands: []*types.Command{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
-					Id:          "foo",
-					PromiseId:   "foo",
-					Url:         "https://foo.com",
-					Time:        0,
-					RetryPolicy: []byte("{}"),
+					RetryPolicy: &subscription.RetryPolicy{Delay: 1, Attempts: 1},
 				},
 			},
 			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
-					Id:          "foo",
-					PromiseId:   "foo",
-					Url:         "https://foo.com",
-					Time:        1,
-					RetryPolicy: []byte("{}"),
-				},
-			},
-		},
-		expected: []*types.Result{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
-					RowsAffected: 1,
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "bar",
+					Timeout: 2,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
 				},
 			},
 			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
-					RowsAffected: 0,
-				},
-			},
-		},
-	},
-	{
-		name: "UpdateNotification",
-		commands: []*types.Command{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
-					Id:          "foo",
-					PromiseId:   "foo",
-					Url:         "https://foo.com",
-					Time:        0,
-					RetryPolicy: []byte("{}"),
-				},
-			},
-			{
-				Kind: types.StoreUpdateNotification,
-				UpdateNotification: &types.UpdateNotificationCommand{
-					Id:        "foo",
-					PromiseId: "foo",
-					Time:      1,
-					Attempt:   1,
-				},
-			},
-		},
-		expected: []*types.Result{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
-					RowsAffected: 1,
-				},
-			},
-			{
-				Kind: types.StoreUpdateNotification,
-				UpdateNotification: &types.AlterNotificationsResult{
-					RowsAffected: 1,
-				},
-			},
-		},
-	},
-	{
-		name: "DeleteNotification",
-		commands: []*types.Command{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
-					Id:          "foo",
-					PromiseId:   "foo",
-					Url:         "https://foo.com",
-					Time:        0,
-					RetryPolicy: []byte("{}"),
-				},
-			},
-			{
-				Kind: types.StoreDeleteNotification,
-				DeleteNotification: &types.DeleteNotificationCommand{
-					Id:        "foo",
-					PromiseId: "foo",
-				},
-			},
-		},
-		expected: []*types.Result{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
-					RowsAffected: 1,
-				},
-			},
-			{
-				Kind: types.StoreDeleteNotification,
-				DeleteNotification: &types.AlterNotificationsResult{
-					RowsAffected: 1,
-				},
-			},
-		},
-	},
-	{
-		name: "ReadNotification",
-		commands: []*types.Command{
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
-					Id:          "foo",
-					PromiseId:   "foo",
-					Url:         "https://foo.com",
-					Time:        0,
-					RetryPolicy: []byte("{\"delay\":1,\"attempts\":1}"),
-				},
-			},
-			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
 					Id:          "bar",
 					PromiseId:   "bar",
 					Url:         "https://bar.com",
-					Time:        1,
-					RetryPolicy: []byte("{\"delay\":2,\"attempts\":2}"),
+					RetryPolicy: &subscription.RetryPolicy{Delay: 2, Attempts: 2},
 				},
 			},
 			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.CreateNotificationCommand{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "baz",
+					Timeout: 2,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
 					Id:          "baz",
 					PromiseId:   "baz",
 					Url:         "https://baz.com",
-					Time:        2,
-					RetryPolicy: []byte("{\"delay\":3,\"attempts\":3}"),
+					RetryPolicy: &subscription.RetryPolicy{Delay: 3, Attempts: 3},
+				},
+			},
+			{
+				Kind: types.StoreTimeoutCreateNotifications,
+				TimeoutCreateNotifications: &types.TimeoutCreateNotificationsCommand{
+					Time: 2,
+				},
+			},
+			{
+				Kind: types.StoreTimeoutDeleteSubscriptions,
+				TimeoutDeleteSubscriptions: &types.TimeoutDeleteSubscriptionsCommand{
+					Time: 2,
+				},
+			},
+			{
+				Kind: types.StoreTimeoutPromises,
+				TimeoutPromises: &types.TimeoutPromisesCommand{
+					Time: 2,
+				},
+			},
+			{
+				Kind: types.StoreReadNotifications,
+				ReadNotifications: &types.ReadNotificationsCommand{
+					N: 5,
+				},
+			},
+			{
+				Kind: types.StoreReadSubscriptions,
+				ReadSubscriptions: &types.ReadSubscriptionsCommand{
+					PromiseIds: []string{"foo", "bar", "baz"},
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.SearchPromisesCommand{
+					Q:      "*",
+					States: []promise.State{promise.Timedout},
+					Limit:  5,
+				},
+			},
+		},
+		expected: []*types.Result{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreTimeoutCreateNotifications,
+				TimeoutCreateNotifications: &types.AlterNotificationsResult{
+					RowsAffected: 3,
+				},
+			},
+			{
+				Kind: types.StoreTimeoutDeleteSubscriptions,
+				TimeoutDeleteSubscriptions: &types.AlterSubscriptionsResult{
+					RowsAffected: 3,
+				},
+			},
+			{
+				Kind: types.StoreTimeoutPromises,
+				TimeoutPromises: &types.AlterPromisesResult{
+					RowsAffected: 3,
+				},
+			},
+			{
+				Kind: types.StoreReadNotifications,
+				ReadNotifications: &types.QueryNotificationsResult{
+					RowsReturned: 3,
+					Records: []*notification.NotificationRecord{
+						{
+							Id:          "bar",
+							PromiseId:   "bar",
+							Url:         "https://bar.com",
+							RetryPolicy: []byte("{\"delay\":2,\"attempts\":2}"),
+							Time:        2,
+							Attempt:     0,
+						},
+						{
+							Id:          "baz",
+							PromiseId:   "baz",
+							Url:         "https://baz.com",
+							RetryPolicy: []byte("{\"delay\":3,\"attempts\":3}"),
+							Time:        2,
+							Attempt:     0,
+						},
+						{
+							Id:          "foo",
+							PromiseId:   "foo",
+							Url:         "https://foo.com",
+							RetryPolicy: []byte("{\"delay\":1,\"attempts\":1}"),
+							Time:        2,
+							Attempt:     0,
+						},
+					},
+				},
+			},
+			{
+				Kind: types.StoreReadSubscriptions,
+				ReadSubscriptions: &types.QuerySubscriptionsResult{
+					RowsReturned: 0,
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.QueryPromisesResult{
+					RowsReturned: 3,
+					LastSortId:   1,
+					Records: []*promise.PromiseRecord{
+						{
+							Id:           "baz",
+							State:        8,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							CompletedOn:  int64ToPointer(2),
+							Tags:         []byte("{}"),
+							SortId:       3,
+						},
+						{
+							Id:           "bar",
+							State:        8,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							CompletedOn:  int64ToPointer(2),
+							Tags:         []byte("{}"),
+							SortId:       2,
+						},
+						{
+							Id:           "foo",
+							State:        8,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							CompletedOn:  int64ToPointer(2),
+							Tags:         []byte("{}"),
+							SortId:       1,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "CreateNotifications",
+		commands: []*types.Command{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "foo",
+					Timeout: 1,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
+					Id:          "foo",
+					PromiseId:   "foo",
+					Url:         "https://foo.com",
+					RetryPolicy: &subscription.RetryPolicy{Delay: 1, Attempts: 1},
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
+					Id:          "bar",
+					PromiseId:   "foo",
+					Url:         "https://bar.com",
+					RetryPolicy: &subscription.RetryPolicy{Delay: 2, Attempts: 2},
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
+					Id:          "baz",
+					PromiseId:   "foo",
+					Url:         "https://baz.com",
+					RetryPolicy: &subscription.RetryPolicy{Delay: 3, Attempts: 3},
+				},
+			},
+			{
+				Kind: types.StoreUpdatePromise,
+				UpdatePromise: &types.UpdatePromiseCommand{
+					Id:    "foo",
+					State: 2,
+					Value: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					CompletedOn: 2,
+				},
+			},
+			{
+				Kind: types.StoreCreateNotifications,
+				CreateNotifications: &types.CreateNotificationsCommand{
+					PromiseId: "foo",
+					Time:      2,
 				},
 			},
 			{
@@ -2073,21 +2211,39 @@ var TestCases = []*testCase{
 		},
 		expected: []*types.Result{
 			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
 					RowsAffected: 1,
 				},
 			},
 			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
 				},
 			},
 			{
-				Kind: types.StoreCreateNotification,
-				CreateNotification: &types.AlterNotificationsResult{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
 					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreUpdatePromise,
+				UpdatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateNotifications,
+				CreateNotifications: &types.AlterNotificationsResult{
+					RowsAffected: 3,
 				},
 			},
 			{
@@ -2096,30 +2252,260 @@ var TestCases = []*testCase{
 					RowsReturned: 3,
 					Records: []*notification.NotificationRecord{
 						{
-							Id:          "foo",
-							PromiseId:   "foo",
-							Url:         "https://foo.com",
-							Time:        0,
-							Attempt:     0,
-							RetryPolicy: []byte("{\"delay\":1,\"attempts\":1}"),
-						},
-						{
 							Id:          "bar",
-							PromiseId:   "bar",
+							PromiseId:   "foo",
 							Url:         "https://bar.com",
-							Time:        1,
-							Attempt:     0,
 							RetryPolicy: []byte("{\"delay\":2,\"attempts\":2}"),
+							Time:        2,
+							Attempt:     0,
 						},
 						{
 							Id:          "baz",
-							PromiseId:   "baz",
+							PromiseId:   "foo",
 							Url:         "https://baz.com",
+							RetryPolicy: []byte("{\"delay\":3,\"attempts\":3}"),
 							Time:        2,
 							Attempt:     0,
-							RetryPolicy: []byte("{\"delay\":3,\"attempts\":3}"),
+						},
+						{
+							Id:          "foo",
+							PromiseId:   "foo",
+							Url:         "https://foo.com",
+							RetryPolicy: []byte("{\"delay\":1,\"attempts\":1}"),
+							Time:        2,
+							Attempt:     0,
 						},
 					},
+				},
+			},
+		},
+	},
+	{
+		name: "UpdateNotification",
+		commands: []*types.Command{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "foo",
+					Timeout: 1,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
+					Id:          "foo",
+					PromiseId:   "foo",
+					Url:         "https://foo.com",
+					RetryPolicy: &subscription.RetryPolicy{Delay: 1, Attempts: 1},
+				},
+			},
+			{
+				Kind: types.StoreUpdatePromise,
+				UpdatePromise: &types.UpdatePromiseCommand{
+					Id:    "foo",
+					State: 2,
+					Value: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					CompletedOn: 2,
+				},
+			},
+			{
+				Kind: types.StoreCreateNotifications,
+				CreateNotifications: &types.CreateNotificationsCommand{
+					PromiseId: "foo",
+					Time:      2,
+				},
+			},
+			{
+				Kind: types.StoreUpdateNotification,
+				UpdateNotification: &types.UpdateNotificationCommand{
+					Id:        "foo",
+					PromiseId: "foo",
+					Time:      4,
+					Attempt:   1,
+				},
+			},
+			{
+				Kind: types.StoreReadNotifications,
+				ReadNotifications: &types.ReadNotificationsCommand{
+					N: 1,
+				},
+			},
+		},
+		expected: []*types.Result{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreUpdatePromise,
+				UpdatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateNotifications,
+				CreateNotifications: &types.AlterNotificationsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreUpdateNotification,
+				UpdateNotification: &types.AlterNotificationsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreReadNotifications,
+				ReadNotifications: &types.QueryNotificationsResult{
+					RowsReturned: 1,
+					Records: []*notification.NotificationRecord{
+						{
+							Id:          "foo",
+							PromiseId:   "foo",
+							Url:         "https://foo.com",
+							RetryPolicy: []byte("{\"delay\":1,\"attempts\":1}"),
+							Time:        4,
+							Attempt:     1,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "DeleteNotification",
+		commands: []*types.Command{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "foo",
+					Timeout: 1,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.CreateSubscriptionCommand{
+					Id:          "foo",
+					PromiseId:   "foo",
+					Url:         "https://foo.com",
+					RetryPolicy: &subscription.RetryPolicy{Delay: 1, Attempts: 1},
+				},
+			},
+			{
+				Kind: types.StoreUpdatePromise,
+				UpdatePromise: &types.UpdatePromiseCommand{
+					Id:    "foo",
+					State: 2,
+					Value: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					CompletedOn: 2,
+				},
+			},
+			{
+				Kind: types.StoreCreateNotifications,
+				CreateNotifications: &types.CreateNotificationsCommand{
+					PromiseId: "foo",
+					Time:      2,
+				},
+			},
+			{
+				Kind: types.StoreDeleteSubscriptions,
+				DeleteSubscriptions: &types.DeleteSubscriptionsCommand{
+					PromiseId: "foo",
+				},
+			},
+			{
+				Kind: types.StoreDeleteNotification,
+				DeleteNotification: &types.DeleteNotificationCommand{
+					Id:        "foo",
+					PromiseId: "foo",
+				},
+			},
+			{
+				Kind: types.StoreReadSubscriptions,
+				ReadSubscriptions: &types.ReadSubscriptionsCommand{
+					PromiseIds: []string{"foo"},
+				},
+			},
+			{
+				Kind: types.StoreReadNotifications,
+				ReadNotifications: &types.ReadNotificationsCommand{
+					N: 1,
+				},
+			},
+		},
+		expected: []*types.Result{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateSubscription,
+				CreateSubscription: &types.AlterSubscriptionsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreUpdatePromise,
+				UpdatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreateNotifications,
+				CreateNotifications: &types.AlterNotificationsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreDeleteSubscriptions,
+				DeleteSubscriptions: &types.AlterSubscriptionsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreDeleteNotification,
+				DeleteNotification: &types.AlterNotificationsResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreReadSubscriptions,
+				ReadSubscriptions: &types.QuerySubscriptionsResult{
+					RowsReturned: 0,
+				},
+			},
+			{
+				Kind: types.StoreReadNotifications,
+				ReadNotifications: &types.QueryNotificationsResult{
+					RowsReturned: 0,
 				},
 			},
 		},

--- a/internal/kernel/types/aio_store.go
+++ b/internal/kernel/types/aio_store.go
@@ -23,9 +23,12 @@ const (
 	StoreDeleteSubscription
 	StoreDeleteSubscriptions
 	StoreReadNotifications
-	StoreCreateNotification
+	StoreCreateNotifications
 	StoreUpdateNotification
 	StoreDeleteNotification
+	StoreTimeoutPromises
+	StoreTimeoutDeleteSubscriptions
+	StoreTimeoutCreateNotifications
 )
 
 type StoreSubmission struct {
@@ -41,44 +44,52 @@ type Transaction struct {
 }
 
 type Command struct {
-	Kind                StoreKind
-	ReadPromise         *ReadPromiseCommand
-	SearchPromises      *SearchPromisesCommand
-	CreatePromise       *CreatePromiseCommand
-	UpdatePromise       *UpdatePromiseCommand
-	ReadTimeouts        *ReadTimeoutsCommand
-	CreateTimeout       *CreateTimeoutCommand
-	DeleteTimeout       *DeleteTimeoutCommand
-	ReadSubscription    *ReadSubscriptionCommand
-	ReadSubscriptions   *ReadSubscriptionsCommand
-	CreateSubscription  *CreateSubscriptionCommand
-	DeleteSubscription  *DeleteSubscriptionCommand
-	DeleteSubscriptions *DeleteSubscriptionsCommand
-	ReadNotifications   *ReadNotificationsCommand
-	CreateNotification  *CreateNotificationCommand
-	UpdateNotification  *UpdateNotificationCommand
-	DeleteNotification  *DeleteNotificationCommand
+	Kind                       StoreKind
+	ReadPromise                *ReadPromiseCommand
+	SearchPromises             *SearchPromisesCommand
+	CreatePromise              *CreatePromiseCommand
+	UpdatePromise              *UpdatePromiseCommand
+	ReadTimeouts               *ReadTimeoutsCommand
+	CreateTimeout              *CreateTimeoutCommand
+	DeleteTimeout              *DeleteTimeoutCommand
+	ReadSubscription           *ReadSubscriptionCommand
+	ReadSubscriptions          *ReadSubscriptionsCommand
+	CreateSubscription         *CreateSubscriptionCommand
+	DeleteSubscription         *DeleteSubscriptionCommand
+	DeleteSubscriptions        *DeleteSubscriptionsCommand
+	ReadNotifications          *ReadNotificationsCommand
+	CreateNotifications        *CreateNotificationsCommand
+	UpdateNotification         *UpdateNotificationCommand
+	DeleteNotification         *DeleteNotificationCommand
+	TimeoutPromises            *TimeoutPromisesCommand
+	TimeoutDeleteSubscriptions *TimeoutDeleteSubscriptionsCommand
+	TimeoutCreateNotifications *TimeoutCreateNotificationsCommand
 }
 
 type Result struct {
-	Kind                StoreKind
-	ReadPromise         *QueryPromisesResult
-	SearchPromises      *QueryPromisesResult
-	CreatePromise       *AlterPromisesResult
-	UpdatePromise       *AlterPromisesResult
-	ReadTimeouts        *QueryTimeoutsResult
-	CreateTimeout       *AlterTimeoutsResult
-	DeleteTimeout       *AlterTimeoutsResult
-	ReadSubscription    *QuerySubscriptionsResult
-	ReadSubscriptions   *QuerySubscriptionsResult
-	CreateSubscription  *AlterSubscriptionResult
-	DeleteSubscription  *AlterSubscriptionResult
-	DeleteSubscriptions *AlterSubscriptionResult
-	ReadNotifications   *QueryNotificationsResult
-	CreateNotification  *AlterNotificationsResult
-	UpdateNotification  *AlterNotificationsResult
-	DeleteNotification  *AlterNotificationsResult
+	Kind                       StoreKind
+	ReadPromise                *QueryPromisesResult
+	SearchPromises             *QueryPromisesResult
+	CreatePromise              *AlterPromisesResult
+	UpdatePromise              *AlterPromisesResult
+	ReadTimeouts               *QueryTimeoutsResult
+	CreateTimeout              *AlterTimeoutsResult
+	DeleteTimeout              *AlterTimeoutsResult
+	ReadSubscription           *QuerySubscriptionsResult
+	ReadSubscriptions          *QuerySubscriptionsResult
+	CreateSubscription         *AlterSubscriptionsResult
+	DeleteSubscription         *AlterSubscriptionsResult
+	DeleteSubscriptions        *AlterSubscriptionsResult
+	ReadNotifications          *QueryNotificationsResult
+	CreateNotifications        *AlterNotificationsResult
+	UpdateNotification         *AlterNotificationsResult
+	DeleteNotification         *AlterNotificationsResult
+	TimeoutPromises            *AlterPromisesResult
+	TimeoutDeleteSubscriptions *AlterSubscriptionsResult
+	TimeoutCreateNotifications *AlterNotificationsResult
 }
+
+// Promise commands
 
 type ReadPromiseCommand struct {
 	Id string
@@ -107,6 +118,8 @@ type UpdatePromiseCommand struct {
 	CompletedOn int64
 }
 
+// Promise results
+
 type QueryPromisesResult struct {
 	RowsReturned int64
 	LastSortId   int64
@@ -116,6 +129,8 @@ type QueryPromisesResult struct {
 type AlterPromisesResult struct {
 	RowsAffected int64
 }
+
+// Timeout commands
 
 type ReadTimeoutsCommand struct {
 	N int
@@ -130,6 +145,20 @@ type DeleteTimeoutCommand struct {
 	Id string
 }
 
+type TimeoutPromisesCommand struct {
+	Time int64
+}
+
+type TimeoutDeleteSubscriptionsCommand struct {
+	Time int64
+}
+
+type TimeoutCreateNotificationsCommand struct {
+	Time int64
+}
+
+// Timeout results
+
 type QueryTimeoutsResult struct {
 	RowsReturned int64
 	Records      []*timeout.TimeoutRecord
@@ -138,6 +167,8 @@ type QueryTimeoutsResult struct {
 type AlterTimeoutsResult struct {
 	RowsAffected int64
 }
+
+// Subscription commands
 
 type ReadSubscriptionCommand struct {
 	Id        string
@@ -165,25 +196,26 @@ type DeleteSubscriptionsCommand struct {
 	PromiseId string
 }
 
+// Subscription results
+
 type QuerySubscriptionsResult struct {
 	RowsReturned int64
 	Records      []*subscription.SubscriptionRecord
 }
 
-type AlterSubscriptionResult struct {
+type AlterSubscriptionsResult struct {
 	RowsAffected int64
 }
+
+// Notification commands
 
 type ReadNotificationsCommand struct {
 	N int
 }
 
-type CreateNotificationCommand struct {
-	Id          string
-	PromiseId   string
-	Url         string
-	RetryPolicy []byte
-	Time        int64
+type CreateNotificationsCommand struct {
+	PromiseId string
+	Time      int64
 }
 
 type UpdateNotificationCommand struct {
@@ -197,6 +229,8 @@ type DeleteNotificationCommand struct {
 	Id        string
 	PromiseId string
 }
+
+// Notification results
 
 type QueryNotificationsResult struct {
 	RowsReturned int64


### PR DESCRIPTION
Rather than switch the state of "logically timedout" promises at read time, we can timeout promises prior to searching.  To do this we need ensure we still create the corresponding notifications, delete subscriptions, and update the promise all in one transaction.

```sql
INSERT INTO notifications
    (id, promise_id, url, retry_policy, time, attempt)
SELECT
	id, promise_id, url, retry_policy, $1, 0
FROM
	subscriptions
WHERE
	promise_id IN (SELECT id FROM promises WHERE state = 1 AND timeout <= $1)

DELETE FROM
	subscriptions
WHERE
	promise_id IN (SELECT id FROM promises WHERE state = 1 AND timeout <= $1)

UPDATE
	promises
SET
	state = 8, completed_on = timeout
WHERE
	state = 1 AND timeout <= $1
```

This PR also changes the regular timeout promises coroutine to use the same logic as well as all complete promise coroutines to create notifications using the same logic. 