### PR TITLE
feat(chainguard): use distroless chainguard image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.21 AS builder
+FROM cgr.dev/chainguard/go AS builder
 
 WORKDIR /app
 COPY . .
 
 RUN go build -o resonate .
 
-FROM golang:1.21
+FROM cgr.dev/chainguard/glibc-dynamic
 
 WORKDIR /app
 COPY --from=builder /app/resonate .


### PR DESCRIPTION
Using distroless image reduces our image footprint by ~96%.

<img width="616" alt="Screenshot 2023-11-07 at 1 26 29 PM" src="https://github.com/resonatehq/resonate/assets/65991626/7f61b6e4-c1e9-48a8-88c2-467eada72ac4">


For the curious, take a look at docs here: 
- https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-go/#advanced-usage
