### PR TITLE
refactor(flags): keep flags consistent and clean with just ports

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -95,7 +95,7 @@ var serveCmd = &cobra.Command{
 		mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 
 		metricsServer := &netHttp.Server{
-			Addr:    fmt.Sprintf(":%d", config.Metrics.Port),
+			Addr:    fmt.Sprintf("0.0.0.0:%d", config.Metrics.Port),
 			Handler: mux,
 		}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -163,14 +163,14 @@ var serveCmd = &cobra.Command{
 func init() {
 	// api
 	serveCmd.Flags().Int("api-size", 100, "size of the submission queue buffered channel")
-	serveCmd.Flags().String("api-http-addr", "0.0.0.0:8001", "http server address")
+	serveCmd.Flags().String("api-http-port", "8001", "http server port")
 	serveCmd.Flags().Duration("api-http-timeout", 10*time.Second, "http server graceful shutdown timeout")
-	serveCmd.Flags().String("api-grpc-addr", "0.0.0.0:50051", "grpc server address")
+	serveCmd.Flags().String("api-grpc-port", "50051", "grpc server port")
 
 	_ = viper.BindPFlag("api.size", serveCmd.Flags().Lookup("api-size"))
-	_ = viper.BindPFlag("api.subsystems.http.addr", serveCmd.Flags().Lookup("api-http-addr"))
+	_ = viper.BindPFlag("api.subsystems.http.port", serveCmd.Flags().Lookup("api-http-port"))
 	_ = viper.BindPFlag("api.subsystems.http.timeout", serveCmd.Flags().Lookup("api-http-timeout"))
-	_ = viper.BindPFlag("api.subsystems.grpc.addr", serveCmd.Flags().Lookup("api-grpc-addr"))
+	_ = viper.BindPFlag("api.subsystems.grpc.port", serveCmd.Flags().Lookup("api-grpc-port"))
 
 	// aio
 	serveCmd.Flags().Int("aio-size", 100, "size of the completion queue buffered channel")

--- a/internal/app/subsystems/api/grpc/grpc.go
+++ b/internal/app/subsystems/api/grpc/grpc.go
@@ -2,9 +2,11 @@ package grpc
 
 import (
 	"context"
-	"github.com/resonatehq/resonate/internal/app/subsystems/api/service"
+	"fmt"
 	"log/slog"
 	"net"
+
+	"github.com/resonatehq/resonate/internal/app/subsystems/api/service"
 
 	"github.com/resonatehq/resonate/internal/api"
 	grpcApi "github.com/resonatehq/resonate/internal/app/subsystems/api/grpc/api"
@@ -16,7 +18,7 @@ import (
 )
 
 type Config struct {
-	Addr string
+	Port int
 }
 
 type Grpc struct {
@@ -37,15 +39,17 @@ func New(api api.API, config *Config) api.Subsystem {
 }
 
 func (g *Grpc) Start(errors chan<- error) {
+	addr := fmt.Sprintf("0.0.0.0:%d", g.config.Port)
+
 	// Create a listener on a specific port
-	listen, err := net.Listen("tcp", g.config.Addr)
+	listen, err := net.Listen("tcp", addr)
 	if err != nil {
 		errors <- err
 		return
 	}
 
 	// Start the gRPC server
-	slog.Info("starting grpc server", "addr", g.config.Addr)
+	slog.Info("starting grpc server", "addr", addr)
 	if err := g.server.Serve(listen); err != nil {
 		errors <- err
 	}

--- a/internal/app/subsystems/api/grpc/grpc_test.go
+++ b/internal/app/subsystems/api/grpc/grpc_test.go
@@ -29,7 +29,7 @@ func setup() (*grpcTest, error) {
 	api := &test.API{}
 	errors := make(chan error)
 	subsystem := New(api, &Config{
-		Addr: "127.0.0.1:5555",
+		Port: 5555,
 	})
 
 	// start grpc server

--- a/internal/app/subsystems/api/http/http.go
+++ b/internal/app/subsystems/api/http/http.go
@@ -2,9 +2,11 @@ package http
 
 import (
 	"context"
-	"github.com/resonatehq/resonate/internal/app/subsystems/api/service"
+	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/resonatehq/resonate/internal/app/subsystems/api/service"
 
 	"log/slog"
 
@@ -13,7 +15,7 @@ import (
 )
 
 type Config struct {
-	Addr    string
+	Port    int
 	Timeout time.Duration
 }
 
@@ -42,14 +44,14 @@ func New(api api.API, config *Config) api.Subsystem {
 	return &Http{
 		config: config,
 		server: &http.Server{
-			Addr:    config.Addr,
+			Addr:    fmt.Sprintf("0.0.0.0:%d", config.Port),
 			Handler: r,
 		},
 	}
 }
 
 func (h *Http) Start(errors chan<- error) {
-	slog.Info("starting http server", "addr", h.config.Addr)
+	slog.Info("starting http server", "addr", h.server.Addr)
 	if err := h.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		errors <- err
 	}

--- a/internal/app/subsystems/api/http/http_test.go
+++ b/internal/app/subsystems/api/http/http_test.go
@@ -26,7 +26,7 @@ func setup() *httpTest {
 	api := &test.API{}
 	errors := make(chan error)
 	subsystem := New(api, &Config{
-		Addr:    "127.0.0.1:8888",
+		Port:    8888,
 		Timeout: 1 * time.Second,
 	})
 


### PR DESCRIPTION
**Before**
Inconsistent input and log outputs and unnecessarily verbose. 
<img width="1033" alt="Screenshot 2023-11-02 at 10 22 11 AM" src="https://github.com/resonatehq/resonate/assets/65991626/713508a3-bc45-425a-8bf6-5f8a116e0b0f">

**After**
Consistent input and output for all 3 servers. Also consistent with db flags which take in ports. 
<img width="773" alt="Screenshot 2023-11-02 at 10 25 30 AM" src="https://github.com/resonatehq/resonate/assets/65991626/0f0c64fb-81a7-462b-8d68-76eeabcc2f66">
