### PR TITLE
Add search dsl

### DIFF
--- a/internal/app/subsystems/aio/store/test/util.go
+++ b/internal/app/subsystems/aio/store/test/util.go
@@ -1072,7 +1072,247 @@ var TestCases = []*testCase{
 		},
 	},
 	{
-		name: "SearchPromises",
+		name: "SearchPromisesById",
+		commands: []*types.Command{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "foo.a",
+					Timeout: 2,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "foo.b",
+					Timeout: 2,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "a.bar",
+					Timeout: 2,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.CreatePromiseCommand{
+					Id:      "b.bar",
+					Timeout: 2,
+					Param: promise.Value{
+						Headers: map[string]string{},
+						Data:    []byte{},
+					},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.SearchPromisesCommand{
+					Q: "foo.*",
+					States: []promise.State{
+						promise.Pending,
+					},
+					Limit: 2,
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.SearchPromisesCommand{
+					Q: "*.bar",
+					States: []promise.State{
+						promise.Pending,
+					},
+					Limit: 2,
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.SearchPromisesCommand{
+					Q: "*",
+					States: []promise.State{
+						promise.Pending,
+					},
+					Limit: 2,
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.SearchPromisesCommand{
+					Q: "*",
+					States: []promise.State{
+						promise.Pending,
+					},
+					Limit:  2,
+					SortId: int64ToPointer(3),
+				},
+			},
+		},
+		expected: []*types.Result{
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreCreatePromise,
+				CreatePromise: &types.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.QueryPromisesResult{
+					RowsReturned: 2,
+					LastSortId:   1,
+					Records: []*promise.PromiseRecord{
+						{
+							Id:           "foo.b",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       2,
+						},
+						{
+							Id:           "foo.a",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       1,
+						},
+					},
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.QueryPromisesResult{
+					RowsReturned: 2,
+					LastSortId:   3,
+					Records: []*promise.PromiseRecord{
+						{
+							Id:           "b.bar",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       4,
+						},
+						{
+							Id:           "a.bar",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       3,
+						},
+					},
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.QueryPromisesResult{
+					RowsReturned: 2,
+					LastSortId:   3,
+					Records: []*promise.PromiseRecord{
+						{
+							Id:           "b.bar",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       4,
+						},
+						{
+							Id:           "a.bar",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       3,
+						},
+					},
+				},
+			},
+			{
+				Kind: types.StoreSearchPromises,
+				SearchPromises: &types.QueryPromisesResult{
+					RowsReturned: 2,
+					LastSortId:   1,
+					Records: []*promise.PromiseRecord{
+						{
+							Id:           "foo.b",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       2,
+						},
+						{
+							Id:           "foo.a",
+							State:        1,
+							ParamHeaders: []byte("{}"),
+							ParamData:    []byte{},
+							Timeout:      2,
+							CreatedOn:    int64ToPointer(1),
+							Tags:         []byte("{}"),
+							SortId:       1,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "SearchPromisesByState",
 		commands: []*types.Command{
 			{
 				Kind: types.StoreCreatePromise,

--- a/test/dst/generator.go
+++ b/test/dst/generator.go
@@ -125,6 +125,14 @@ func (g *Generator) GenerateSearchPromises(r *rand.Rand, t int64) *types.Request
 	limit := r.Intn(10)
 	states := []promise.State{}
 
+	var query string
+	switch r.Intn(2) {
+	case 0:
+		query = fmt.Sprintf("*%d", r.Intn(10))
+	default:
+		query = fmt.Sprintf("%d*", r.Intn(10))
+	}
+
 	for i := 0; i < r.Intn(5); i++ {
 		switch r.Intn(5) {
 		case 0:
@@ -143,7 +151,7 @@ func (g *Generator) GenerateSearchPromises(r *rand.Rand, t int64) *types.Request
 	return &types.Request{
 		Kind: types.SearchPromises,
 		SearchPromises: &types.SearchPromisesRequest{
-			Q:      "*",
+			Q:      query,
 			States: states,
 			Limit:  limit,
 		},


### PR DESCRIPTION
Currently only simple wildcard queries with an asterisk `*` are supported

| query | sql | regex equivalent |
| --- | --- | --- |
| `*` | `WHERE id LIKE %` | `^.*$` |
| `foo.*` | `WHERE id LIKE foo.%` | `^foo\..*$` |
| `*.bar` | `WHERE id LIKE %.bar` | `^.*bar\.$` |