### PR TITLE
feat(tasks): several small updates

### DIFF
--- a/cmd/serve/flags.go
+++ b/cmd/serve/flags.go
@@ -4,11 +4,15 @@ import (
 	"encoding/json"
 
 	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/connections/t_conn"
+	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/routes/t_route"
 )
 
 type (
 	// ConnectionSlice is a slice of connections a user can define to configure the queueing subsystem.
 	ConnectionSlice []*t_conn.ConnectionConfig
+
+	// RouteSlice is a slice of routing configurations a user can define to configure the queueing subsystem.
+	RouteSlice []*t_route.RoutingConfig
 )
 
 func (c *ConnectionSlice) String() string {
@@ -28,6 +32,27 @@ func (c *ConnectionSlice) Set(v string) error {
 	return nil
 }
 
-func (c *ConnectionSlice) Type() string {
+func (r *ConnectionSlice) Type() string {
 	return "ConnectionSlice"
+}
+
+func (r *RouteSlice) String() string {
+	if r == nil || len(*r) == 0 {
+		return ""
+	}
+	jsonStr, _ := json.Marshal(r)
+	return string(jsonStr)
+}
+
+func (r *RouteSlice) Set(v string) error {
+	routings := make([]*t_route.RoutingConfig, 0)
+	if err := json.Unmarshal([]byte(v), &routings); err != nil {
+		return err
+	}
+	*r = RouteSlice(routings)
+	return nil
+}
+
+func (r *RouteSlice) Type() string {
+	return "RouteSlice"
 }

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -66,7 +66,7 @@ func ServeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			queuing, err := queuing.NewSubsytemOrDie(config.AIO.Subsystems.Queuing.Config)
+			queuing, err := queuing.NewSubsytemOrDie(config.API.BaseURL, config.AIO.Subsystems.Queuing.Config)
 			if err != nil {
 				return err
 			}
@@ -189,11 +189,13 @@ func ServeCmd() *cobra.Command {
 	cmd.Flags().String("api-http-addr", "0.0.0.0:8001", "http server address")
 	cmd.Flags().Duration("api-http-timeout", 10*time.Second, "http server graceful shutdown timeout")
 	cmd.Flags().String("api-grpc-addr", "0.0.0.0:50051", "grpc server address")
+	cmd.Flags().String("api-base-url", "http://localhost:8001", "base url to automatically generate absolute URLs for the server's resources")
 
 	_ = viper.BindPFlag("api.size", cmd.Flags().Lookup("api-size"))
 	_ = viper.BindPFlag("api.subsystems.http.addr", cmd.Flags().Lookup("api-http-addr"))
 	_ = viper.BindPFlag("api.subsystems.http.timeout", cmd.Flags().Lookup("api-http-timeout"))
 	_ = viper.BindPFlag("api.subsystems.grpc.addr", cmd.Flags().Lookup("api-grpc-addr"))
+	_ = viper.BindPFlag("api.baseUrl", cmd.Flags().Lookup("api-base-url"))
 
 	// aio
 	// Store
@@ -219,9 +221,11 @@ func ServeCmd() *cobra.Command {
 	cmd.Flags().Duration("aio-network-timeout", 10*time.Second, "network request timeout")
 	// Queuing
 	cmd.Flags().Int("aio-queuing-size", 100, "size of queuing submission queue buffered channel")
-	cmd.Flags().Int("aio-queuing-workers", 1, "number of queuing workers") // must be 1.
+	cmd.Flags().Int("aio-queuing-workers", 1, "number of queuing workers")
+	cmd.Flags().Lookup("aio-queuing-workers").Hidden = true // must be 1.
 	cmd.Flags().Int("aio-queuing-batch-size", 100, "max submissions processed each tick by a queuing worker")
 	cmd.Flags().Var(&ConnectionSlice{}, "aio-queuing-connections", "queuing subsystem connections")
+	cmd.Flags().Var(&RouteSlice{}, "aio-queuing-routes", "queuing subsystem routes")
 
 	// Store
 	_ = viper.BindPFlag("aio.size", cmd.Flags().Lookup("aio-size"))
@@ -250,6 +254,7 @@ func ServeCmd() *cobra.Command {
 	_ = viper.BindPFlag("aio.subsystems.queuing.subsystem.workers", cmd.Flags().Lookup("aio-queuing-workers"))
 	_ = viper.BindPFlag("aio.subsystems.queuing.subsystem.batchSize", cmd.Flags().Lookup("aio-queuing-batch-size"))
 	_ = viper.BindPFlag("aio.subsystems.queuing.config.connections", cmd.Flags().Lookup("aio-queuing-connections"))
+	_ = viper.BindPFlag("aio.subsystems.queuing.config.routes", cmd.Flags().Lookup("aio-queuing-routes"))
 
 	// system
 	cmd.Flags().Int("system-notification-cache-size", 100, "max number of notifications to keep in cache")

--- a/cmd/util/config.go
+++ b/cmd/util/config.go
@@ -27,6 +27,7 @@ type Config struct {
 }
 
 type APIConfig struct {
+	BaseURL    string
 	Size       int
 	Subsystems *APISubsystems
 }

--- a/internal/app/subsystems/aio/queuing/connections/connections.go
+++ b/internal/app/subsystems/aio/queuing/connections/connections.go
@@ -8,6 +8,17 @@ import (
 )
 
 func NewConnection(tasks <-chan *t_conn.ConnectionSubmission, cfg *t_conn.ConnectionConfig) (t_conn.Connection, error) {
+	// Validate all required fields are present.
+	if cfg == nil {
+		return nil, fmt.Errorf("connection config is empty")
+	}
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("field 'name' is empty for connection '%s'", cfg.Name)
+	}
+	if cfg.Kind == "" {
+		return nil, fmt.Errorf("field 'kind' is empty for connection '%s'", cfg.Name)
+	}
+
 	var (
 		conn t_conn.Connection
 		err  error

--- a/internal/app/subsystems/aio/queuing/connections/t_conn/connections.go
+++ b/internal/app/subsystems/aio/queuing/connections/t_conn/connections.go
@@ -20,17 +20,16 @@ type (
 		// kind identifies the type of queueing system to connect to (e.g. http, aws.sqs, etc.)
 		Kind ConnectionKind
 
-		// Pattern is the pattern to match the task id.
-		Pattern string
-
 		// Name identifies the existing connection to the queueing system.
 		Name string
 
-		// Queue identifies the task queue within the queueing system.
-		Queue string
-
 		// Metadata is the any additional information or configuration for the connection.
 		Metadata *metadata.Metadata
+	}
+
+	Links struct {
+		Claim    string `json:"claim"`
+		Complete string `json:"complete"`
 	}
 
 	ConnectionSubmission struct {
@@ -42,6 +41,9 @@ type (
 
 		// Counter is the version of the task for claiming purposes.
 		Counter int `json:"counter"`
+
+		// Links are the links to claim and complete the specific task.
+		Links Links `json:"links"`
 	}
 
 	Connection interface {

--- a/internal/app/subsystems/aio/queuing/routes/pattern/pattern.go
+++ b/internal/app/subsystems/aio/queuing/routes/pattern/pattern.go
@@ -1,0 +1,39 @@
+package pattern
+
+import (
+	"fmt"
+
+	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/metadata"
+	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/routes/t_route"
+)
+
+type (
+	Pattern struct {
+		meta Metadata
+	}
+
+	Metadata struct {
+		Pattern string `mapstructure:"pattern"`
+	}
+)
+
+func New(meta *metadata.Metadata) (t_route.Route, error) {
+	p := &Pattern{}
+	md := Metadata{}
+
+	if err := metadata.Decode(meta.Properties, &md); err != nil {
+		return nil, err
+	}
+
+	p.meta = md
+
+	if p.meta.Pattern == "" {
+		return nil, fmt.Errorf("pattern is required")
+	}
+
+	return p, nil
+}
+
+func (p *Pattern) Route() string {
+	return p.meta.Pattern
+}

--- a/internal/app/subsystems/aio/queuing/routes/routes.go
+++ b/internal/app/subsystems/aio/queuing/routes/routes.go
@@ -1,0 +1,28 @@
+package routes
+
+import (
+	"fmt"
+
+	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/routes/pattern"
+	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/routes/t_route"
+)
+
+func NewRoute(cfg *t_route.RoutingConfig) (t_route.Route, error) {
+	var (
+		route t_route.Route
+		err   error
+	)
+
+	switch cfg.Kind {
+	case t_route.Pattern:
+		route, err = pattern.New(cfg.Metadata)
+	default:
+		return nil, fmt.Errorf("invalid routing kind: %s", cfg.Kind)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return route, nil
+}

--- a/internal/app/subsystems/aio/queuing/routes/routes.go
+++ b/internal/app/subsystems/aio/queuing/routes/routes.go
@@ -8,6 +8,26 @@ import (
 )
 
 func NewRoute(cfg *t_route.RoutingConfig) (t_route.Route, error) {
+	// Validate all required fields are present.
+	if cfg == nil {
+		return nil, fmt.Errorf("routing config is nil")
+	}
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("field 'name' is empty")
+	}
+	if cfg.Kind == "" {
+		return nil, fmt.Errorf("field 'kind' is empty for route '%s'", cfg.Name)
+	}
+	if cfg.Target == nil {
+		return nil, fmt.Errorf("field 'target' is empty for route' %s'", cfg.Name)
+	}
+	if cfg.Target.Connection == "" {
+		return nil, fmt.Errorf("field 'target.connection' is empty for route '%s'", cfg.Name)
+	}
+	if cfg.Target.Queue == "" {
+		return nil, fmt.Errorf("field 'target.queue' is empty for route '%s'", cfg.Name)
+	}
+
 	var (
 		route t_route.Route
 		err   error

--- a/internal/app/subsystems/aio/queuing/routes/t_route/routes.go
+++ b/internal/app/subsystems/aio/queuing/routes/t_route/routes.go
@@ -19,7 +19,7 @@ type (
 		Name string
 
 		// Target identifies the connection and queue to route the task to.
-		Target Target
+		Target *Target
 
 		// Metadata is the any additional information or configuration for the specific routing kind.
 		Metadata *metadata.Metadata

--- a/internal/app/subsystems/aio/queuing/routes/t_route/routes.go
+++ b/internal/app/subsystems/aio/queuing/routes/t_route/routes.go
@@ -1,0 +1,39 @@
+package t_route
+
+import (
+	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/metadata"
+)
+
+const (
+	Pattern RoutingKind = "pattern"
+)
+
+type (
+	RoutingKind string
+
+	RoutingConfig struct {
+		// Kind identifies the type of routing to use (e.g. pattern, etc.)
+		Kind RoutingKind
+
+		// Name identifies the existing routing in the queueing system.
+		Name string
+
+		// Target identifies the connection and queue to route the task to.
+		Target Target
+
+		// Metadata is the any additional information or configuration for the specific routing kind.
+		Metadata *metadata.Metadata
+	}
+
+	Target struct {
+		// Connection identifies the connection to route the task to.
+		Connection string
+
+		// Queue identifies the task queue within the queueing system.
+		Queue string
+	}
+
+	Route interface {
+		Route() string
+	}
+)

--- a/internal/app/subsystems/aio/queuing/worker.go
+++ b/internal/app/subsystems/aio/queuing/worker.go
@@ -1,14 +1,24 @@
 package queuing
 
 import (
+	"fmt"
+
 	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/connections/t_conn"
 	"github.com/resonatehq/resonate/internal/kernel/bus"
 	"github.com/resonatehq/resonate/internal/kernel/t_aio"
 	"github.com/resonatehq/resonate/internal/util"
 )
 
+const (
+	taskClaimEndpoint    string = "tasks/claim" // TODO: make this configurable ? so no broken link ? testing..
+	taskCompleteEndpoint string = "tasks/complete"
+)
+
 // QueuingWorker is a worker that dispatches submissions to the appropriate connections.
 type QueuingWorker struct {
+	// BaseURL is the base URL for the API.
+	BaseURL string
+
 	// ConnectionRouter is the router to route requests to the appropriate connections.
 	ConnectionRouter Router
 
@@ -38,6 +48,10 @@ func (w *QueuingWorker) Process(sqes []*bus.SQE[t_aio.Submission, t_aio.Completi
 				Queue:   matchResult.Queue,
 				TaskId:  sqe.Submission.Queuing.TaskId,
 				Counter: sqe.Submission.Queuing.Counter,
+				Links: t_conn.Links{
+					Claim:    fmt.Sprintf("%s/%s", w.BaseURL, taskClaimEndpoint),
+					Complete: fmt.Sprintf("%s/%s", w.BaseURL, taskCompleteEndpoint),
+				},
 			}
 		}
 	}

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -131,7 +131,7 @@ const (
 		PRIMARY KEY(id) 
 	);
 	
-	INSERT INTO migrations (id) VALUES (1);`
+	INSERT INTO migrations (id) VALUES (1) ON CONFLICT(id) DO NOTHING;`
 
 	DROP_TABLE_STATEMENT = `
 	DROP TABLE notifications;

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -126,7 +126,7 @@ const (
 		id    INTEGER PRIMARY KEY
 	);
 	
-	INSERT INTO migrations (id) VALUES (1);`
+	INSERT INTO migrations (id) VALUES (1) ON CONFLICT(id) DO NOTHING;`
 
 	PROMISE_SELECT_STATEMENT = `
 	SELECT

--- a/test/dst/dst_test.go
+++ b/test/dst/dst_test.go
@@ -65,7 +65,7 @@ func TestDST(t *testing.T) {
 			{
 				Kind: t_route.Pattern,
 				Name: "default",
-				Target: t_route.Target{
+				Target: &t_route.Target{
 					Connection: "summarize",
 					Queue:      "analytics",
 				},

--- a/test/dst/dst_test.go
+++ b/test/dst/dst_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing"
 	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/connections/t_conn"
 	queuing_metadata "github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/metadata"
+	"github.com/resonatehq/resonate/internal/app/subsystems/aio/queuing/routes/t_route"
+
 	"github.com/resonatehq/resonate/internal/app/subsystems/aio/store/sqlite"
 	"github.com/resonatehq/resonate/internal/kernel/system"
 	"github.com/resonatehq/resonate/internal/kernel/t_aio"
@@ -47,16 +49,29 @@ func TestDST(t *testing.T) {
 	}
 
 	// TODO: DST version so just test the kernel.
-	queuing, err := queuing.NewSubsytemOrDie(&queuing.Config{
+	queuing, err := queuing.NewSubsytemOrDie("http://localhost:8001", &queuing.Config{
 		Connections: []*t_conn.ConnectionConfig{
 			{
-				Kind:    t_conn.HTTP,
-				Pattern: "/payments/*",
-				Name:    "payments-demo",
-				Queue:   "payments-demo",
+				Kind: t_conn.HTTP,
+				Name: "summarize",
 				Metadata: &queuing_metadata.Metadata{
 					Properties: map[string]interface{}{
 						"url": "http://localhost:5001",
+					},
+				},
+			},
+		},
+		Routes: []*t_route.RoutingConfig{
+			{
+				Kind: t_route.Pattern,
+				Name: "default",
+				Target: t_route.Target{
+					Connection: "summarize",
+					Queue:      "analytics",
+				},
+				Metadata: &queuing_metadata.Metadata{
+					Properties: map[string]interface{}{
+						"pattern": "/gpu/summarize/*",
 					},
 				},
 			},

--- a/test/dst/generator.go
+++ b/test/dst/generator.go
@@ -173,7 +173,7 @@ func (g *Generator) GenerateCreatePromise(r *rand.Rand, t int64) *t_api.Request 
 	id := g.idSet[r.Intn(len(g.idSet))]
 
 	if RandBool(r) {
-		id = fmt.Sprintf("payments/%s", id)
+		id = fmt.Sprintf("/gpu/summarize/%s", id)
 	}
 
 	idempotencyKey := g.idemotencyKeySet[r.Intn(len(g.idemotencyKeySet))]


### PR DESCRIPTION
Fixes https://github.com/resonatehq/resonate/issues/253
Fixes https://github.com/resonatehq/resonate/issues/254

### Changes: 

1. Separate routing information into it's own entity: 
2. Added baseURL configuration to give worker's absolute URL. 
3. Put queue in HTTP body for optional usage and consistency in configuration / queueing semantics. 
4. Fixed small migrations table bug. 
5. Queueing subsytem can only have 1 worker. 


<img width="364" alt="Screenshot 2024-04-03 at 1 56 50 PM" src="https://github.com/resonatehq/resonate/assets/65991626/1e9a9cde-1d05-4753-a8c2-a7057a40127b">

### Notes: 

A bit of the code restructure is not directly necessary for these change, but puts us a step closer to when we support various types of routing (not just regex pattern matching). 