### PR TITLE
Feat: Improve log level flag description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work
 resonate*
 coverage.out
 .env
+
+# ignore goland files
+.idea

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log/slog"
 	"math/rand" // nosemgrep
 
 	"github.com/mitchellh/mapstructure"
@@ -57,7 +56,7 @@ type MetricsConfig struct {
 }
 
 type LogConfig struct {
-	Level slog.Level
+	Level string
 }
 
 // DST Config

--- a/cmd/dst.go
+++ b/cmd/dst.go
@@ -22,6 +22,7 @@ import (
 	"github.com/resonatehq/resonate/internal/kernel/t_aio"
 	"github.com/resonatehq/resonate/internal/kernel/t_api"
 	"github.com/resonatehq/resonate/internal/metrics"
+	"github.com/resonatehq/resonate/pkg/log"
 	"github.com/resonatehq/resonate/test/dst"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -102,8 +103,13 @@ var dstRunCmd = &cobra.Command{
 		}
 
 		// logger
+		logLevel, err := log.ParseLevel(config.Log.Level)
+		if err != nil {
+			slog.Error("failed to parse log level", "error", err)
+			return err
+		}
 		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			Level: config.Log.Level,
+			Level: logLevel,
 			ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
 				// suppress time attr
 				if attr.Key == "time" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (defaults to resonate.yml)")
-	rootCmd.PersistentFlags().Int("log-level", 0, "log level")
+	rootCmd.PersistentFlags().String("log-level", "info", "log level, Options: debug, info, warn, error.")
 	_ = viper.BindPFlag("log.level", rootCmd.PersistentFlags().Lookup("log-level"))
 	_ = viper.BindPFlag("dst.log.level", rootCmd.PersistentFlags().Lookup("log-level"))
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/resonatehq/resonate/internal/kernel/t_aio"
 	"github.com/resonatehq/resonate/internal/kernel/t_api"
 	"github.com/resonatehq/resonate/internal/metrics"
+	"github.com/resonatehq/resonate/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -36,7 +37,12 @@ var serveCmd = &cobra.Command{
 		}
 
 		// logger
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: config.Log.Level}))
+		logLevel, err := log.ParseLevel(config.Log.Level)
+		if err != nil {
+			slog.Error("failed to parse log level", "error", err)
+			return err
+		}
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
 		slog.SetDefault(logger)
 
 		// instantiate metrics

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -29,6 +29,6 @@ func ParseLevel(lvl string) (slog.Level, error) {
 	case "error":
 		return ErrorLevel, nil
 	default:
-		return 0, fmt.Errorf("unrecognized level: %q", lvl)
+		return 0, fmt.Errorf("unrecognized level: %s", lvl)
 	}
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+const (
+	// DebugLevel defines debug log level.
+	DebugLevel = slog.LevelDebug
+	// InfoLevel defines info log level.
+	InfoLevel = slog.LevelInfo
+	// WarnLevel defines warn log level.
+	WarnLevel = slog.LevelWarn
+	// ErrorLevel defines error log level.
+	ErrorLevel = slog.LevelError
+)
+
+// ParseLevel takes a string level and returns the slog log level constant.
+func ParseLevel(lvl string) (slog.Level, error) {
+	switch strings.ToLower(lvl) {
+	case "debug":
+		return DebugLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "warn":
+		return WarnLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	default:
+		return 0, fmt.Errorf("unrecognized level: %q", lvl)
+	}
+}


### PR DESCRIPTION
Solve issue #94 
### Modification Description
- Add package `pkg/log`
- Change the type of flag `log-level` to string
### Test cases
```sh
$ resonate -h 
...
     --log-level string   log level, Options: debug, info, warn, error. (default "info")
...
# Debug
$ resnoate serve --log-level=debug
time=xxx level=INFO msg="starting http server" addr=0.0.0.0:8001
time=xxx level=INFO msg="starting grpc server" addr=0.0.0.0:50051
...
time=xxx level=DEBUG msg=scheduler:add coroutine="Coroutine(metadata=Metadata(tid=tick:1699989540758:notify, tags=map[name:notify-subscriptions]))"
time=xxx level=DEBUG msg=scheduler:add coroutine="Coroutine(metadata=Metadata(tid=tick:1699989540758:timeout, tags=map[name:timeout-promises]))"
...
# Info
$ resonate serve --log-level=info
time=xxx level=INFO msg="starting http server" addr=0.0.0.0:8001
time=xxx level=INFO msg="starting metrics server" addr=:9090
...

$ resonate serve
time=xxx level=INFO msg="starting http server" addr=0.0.0.0:8001
time=xxx level=INFO msg="starting metrics server" addr=:9090
...

# Warn and Error
$ resonate serve --log-level=warn

$ resonate serve --log-level=error

# Uppercase level
$ resonate serve --log-level=DEBUG
...
time=xxx level=DEBUG msg=scheduler:rmv coroutine="Coroutine(metadata=Metadata(tid=tick:1699990746456:notify, tags=map[aio:store name:notify-subscriptions]))"


# Unsupported level
$ resonate serve --log-level=not-support
xxx ERROR failed to parse log level error="unrecognized level: not-support"
Error: unrecognized level: "not-support"
Usage:
  resonate serve [flags]
...
```

