### PR TITLE
fix(race): fixing race condition found with test harness

### DIFF
--- a/internal/app/subsystems/api/service/service.go
+++ b/internal/app/subsystems/api/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/resonatehq/resonate/internal/api"
@@ -55,8 +54,6 @@ func (s *Service) ReadPromise(id string, header *Header) (*t_api.ReadPromiseResp
 		},
 		Callback: s.sendOrPanic(cq),
 	})
-
-	time.Sleep(20 * time.Second)
 
 	cqe := <-cq
 	if cqe.Error != nil {
@@ -166,8 +163,6 @@ func (s *Service) CreatePromise(id string, header *CreatePromiseHeader, body *Cr
 		},
 		Callback: s.sendOrPanic(cq),
 	})
-
-	time.Sleep(20 * time.Second)
 
 	cqe := <-cq
 	if cqe.Error != nil {


### PR DESCRIPTION
**Changes**
- Add a buffered channel of size 1 to get rid of race condition. 
- Update the callback to just write to the channel since a write to a closed channel already causes a panic. 


**Context**
I made the assumption the `sendOrPanic` only cares that the api goroutine didn't die and is available to complete the request. Since we defer the close() in the api goroutine, it means that if the kernel can write to the channel (without panicing), the api layer goroutine is available and has not exited or paniced.  so should be same behavior as before minus race condition.