### PR TITLE
Add additional order by clause to task queries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     security_opt:
     - no-new-privileges:true
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U username -d resonate_dst"]
+      test: ["CMD-SHELL", "pg_isready -U username -d resonate"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,11 @@ services:
     tmpfs: /var/run/postgresql:rw,nosuid,nodev,noexec,mode=1777
     security_opt:
     - no-new-privileges:true
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U username -d resonate_dst"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # dst
   resonate-dst:
@@ -68,3 +73,8 @@ services:
     tmpfs: /var/run/postgresql:rw,nosuid,nodev,noexec,mode=1777
     security_opt:
     - no-new-privileges:true
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U username -d resonate_dst"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -274,7 +274,7 @@ const (
 		complete_timeout < $2 AND 
 		promise_timeout > $2
 	ORDER BY
-		created_on ASC`
+		created_on ASC, id`
 
 	LOCK_READ_STATEMENT = `
 	SELECT 

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -259,7 +259,7 @@ const (
 		complete_timeout < ? AND 
 		promise_timeout > ?
 	ORDER BY
-		created_on ASC`
+		created_on ASC, id`
 
 	LOCK_READ_STATEMENT = `
 	SELECT 


### PR DESCRIPTION
Fixes #276 

ORDER BY created_on can be ambiguous because the timestamp is not guaranteed to be unique. This PR adds id as an additional clause, which is unique, restoring determinism to the queries.