### PR TITLE
refactor(routing): routing based on the endpoint not domain

### DIFF
--- a/internal/app/subsystems/aio/queuing/routing.go
+++ b/internal/app/subsystems/aio/queuing/routing.go
@@ -55,15 +55,15 @@ func NewRouter() Router {
 }
 
 func (r *RouterImpl) Handle(pattern string, handler *RouteHandler) {
-	// chi routing pattern must begin with '/'
-	pattern = "/" + pattern
+	// chi routing pattern must begin with '/' and accept any domain.
+	pattern = "/" + "{http}://{domain}" + pattern
 
 	r.patterns.Post(pattern, func(w http.ResponseWriter, r *http.Request) {})
 	r.handlers[pattern] = handler
 }
 
 func (r *RouterImpl) Match(route string) (*MatchResult, error) {
-	// chi routing pattern must begin with '/'
+	// chi routing pattern must begin with '/'.
 	route = "/" + route
 
 	rctx := chi.NewRouteContext()

--- a/internal/app/subsystems/aio/queuing/routing_test.go
+++ b/internal/app/subsystems/aio/queuing/routing_test.go
@@ -1,0 +1,86 @@
+package queuing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRouting(t *testing.T) {
+
+	tcs := []struct {
+		name           string
+		pattern        string
+		route          string
+		expectedResult *MatchResult
+		expectedErr    error
+	}{
+		{
+			name:    "simple .com",
+			pattern: "/payments/*",
+			route:   "http://demo.example.com/payments/123",
+			expectedResult: &MatchResult{
+				Route:        "/http://demo.example.com/payments/123",
+				RoutePattern: "/{http}://{domain}/payments/*",
+				Connection:   "conn1",
+			},
+		},
+		{
+			name:    "simple .io",
+			pattern: "/payments/*",
+			route:   "http://demo.example.io/payments/123",
+			expectedResult: &MatchResult{
+				Route:        "/http://demo.example.io/payments/123",
+				RoutePattern: "/{http}://{domain}/payments/*",
+				Connection:   "conn1",
+			},
+		},
+		{
+			name:    "simple localhost",
+			pattern: "/payments/*",
+			route:   "http://localhost/payments/123",
+			expectedResult: &MatchResult{
+				Route:        "/http://localhost/payments/123",
+				RoutePattern: "/{http}://{domain}/payments/*",
+				Connection:   "conn1",
+			},
+		},
+		{
+			name:    "simple localhost https",
+			pattern: "/payments/*",
+			route:   "https://localhost/payments/123",
+			expectedResult: &MatchResult{
+				Route:        "/https://localhost/payments/123",
+				RoutePattern: "/{http}://{domain}/payments/*",
+				Connection:   "conn1",
+			},
+		},
+		{
+			name:        "simple .com",
+			pattern:     "/payments/*",
+			route:       "http://demo.example.com/analytics/123",
+			expectedErr: ErrRouteDoesNotMatchAnyPattern,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			router := NewRouter()
+
+			router.Handle(tc.pattern, &RouteHandler{
+				Connection: "conn1",
+			})
+
+			result, err := router.Match(tc.route)
+			if tc.expectedErr != nil {
+				assert.Equal(t, tc.expectedErr, err)
+				return
+			}
+
+			assert.Equal(t, tc.expectedResult.Route, result.Route)
+			assert.Equal(t, tc.expectedResult.RoutePattern, result.RoutePattern)
+			assert.Equal(t, tc.expectedResult.Connection, result.Connection)
+		})
+
+	}
+}


### PR DESCRIPTION
Pattern should me not include domain. Note that now we are enforcing promise ids to be http://{domain}/{pattern} format for ctx.call operations to work properly (might affect existing examples). 

<img width="407" alt="Screenshot 2024-03-22 at 3 50 42 PM" src="https://github.com/resonatehq/resonate/assets/65991626/a52a5fb0-7cfc-4aee-84e8-05ef7fe59d6b">
