### PR TITLE
refactor common code from http and grpc subsystem into a service

### DIFF
--- a/internal/app/subsystems/api/grpc/grpc.go
+++ b/internal/app/subsystems/api/grpc/grpc.go
@@ -25,7 +25,7 @@ type Grpc struct {
 }
 
 func New(api api.API, config *Config) api.Subsystem {
-	s := &server{service: &service.Service{Api: api, ServerProtocol: "grpc"}}
+	s := &server{service: service.New(api, "grpc")}
 
 	server := grpc.NewServer(grpc.UnaryInterceptor(s.log)) // nosemgrep
 	grpcApi.RegisterPromiseServiceServer(server, s)

--- a/internal/app/subsystems/api/grpc/grpc.go
+++ b/internal/app/subsystems/api/grpc/grpc.go
@@ -25,7 +25,7 @@ type Grpc struct {
 }
 
 func New(api api.API, config *Config) api.Subsystem {
-	s := &server{service: &service.Service{Api: api}}
+	s := &server{service: &service.Service{Api: api, ServerProtocol: "grpc"}}
 
 	server := grpc.NewServer(grpc.UnaryInterceptor(s.log)) // nosemgrep
 	grpcApi.RegisterPromiseServiceServer(server, s)

--- a/internal/app/subsystems/api/grpc/grpc.go
+++ b/internal/app/subsystems/api/grpc/grpc.go
@@ -2,15 +2,13 @@ package grpc
 
 import (
 	"context"
-	"net"
-
+	"github.com/resonatehq/resonate/internal/app/subsystems/api/service"
 	"log/slog"
+	"net"
 
 	"github.com/resonatehq/resonate/internal/api"
 	grpcApi "github.com/resonatehq/resonate/internal/app/subsystems/api/grpc/api"
-	"github.com/resonatehq/resonate/internal/kernel/bus"
 	"github.com/resonatehq/resonate/internal/kernel/t_api"
-	"github.com/resonatehq/resonate/internal/util"
 	"github.com/resonatehq/resonate/pkg/promise"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -27,7 +25,7 @@ type Grpc struct {
 }
 
 func New(api api.API, config *Config) api.Subsystem {
-	s := &server{api: api}
+	s := &server{service: &service.Service{Api: api}}
 
 	server := grpc.NewServer(grpc.UnaryInterceptor(s.log)) // nosemgrep
 	grpcApi.RegisterPromiseServiceServer(server, s)
@@ -64,7 +62,7 @@ func (g *Grpc) String() string {
 
 type server struct {
 	grpcApi.UnimplementedPromiseServiceServer
-	api api.API
+	service *service.Service
 }
 
 func (s *server) log(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
@@ -75,133 +73,55 @@ func (s *server) log(ctx context.Context, req interface{}, info *grpc.UnaryServe
 }
 
 func (s *server) ReadPromise(ctx context.Context, req *grpcApi.ReadPromiseRequest) (*grpcApi.ReadPromiseResponse, error) {
-	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
-	defer close(cq)
-
-	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
-		Tags: "grpc",
-		Submission: &t_api.Request{
-			Kind: t_api.ReadPromise,
-			ReadPromise: &t_api.ReadPromiseRequest{
-				Id: req.Id,
-			},
-		},
-		Callback: s.sendOrPanic(cq),
-	})
-
-	cqe := <-cq
-	if cqe.Error != nil {
-		return nil, grpcStatus.Error(codes.Internal, cqe.Error.Error())
+	resp, err := s.service.ReadPromise(req.Id)
+	if err != nil {
+		return nil, grpcStatus.Error(codes.Internal, err.Error())
 	}
 
-	util.Assert(cqe.Completion.ReadPromise != nil, "response must not be nil")
-
 	return &grpcApi.ReadPromiseResponse{
-		Status:  protoStatus(cqe.Completion.ReadPromise.Status),
-		Promise: protoPromise(cqe.Completion.ReadPromise.Promise),
+		Status:  protoStatus(resp.Status),
+		Promise: protoPromise(resp.Promise),
 	}, nil
 }
 
 func (s *server) SearchPromises(ctx context.Context, req *grpcApi.SearchPromisesRequest) (*grpcApi.SearchPromisesResponse, error) {
-	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
-	defer close(cq)
-
-	var searchPromises *t_api.SearchPromisesRequest
-
-	if req.Cursor != "" {
-		cursor, err := t_api.NewCursor[t_api.SearchPromisesRequest](req.Cursor)
-		if err != nil {
-			return nil, grpcStatus.Error(codes.InvalidArgument, err.Error())
-		}
-		searchPromises = cursor.Next
-	} else {
-		// validate
-		if req.Q == "" {
-			return nil, grpcStatus.Error(codes.InvalidArgument, "invalid query")
-		}
-
-		var states []promise.State
-		switch req.State {
-		case grpcApi.SearchState_SEARCH_ALL:
-			states = []promise.State{
-				promise.Pending,
-				promise.Resolved,
-				promise.Rejected,
-				promise.Timedout,
-				promise.Canceled,
-			}
-		case grpcApi.SearchState_SEARCH_PENDING:
-			states = []promise.State{
-				promise.Pending,
-			}
-		case grpcApi.SearchState_SEARCH_RESOLVED:
-			states = []promise.State{
-				promise.Resolved,
-			}
-		case grpcApi.SearchState_SEARCH_REJECTED:
-			states = []promise.State{
-				promise.Rejected,
-				promise.Timedout,
-				promise.Canceled,
-			}
-		default:
-			return nil, grpcStatus.Error(codes.InvalidArgument, "invalid state")
-		}
-
-		limit := int(req.Limit)
-		if limit <= 0 || limit > 100 {
-			limit = 100
-		}
-
-		searchPromises = &t_api.SearchPromisesRequest{
-			Q:      req.Q,
-			States: states,
-			Limit:  limit,
+	params := &service.SearchPromiseParams{
+		Q:      req.Q,
+		State:  searchState(req.State),
+		Limit:  int(req.Limit),
+		Cursor: req.Cursor,
+	}
+	resp, err := s.service.SearchPromises(params)
+	if err != nil {
+		if verr, ok := err.(*service.ValidationError); ok {
+			return nil, grpcStatus.Error(codes.InvalidArgument, verr.Error())
+		} else {
+			return nil, grpcStatus.Error(codes.Internal, err.Error())
 		}
 	}
 
-	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
-		Tags: "grpc",
-		Submission: &t_api.Request{
-			Kind:           t_api.SearchPromises,
-			SearchPromises: searchPromises,
-		},
-		Callback: s.sendOrPanic(cq),
-	})
-
-	cqe := <-cq
-	if cqe.Error != nil {
-		return nil, grpcStatus.Error(codes.Internal, cqe.Error.Error())
-	}
-
-	util.Assert(cqe.Completion.SearchPromises != nil, "response must not be nil")
-
-	promises := make([]*grpcApi.Promise, len(cqe.Completion.SearchPromises.Promises))
-	for i, promise := range cqe.Completion.SearchPromises.Promises {
+	promises := make([]*grpcApi.Promise, len(resp.Promises))
+	for i, promise := range resp.Promises {
 		promises[i] = protoPromise(promise)
 	}
 
 	cursor := ""
-	if cqe.Completion.SearchPromises.Cursor != nil {
+	if resp.Cursor != nil {
 		var err error
-		cursor, err = cqe.Completion.SearchPromises.Cursor.Encode()
+		cursor, err = resp.Cursor.Encode()
 		if err != nil {
-			return nil, grpcStatus.Error(codes.Internal, cqe.Error.Error())
+			return nil, grpcStatus.Error(codes.Internal, err.Error())
 		}
-
 	}
 
 	return &grpcApi.SearchPromisesResponse{
-		Status:   protoStatus(cqe.Completion.SearchPromises.Status),
+		Status:   protoStatus(resp.Status),
 		Cursor:   cursor,
 		Promises: promises,
 	}, nil
 }
 
 func (s *server) CreatePromise(ctx context.Context, req *grpcApi.CreatePromiseRequest) (*grpcApi.CreatePromiseResponse, error) {
-	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
-	defer close(cq)
-
 	var idempotencyKey *promise.IdempotencyKey
 	if req.IdempotencyKey != "" {
 		i := promise.IdempotencyKey(req.IdempotencyKey)
@@ -218,41 +138,31 @@ func (s *server) CreatePromise(ctx context.Context, req *grpcApi.CreatePromiseRe
 		data = req.Param.Data
 	}
 
-	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
-		Tags: "grpc",
-		Submission: &t_api.Request{
-			Kind: t_api.CreatePromise,
-			CreatePromise: &t_api.CreatePromiseRequest{
-				Id:             req.Id,
-				IdempotencyKey: idempotencyKey,
-				Strict:         req.Strict,
-				Param: promise.Value{
-					Headers: headers,
-					Data:    data,
-				},
-				Timeout: req.Timeout,
-			},
-		},
-		Callback: s.sendOrPanic(cq),
-	})
-
-	cqe := <-cq
-	if cqe.Error != nil {
-		return nil, grpcStatus.Error(codes.Internal, cqe.Error.Error())
+	header := &service.CreatePromiseHeader{
+		Strict:         req.Strict,
+		IdempotencyKey: idempotencyKey,
 	}
 
-	util.Assert(cqe.Completion.CreatePromise != nil, "response must not be nil")
+	body := &service.CreatePromiseBody{
+		Param: promise.Value{
+			Headers: headers,
+			Data:    data,
+		},
+		Timeout: req.Timeout,
+	}
+
+	resp, err := s.service.CreatePromise(req.Id, header, body)
+	if err != nil {
+		return nil, grpcStatus.Error(codes.Internal, err.Error())
+	}
 
 	return &grpcApi.CreatePromiseResponse{
-		Status:  protoStatus(cqe.Completion.CreatePromise.Status),
-		Promise: protoPromise(cqe.Completion.CreatePromise.Promise),
+		Status:  protoStatus(resp.Status),
+		Promise: protoPromise(resp.Promise),
 	}, nil
 }
 
 func (s *server) CancelPromise(ctx context.Context, req *grpcApi.CancelPromiseRequest) (*grpcApi.CancelPromiseResponse, error) {
-	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
-	defer close(cq)
-
 	var idempotencyKey *promise.IdempotencyKey
 	if req.IdempotencyKey != "" {
 		i := promise.IdempotencyKey(req.IdempotencyKey)
@@ -269,40 +179,29 @@ func (s *server) CancelPromise(ctx context.Context, req *grpcApi.CancelPromiseRe
 		data = req.Value.Data
 	}
 
-	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
-		Tags: "grpc",
-		Submission: &t_api.Request{
-			Kind: t_api.CancelPromise,
-			CancelPromise: &t_api.CancelPromiseRequest{
-				Id:             req.Id,
-				IdempotencyKey: idempotencyKey,
-				Strict:         req.Strict,
-				Value: promise.Value{
-					Headers: headers,
-					Data:    data,
-				},
-			},
-		},
-		Callback: s.sendOrPanic(cq),
-	})
-
-	cqe := <-cq
-	if cqe.Error != nil {
-		return nil, grpcStatus.Error(codes.Internal, cqe.Error.Error())
+	header := &service.CancelPromiseHeader{
+		Strict:         req.Strict,
+		IdempotencyKey: idempotencyKey,
 	}
 
-	util.Assert(cqe.Completion.CancelPromise != nil, "response must not be nil")
+	body := &service.CancelPromiseBody{
+		Value: promise.Value{
+			Headers: headers,
+			Data:    data,
+		},
+	}
+	resp, err := s.service.CancelPromise(req.Id, header, body)
+	if err != nil {
+		return nil, grpcStatus.Error(codes.Internal, err.Error())
+	}
 
 	return &grpcApi.CancelPromiseResponse{
-		Status:  protoStatus(cqe.Completion.CancelPromise.Status),
-		Promise: protoPromise(cqe.Completion.CancelPromise.Promise),
+		Status:  protoStatus(resp.Status),
+		Promise: protoPromise(resp.Promise),
 	}, nil
 }
 
 func (s *server) ResolvePromise(ctx context.Context, req *grpcApi.ResolvePromiseRequest) (*grpcApi.ResolvePromiseResponse, error) {
-	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
-	defer close(cq)
-
 	var idempotencyKey *promise.IdempotencyKey
 	if req.IdempotencyKey != "" {
 		i := promise.IdempotencyKey(req.IdempotencyKey)
@@ -319,39 +218,30 @@ func (s *server) ResolvePromise(ctx context.Context, req *grpcApi.ResolvePromise
 		data = req.Value.Data
 	}
 
-	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
-		Tags: "grpc",
-		Submission: &t_api.Request{
-			Kind: t_api.ResolvePromise,
-			ResolvePromise: &t_api.ResolvePromiseRequest{
-				Id:             req.Id,
-				IdempotencyKey: idempotencyKey,
-				Strict:         req.Strict,
-				Value: promise.Value{
-					Headers: headers,
-					Data:    data,
-				},
-			},
-		},
-		Callback: s.sendOrPanic(cq),
-	})
-
-	cqe := <-cq
-	if cqe.Error != nil {
-		return nil, grpcStatus.Error(codes.Internal, cqe.Error.Error())
+	header := &service.ResolvePromiseHeader{
+		Strict:         req.Strict,
+		IdempotencyKey: idempotencyKey,
 	}
 
-	util.Assert(cqe.Completion.ResolvePromise != nil, "response must not be nil")
+	body := &service.ResolvePromiseBody{
+		Value: promise.Value{
+			Headers: headers,
+			Data:    data,
+		},
+	}
+
+	resp, err := s.service.ResolvePromise(req.Id, header, body)
+	if err != nil {
+		return nil, grpcStatus.Error(codes.Internal, err.Error())
+	}
 
 	return &grpcApi.ResolvePromiseResponse{
-		Status:  protoStatus(cqe.Completion.ResolvePromise.Status),
-		Promise: protoPromise(cqe.Completion.ResolvePromise.Promise),
+		Status:  protoStatus(resp.Status),
+		Promise: protoPromise(resp.Promise),
 	}, nil
 }
 
 func (s *server) RejectPromise(ctx context.Context, req *grpcApi.RejectPromiseRequest) (*grpcApi.RejectPromiseResponse, error) {
-	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
-	defer close(cq)
 
 	var idempotencyKey *promise.IdempotencyKey
 	if req.IdempotencyKey != "" {
@@ -369,50 +259,27 @@ func (s *server) RejectPromise(ctx context.Context, req *grpcApi.RejectPromiseRe
 		data = req.Value.Data
 	}
 
-	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
-		Tags: "grpc",
-		Submission: &t_api.Request{
-			Kind: t_api.RejectPromise,
-			RejectPromise: &t_api.RejectPromiseRequest{
-				Id:             req.Id,
-				IdempotencyKey: idempotencyKey,
-				Strict:         req.Strict,
-				Value: promise.Value{
-					Headers: headers,
-					Data:    data,
-				},
-			},
-		},
-		Callback: s.sendOrPanic(cq),
-	})
-
-	cqe := <-cq
-	if cqe.Error != nil {
-		return nil, grpcStatus.Error(codes.Internal, cqe.Error.Error())
+	header := &service.RejectPromiseHeader{
+		Strict:         req.Strict,
+		IdempotencyKey: idempotencyKey,
 	}
 
-	util.Assert(cqe.Completion.RejectPromise != nil, "response must not be nil")
+	body := &service.RejectPromiseBody{
+		Value: promise.Value{
+			Headers: headers,
+			Data:    data,
+		},
+	}
+
+	resp, err := s.service.RejectPromise(req.Id, header, body)
+	if err != nil {
+		return nil, grpcStatus.Error(codes.Internal, err.Error())
+	}
 
 	return &grpcApi.RejectPromiseResponse{
-		Status:  protoStatus(cqe.Completion.RejectPromise.Status),
-		Promise: protoPromise(cqe.Completion.RejectPromise.Promise),
+		Status:  protoStatus(resp.Status),
+		Promise: protoPromise(resp.Promise),
 	}, nil
-}
-
-func (s *server) sendOrPanic(cq chan *bus.CQE[t_api.Request, t_api.Response]) func(*t_api.Response, error) {
-	return func(completion *t_api.Response, err error) {
-		cqe := &bus.CQE[t_api.Request, t_api.Response]{
-			Tags:       "grpc",
-			Completion: completion,
-			Error:      err,
-		}
-
-		select {
-		case cq <- cqe:
-		default:
-			panic("response channel must not block")
-		}
-	}
 }
 
 func protoStatus(status t_api.ResponseStatus) grpcApi.Status {
@@ -474,6 +341,21 @@ func protoState(state promise.State) grpcApi.State {
 		return grpcApi.State_REJECTED_TIMEDOUT
 	case promise.Canceled:
 		return grpcApi.State_REJECTED_CANCELED
+	default:
+		panic("invalid state")
+	}
+}
+
+func searchState(searchState grpcApi.SearchState) string {
+	switch searchState {
+	case grpcApi.SearchState_SEARCH_ALL:
+		return ""
+	case grpcApi.SearchState_SEARCH_RESOLVED:
+		return "resolved"
+	case grpcApi.SearchState_SEARCH_REJECTED:
+		return "rejected"
+	case grpcApi.SearchState_SEARCH_PENDING:
+		return "pending"
 	default:
 		panic("invalid state")
 	}

--- a/internal/app/subsystems/api/http/http.go
+++ b/internal/app/subsystems/api/http/http.go
@@ -26,7 +26,7 @@ func New(api api.API, config *Config) api.Subsystem {
 	gin.SetMode(gin.ReleaseMode)
 
 	r := gin.New()
-	s := &server{service: &service.Service{Api: api, ServerProtocol: "http"}}
+	s := &server{service: service.New(api, "http")}
 
 	// Middleware
 	r.Use(s.log)

--- a/internal/app/subsystems/api/service/request.go
+++ b/internal/app/subsystems/api/service/request.go
@@ -1,0 +1,52 @@
+package service
+
+import "github.com/resonatehq/resonate/pkg/promise"
+
+type ValidationError struct {
+	msg string // description of error
+}
+
+type SearchPromiseParams struct {
+	Q      string `form:"q" json:"q"`
+	State  string `form:"state" json:"state"`
+	Limit  int    `form:"limit" json:"limit"`
+	Cursor string `form:"cursor" json:"cursor"`
+}
+
+type CreatePromiseHeader struct {
+	IdempotencyKey *promise.IdempotencyKey `header:"idempotency-key"`
+	Strict         bool                    `header:"strict"`
+}
+
+type CreatePromiseBody struct {
+	Param   promise.Value     `json:"param"`
+	Timeout int64             `json:"timeout"`
+	Tags    map[string]string `json:"tags"`
+}
+
+type CancelPromiseHeader struct {
+	IdempotencyKey *promise.IdempotencyKey `header:"idempotency-key"`
+	Strict         bool                    `header:"strict"`
+}
+
+type CancelPromiseBody struct {
+	Value promise.Value `json:"value"`
+}
+
+type ResolvePromiseHeader struct {
+	IdempotencyKey *promise.IdempotencyKey `header:"idempotency-key"`
+	Strict         bool                    `header:"strict"`
+}
+
+type ResolvePromiseBody struct {
+	Value promise.Value `json:"value"`
+}
+
+type RejectPromiseHeader struct {
+	IdempotencyKey *promise.IdempotencyKey `header:"idempotency-key"`
+	Strict         bool                    `header:"strict"`
+}
+
+type RejectPromiseBody struct {
+	Value promise.Value `json:"value"`
+}

--- a/internal/app/subsystems/api/service/service.go
+++ b/internal/app/subsystems/api/service/service.go
@@ -12,12 +12,19 @@ import (
 func (e *ValidationError) Error() string { return e.msg }
 
 type Service struct {
-	Api            api.API
-	ServerProtocol string
+	api            api.API
+	serverProtocol string
+}
+
+func New(api api.API, serverProtocol string) *Service {
+	return &Service{
+		api: api,
+		serverProtocol: serverProtocol,
+	}
 }
 
 func (s *Service) protocol() string {
-	return s.ServerProtocol
+	return s.serverProtocol
 }
 
 // Read Promise
@@ -26,7 +33,7 @@ func (s *Service) ReadPromise(id string) (*t_api.ReadPromiseResponse, error) {
 	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
 	defer close(cq)
 
-	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
 		Tags: s.protocol(),
 		Submission: &t_api.Request{
 			Kind: t_api.ReadPromise,
@@ -106,7 +113,7 @@ func (s *Service) SearchPromises(params *SearchPromiseParams) (*t_api.SearchProm
 	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
 	defer close(cq)
 
-	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
 		Tags: s.protocol(),
 		Submission: &t_api.Request{
 			Kind:           t_api.SearchPromises,
@@ -130,7 +137,7 @@ func (s *Service) CreatePromise(id string, header *CreatePromiseHeader, body *Cr
 	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
 	defer close(cq)
 
-	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
 		Tags: s.protocol(),
 		Submission: &t_api.Request{
 			Kind: t_api.CreatePromise,
@@ -161,7 +168,7 @@ func (s *Service) CancelPromise(id string, header *CancelPromiseHeader, body *Ca
 	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
 	defer close(cq)
 
-	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
 		Tags: s.protocol(),
 		Submission: &t_api.Request{
 			Kind: t_api.CancelPromise,
@@ -190,7 +197,7 @@ func (s *Service) ResolvePromise(id string, header *ResolvePromiseHeader, body *
 	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
 	defer close(cq)
 
-	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
 		Tags: s.protocol(),
 		Submission: &t_api.Request{
 			Kind: t_api.ResolvePromise,
@@ -219,7 +226,7 @@ func (s *Service) RejectPromise(id string, header *RejectPromiseHeader, body *Re
 	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
 	defer close(cq)
 
-	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+	s.api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
 		Tags: s.protocol(),
 		Submission: &t_api.Request{
 			Kind: t_api.RejectPromise,

--- a/internal/app/subsystems/api/service/service.go
+++ b/internal/app/subsystems/api/service/service.go
@@ -1,0 +1,259 @@
+package service
+
+import (
+	"github.com/resonatehq/resonate/internal/api"
+	"github.com/resonatehq/resonate/internal/kernel/bus"
+	"github.com/resonatehq/resonate/internal/kernel/t_api"
+	"github.com/resonatehq/resonate/internal/util"
+	"github.com/resonatehq/resonate/pkg/promise"
+	"strings"
+)
+
+func (e *ValidationError) Error() string { return e.msg }
+
+type Service struct {
+	Api            api.API
+	ServerProtocol string
+}
+
+func (s *Service) protocol() string {
+	return s.ServerProtocol
+}
+
+// Read Promise
+
+func (s *Service) ReadPromise(id string) (*t_api.ReadPromiseResponse, error) {
+	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
+	defer close(cq)
+
+	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+		Tags: s.protocol(),
+		Submission: &t_api.Request{
+			Kind: t_api.ReadPromise,
+			ReadPromise: &t_api.ReadPromiseRequest{
+				Id: id,
+			},
+		},
+		Callback: s.sendOrPanic(cq),
+	})
+
+	cqe := <-cq
+	if cqe.Error != nil {
+		return nil, cqe.Error
+	}
+
+	util.Assert(cqe.Completion.ReadPromise != nil, "response must not be nil")
+	return cqe.Completion.ReadPromise, nil
+
+}
+
+// Search Promise
+
+func (s *Service) SearchPromises(params *SearchPromiseParams) (*t_api.SearchPromisesResponse, error) {
+	var searchPromises *t_api.SearchPromisesRequest
+	if params.Cursor != "" {
+		cursor, err := t_api.NewCursor[t_api.SearchPromisesRequest](params.Cursor)
+		if err != nil {
+			return nil, &ValidationError{msg: err.Error()}
+		}
+		searchPromises = cursor.Next
+	} else {
+		// validate
+		if params.Q == "" {
+			return nil, &ValidationError{msg: "query must be provided"}
+		}
+
+		var states []promise.State
+		switch strings.ToLower(params.State) {
+		case "":
+			states = []promise.State{
+				promise.Pending,
+				promise.Resolved,
+				promise.Rejected,
+				promise.Timedout,
+				promise.Canceled,
+			}
+		case "pending":
+			states = []promise.State{
+				promise.Pending,
+			}
+		case "resolved":
+			states = []promise.State{
+				promise.Resolved,
+			}
+		case "rejected":
+			states = []promise.State{
+				promise.Rejected,
+				promise.Timedout,
+				promise.Canceled,
+			}
+		default:
+			return nil, &ValidationError{"state must be one of: pending, resolved, rejected"}
+		}
+
+		limit := params.Limit
+		if limit <= 0 || limit > 100 {
+			limit = 100
+		}
+
+		searchPromises = &t_api.SearchPromisesRequest{
+			Q:      params.Q,
+			States: states,
+			Limit:  limit,
+		}
+	}
+
+	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
+	defer close(cq)
+
+	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+		Tags: s.protocol(),
+		Submission: &t_api.Request{
+			Kind:           t_api.SearchPromises,
+			SearchPromises: searchPromises,
+		},
+		Callback: s.sendOrPanic(cq),
+	})
+
+	cqe := <-cq
+	if cqe.Error != nil {
+		return nil, cqe.Error
+	}
+
+	util.Assert(cqe.Completion.SearchPromises != nil, "response must not be nil")
+	return cqe.Completion.SearchPromises, nil
+}
+
+// Create Promise
+
+func (s *Service) CreatePromise(id string, header *CreatePromiseHeader, body *CreatePromiseBody) (*t_api.CreatePromiseResponse, error) {
+	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
+	defer close(cq)
+
+	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+		Tags: s.protocol(),
+		Submission: &t_api.Request{
+			Kind: t_api.CreatePromise,
+			CreatePromise: &t_api.CreatePromiseRequest{
+				Id:             id,
+				IdempotencyKey: header.IdempotencyKey,
+				Strict:         header.Strict,
+				Param:          body.Param,
+				Timeout:        body.Timeout,
+				Tags:           body.Tags,
+			},
+		},
+		Callback: s.sendOrPanic(cq),
+	})
+
+	cqe := <-cq
+	if cqe.Error != nil {
+		return nil, cqe.Error
+	}
+
+	util.Assert(cqe.Completion.CreatePromise != nil, "response must not be nil")
+	return cqe.Completion.CreatePromise, nil
+}
+
+// Cancel Promise
+
+func (s *Service) CancelPromise(id string, header *CancelPromiseHeader, body *CancelPromiseBody) (*t_api.CancelPromiseResponse, error) {
+	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
+	defer close(cq)
+
+	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+		Tags: s.protocol(),
+		Submission: &t_api.Request{
+			Kind: t_api.CancelPromise,
+			CancelPromise: &t_api.CancelPromiseRequest{
+				Id:             id,
+				IdempotencyKey: header.IdempotencyKey,
+				Strict:         header.Strict,
+				Value:          body.Value,
+			},
+		},
+		Callback: s.sendOrPanic(cq),
+	})
+
+	cqe := <-cq
+	if cqe.Error != nil {
+		return nil, cqe.Error
+	}
+
+	util.Assert(cqe.Completion.CancelPromise != nil, "response must not be nil")
+	return cqe.Completion.CancelPromise, nil
+}
+
+// Resolve Promise
+
+func (s *Service) ResolvePromise(id string, header *ResolvePromiseHeader, body *ResolvePromiseBody) (*t_api.ResolvePromiseResponse, error) {
+	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
+	defer close(cq)
+
+	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+		Tags: s.protocol(),
+		Submission: &t_api.Request{
+			Kind: t_api.ResolvePromise,
+			ResolvePromise: &t_api.ResolvePromiseRequest{
+				Id:             id,
+				IdempotencyKey: header.IdempotencyKey,
+				Strict:         header.Strict,
+				Value:          body.Value,
+			},
+		},
+		Callback: s.sendOrPanic(cq),
+	})
+
+	cqe := <-cq
+	if cqe.Error != nil {
+		return nil, cqe.Error
+	}
+
+	util.Assert(cqe.Completion.ResolvePromise != nil, "response must not be nil")
+	return cqe.Completion.ResolvePromise, nil
+}
+
+// Reject Promise
+
+func (s *Service) RejectPromise(id string, header *RejectPromiseHeader, body *RejectPromiseBody) (*t_api.RejectPromiseResponse, error) {
+	cq := make(chan *bus.CQE[t_api.Request, t_api.Response])
+	defer close(cq)
+
+	s.Api.Enqueue(&bus.SQE[t_api.Request, t_api.Response]{
+		Tags: s.protocol(),
+		Submission: &t_api.Request{
+			Kind: t_api.RejectPromise,
+			RejectPromise: &t_api.RejectPromiseRequest{
+				Id:             id,
+				IdempotencyKey: header.IdempotencyKey,
+				Strict:         header.Strict,
+				Value:          body.Value,
+			},
+		},
+		Callback: s.sendOrPanic(cq),
+	})
+
+	cqe := <-cq
+	if cqe.Error != nil {
+		return nil, cqe.Error
+	}
+
+	util.Assert(cqe.Completion.RejectPromise != nil, "response must not be nil")
+	return cqe.Completion.RejectPromise, nil
+}
+
+func (s *Service) sendOrPanic(cq chan *bus.CQE[t_api.Request, t_api.Response]) func(*t_api.Response, error) {
+	return func(completion *t_api.Response, err error) {
+		cqe := &bus.CQE[t_api.Request, t_api.Response]{
+			Tags:       s.protocol(),
+			Completion: completion,
+			Error:      err,
+		}
+
+		select {
+		case cq <- cqe:
+		default:
+			panic("response channel must not block")
+		}
+	}
+}

--- a/internal/app/subsystems/api/service/service_test.go
+++ b/internal/app/subsystems/api/service/service_test.go
@@ -1,0 +1,648 @@
+package service
+
+import (
+	"fmt"
+	"github.com/resonatehq/resonate/internal/app/subsystems/api/test"
+	"github.com/resonatehq/resonate/pkg/promise"
+	"testing"
+
+	"github.com/resonatehq/resonate/internal/kernel/t_api"
+	"github.com/stretchr/testify/assert"
+)
+
+type serviceTest struct {
+	*test.API
+	service *Service
+}
+
+func setup() *serviceTest {
+	api := &test.API{}
+	service := New(api, "local")
+
+	return &serviceTest{
+		API:     api,
+		service: service,
+	}
+}
+
+func TestReadPromise(t *testing.T) {
+	serviceTest := setup()
+
+	for _, tc := range []struct {
+		name string
+		id   string
+		req  *t_api.Request
+		res  *t_api.Response
+	}{
+		{
+			name: "ReadPromise",
+			id:   "foo",
+			req: &t_api.Request{
+				Kind: t_api.ReadPromise,
+				ReadPromise: &t_api.ReadPromiseRequest{
+					Id: "foo",
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.ReadPromise,
+				ReadPromise: &t_api.ReadPromiseResponse{
+					Status: t_api.ResponseOK,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Pending,
+					},
+				},
+			},
+		},
+		{
+			name: "ReadPromiseNotFound",
+			id:   "bar",
+			req: &t_api.Request{
+				Kind: t_api.ReadPromise,
+				ReadPromise: &t_api.ReadPromiseRequest{
+					Id: "bar",
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.ReadPromise,
+				ReadPromise: &t_api.ReadPromiseResponse{
+					Status:  t_api.ResponseNotFound,
+					Promise: nil,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceTest.Load(t, tc.req, tc.res)
+
+			res, err := serviceTest.service.ReadPromise(tc.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.res.ReadPromise, res)
+		})
+	}
+}
+
+func TestSearchPromises(t *testing.T) {
+	serviceTest := setup()
+
+	for _, tc := range []struct {
+		name       string
+		serviceReq *SearchPromiseParams
+		req        *t_api.Request
+		res        *t_api.Response
+	}{
+		{
+			name: "SearchPromises",
+			serviceReq: &SearchPromiseParams{
+				Q:     "*",
+				Limit: 10,
+			},
+			req: &t_api.Request{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesRequest{
+					Q: "*",
+					States: []promise.State{
+						promise.Pending,
+						promise.Resolved,
+						promise.Rejected,
+						promise.Timedout,
+						promise.Canceled,
+					},
+					Limit: 10,
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesResponse{
+					Status:   t_api.ResponseOK,
+					Cursor:   nil,
+					Promises: []*promise.Promise{},
+				},
+			},
+		},
+		{
+			name: "SearchPromisesCursor",
+			serviceReq: &SearchPromiseParams{
+				Cursor: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOZXh0Ijp7InEiOiIqIiwic3RhdGVzIjpbIlBFTkRJTkciXSwibGltaXQiOjEwLCJzb3J0SWQiOjEwMH19.yQxXjIxRmxdTQcBDHFv8PyXxrkGa90e4OcIzDqPP1rY",
+			},
+			req: &t_api.Request{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesRequest{
+					Q: "*",
+					States: []promise.State{
+						promise.Pending,
+					},
+					Limit:  10,
+					SortId: test.Int64ToPointer(100),
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesResponse{
+					Status: t_api.ResponseOK,
+					Cursor: &t_api.Cursor[t_api.SearchPromisesRequest]{
+						Next: &t_api.SearchPromisesRequest{
+							Q: "*",
+							States: []promise.State{
+								promise.Pending,
+								promise.Resolved,
+								promise.Rejected,
+								promise.Timedout,
+								promise.Canceled,
+							},
+							Limit:  10,
+							SortId: test.Int64ToPointer(10),
+						},
+					},
+					Promises: []*promise.Promise{},
+				},
+			},
+		},
+		{
+			name: "SearchPromisesPending",
+			serviceReq: &SearchPromiseParams{
+				Q:     "*",
+				State: "pending",
+				Limit: 10,
+			},
+			req: &t_api.Request{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesRequest{
+					Q: "*",
+					States: []promise.State{
+						promise.Pending,
+					},
+					Limit: 10,
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesResponse{
+					Status:   t_api.ResponseOK,
+					Cursor:   nil,
+					Promises: []*promise.Promise{},
+				},
+			},
+		},
+		{
+			name: "SearchPromisesResolved",
+			serviceReq: &SearchPromiseParams{
+				Q:     "*",
+				State: "resolved",
+				Limit: 10,
+			},
+			req: &t_api.Request{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesRequest{
+					Q: "*",
+					States: []promise.State{
+						promise.Resolved,
+					},
+					Limit: 10,
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesResponse{
+					Status:   t_api.ResponseOK,
+					Cursor:   nil,
+					Promises: []*promise.Promise{},
+				},
+			},
+		},
+		{
+			name: "SearchPromisesRejected",
+			serviceReq: &SearchPromiseParams{
+				Q:     "*",
+				State: "rejected",
+				Limit: 10,
+			},
+			req: &t_api.Request{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesRequest{
+					Q: "*",
+					States: []promise.State{
+						promise.Rejected,
+						promise.Timedout,
+						promise.Canceled,
+					},
+					Limit: 10,
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.SearchPromises,
+				SearchPromises: &t_api.SearchPromisesResponse{
+					Status:   t_api.ResponseOK,
+					Cursor:   nil,
+					Promises: []*promise.Promise{},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceTest.Load(t, tc.req, tc.res)
+			res, err := serviceTest.service.SearchPromises(tc.serviceReq)
+			if err != nil {
+				fmt.Println("we are here bro", res.Status)
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.res.SearchPromises, res)
+		})
+	}
+}
+
+func TestCreatePromise(t *testing.T) {
+	serviceTest := setup()
+
+	for _, tc := range []struct {
+		name             string
+		id               string
+		serviceReqHeader *CreatePromiseHeader
+		serviceReqBody   *CreatePromiseBody
+		req              *t_api.Request
+		res              *t_api.Response
+	}{
+		{
+			name: "CreatePromise",
+			id:   "foo",
+			serviceReqHeader: &CreatePromiseHeader{
+				IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+				Strict:         true,
+			},
+			serviceReqBody: &CreatePromiseBody{
+				Param: promise.Value{
+					Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+					Data:    []byte("pending"),
+				},
+				Timeout: 1,
+			},
+
+			req: &t_api.Request{
+				Kind: t_api.CreatePromise,
+				CreatePromise: &t_api.CreatePromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+					Strict:         true,
+					Param: promise.Value{
+						Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+						Data:    []byte("pending"),
+					},
+					Timeout: 1,
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.CreatePromise,
+				CreatePromise: &t_api.CreatePromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Pending,
+					},
+				},
+			},
+		},
+		{
+			name: "CreatePromiseMinimal",
+			id:   "foo",
+			serviceReqHeader: &CreatePromiseHeader{
+				IdempotencyKey: nil,
+				Strict:         false,
+			},
+			serviceReqBody: &CreatePromiseBody{
+				Param: promise.Value{
+					Headers: nil,
+					Data:    nil,
+				},
+				Timeout: 1,
+			},
+
+			req: &t_api.Request{
+				Kind: t_api.CreatePromise,
+				CreatePromise: &t_api.CreatePromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: nil,
+					Strict:         false,
+					Param: promise.Value{
+						Headers: nil,
+						Data:    nil,
+					},
+					Timeout: 1,
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.CreatePromise,
+				CreatePromise: &t_api.CreatePromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Pending,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceTest.Load(t, tc.req, tc.res)
+			res, err := serviceTest.service.CreatePromise(tc.id, tc.serviceReqHeader, tc.serviceReqBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.res.CreatePromise, res)
+		})
+	}
+}
+
+func TestCancelPromise(t *testing.T) {
+	serviceTest := setup()
+
+	for _, tc := range []struct {
+		name             string
+		id               string
+		serviceReqHeader *CancelPromiseHeader
+		serviceReqBody   *CancelPromiseBody
+		req              *t_api.Request
+		res              *t_api.Response
+	}{
+		{
+			name: "CancelPromise",
+			id:   "foo",
+			serviceReqHeader: &CancelPromiseHeader{
+				IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+				Strict:         true,
+			},
+			serviceReqBody: &CancelPromiseBody{
+				Value: promise.Value{
+					Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+					Data:    []byte("cancel"),
+				},
+			},
+			req: &t_api.Request{
+				Kind: t_api.CancelPromise,
+				CancelPromise: &t_api.CancelPromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+					Strict:         true,
+					Value: promise.Value{
+						Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+						Data:    []byte("cancel"),
+					},
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.CancelPromise,
+				CancelPromise: &t_api.CancelPromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Canceled,
+					},
+				},
+			},
+		},
+		{
+			name: "CancelPromiseMinimal",
+			id:   "foo",
+			serviceReqHeader: &CancelPromiseHeader{
+				IdempotencyKey: nil,
+				Strict:         false,
+			},
+			serviceReqBody: &CancelPromiseBody{
+				Value: promise.Value{
+					Headers: nil,
+					Data:    nil,
+				},
+			},
+			req: &t_api.Request{
+				Kind: t_api.CancelPromise,
+				CancelPromise: &t_api.CancelPromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: nil,
+					Strict:         false,
+					Value: promise.Value{
+						Headers: nil,
+						Data:    nil,
+					},
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.CancelPromise,
+				CancelPromise: &t_api.CancelPromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Canceled,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceTest.Load(t, tc.req, tc.res)
+
+			res, err := serviceTest.service.CancelPromise(tc.id, tc.serviceReqHeader, tc.serviceReqBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.res.CancelPromise, res)
+
+		})
+	}
+}
+
+func TestResolvePromise(t *testing.T) {
+	serviceTest := setup()
+	for _, tc := range []struct {
+		name             string
+		id               string
+		serviceReqHeader *ResolvePromiseHeader
+		serviceReqBody   *ResolvePromiseBody
+		req              *t_api.Request
+		res              *t_api.Response
+	}{
+		{
+			name: "ResolvePromise",
+			id:   "foo",
+			serviceReqHeader: &ResolvePromiseHeader{
+				IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+				Strict:         true,
+			},
+			serviceReqBody: &ResolvePromiseBody{
+				Value: promise.Value{
+					Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+					Data:    []byte("cancel"),
+				},
+			},
+			req: &t_api.Request{
+				Kind: t_api.ResolvePromise,
+				ResolvePromise: &t_api.ResolvePromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+					Strict:         true,
+					Value: promise.Value{
+						Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+						Data:    []byte("cancel"),
+					},
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.ResolvePromise,
+				ResolvePromise: &t_api.ResolvePromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Resolved,
+					},
+				},
+			},
+		},
+		{
+			name: "ResolvePromiseMinimal",
+			id:   "foo",
+			serviceReqHeader: &ResolvePromiseHeader{
+				IdempotencyKey: nil,
+				Strict:         false,
+			},
+			serviceReqBody: &ResolvePromiseBody{
+				Value: promise.Value{
+					Headers: nil,
+					Data:    nil,
+				},
+			},
+			req: &t_api.Request{
+				Kind: t_api.ResolvePromise,
+				ResolvePromise: &t_api.ResolvePromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: nil,
+					Strict:         false,
+					Value: promise.Value{
+						Headers: nil,
+						Data:    nil,
+					},
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.ResolvePromise,
+				ResolvePromise: &t_api.ResolvePromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Resolved,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceTest.Load(t, tc.req, tc.res)
+			res, err := serviceTest.service.ResolvePromise(tc.id, tc.serviceReqHeader, tc.serviceReqBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.res.ResolvePromise, res)
+		})
+	}
+}
+
+func TestRejectPromise(t *testing.T) {
+	serviceTest := setup()
+
+	for _, tc := range []struct {
+		name             string
+		id               string
+		serviceReqHeader *RejectPromiseHeader
+		serviceReqBody   *RejectPromiseBody
+		req              *t_api.Request
+		res              *t_api.Response
+	}{
+		{
+			name: "RejectPromise",
+			id:   "foo",
+			serviceReqHeader: &RejectPromiseHeader{
+				IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+				Strict:         true,
+			},
+			serviceReqBody: &RejectPromiseBody{
+				Value: promise.Value{
+					Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+					Data:    []byte("cancel"),
+				},
+			},
+			req: &t_api.Request{
+				Kind: t_api.RejectPromise,
+				RejectPromise: &t_api.RejectPromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: test.IdempotencyKeyToPointer("bar"),
+					Strict:         true,
+					Value: promise.Value{
+						Headers: map[string]string{"a": "a", "b": "b", "c": "c"},
+						Data:    []byte("cancel"),
+					},
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.RejectPromise,
+				RejectPromise: &t_api.RejectPromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Rejected,
+					},
+				},
+			},
+		},
+		{
+			name: "RejectPromiseMinimal",
+			id:   "foo",
+			serviceReqHeader: &RejectPromiseHeader{
+				IdempotencyKey: nil,
+				Strict:         false,
+			},
+			serviceReqBody: &RejectPromiseBody{
+				Value: promise.Value{
+					Headers: nil,
+					Data:    nil,
+				},
+			},
+			req: &t_api.Request{
+				Kind: t_api.RejectPromise,
+				RejectPromise: &t_api.RejectPromiseRequest{
+					Id:             "foo",
+					IdempotencyKey: nil,
+					Strict:         false,
+					Value: promise.Value{
+						Headers: nil,
+						Data:    nil,
+					},
+				},
+			},
+			res: &t_api.Response{
+				Kind: t_api.RejectPromise,
+				RejectPromise: &t_api.RejectPromiseResponse{
+					Status: t_api.ResponseCreated,
+					Promise: &promise.Promise{
+						Id:    "foo",
+						State: promise.Rejected,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceTest.Load(t, tc.req, tc.res)
+
+			res, err := serviceTest.service.RejectPromise(tc.id, tc.serviceReqHeader, tc.serviceReqBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.res.RejectPromise, res)
+		})
+	}
+}


### PR DESCRIPTION
Pros:
- This will help keep common code in one place
- flexibility for wrapping service code with various frameworks (ex: gin, fiber) 
- existing api is maintained 

Cons:
 - some extra copies for translating protbufs into request arguments
 - naming isn't great