### PR TITLE
Remove unnecessary chmod operations in CI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -78,11 +78,9 @@ jobs:
         run: |
           nix build ".#resonate"
           cp ./result/bin/resonate resonate
-          chmod +x resonate
 
           nix build ".#durable-promise-test-harness"
           cp ./result/bin/durable-promise-test-harness durable-promise-test-harness
-          chmod +x durable-promise-test-harness
 
       - name: Run resonate server
         run: |

--- a/.github/workflows/dst.yaml
+++ b/.github/workflows/dst.yaml
@@ -91,7 +91,6 @@ jobs:
         fail-on-cache-miss: true
     - name: Run dst (seed=${{ needs.seed.outputs.seed }}, scenario=${{ matrix.scenario }}, store=${{ matrix.store }})
       run: |
-        chmod +x resonate
         ./resonate dst run --seed ${{ needs.seed.outputs.seed }} --scenario ${{ matrix.scenario }} --aio-store ${{ matrix.store }} > logs.txt 2>&1
     - name: Create issue if dst failed
       env:
@@ -158,7 +157,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.github_token }}
       if: ${{ failure() }}
       run: |
-        chmod +x resonate
         ./resonate dst issue \
           --seed ${{ needs.seed.outputs.seed }} \
           --scenario ${{ matrix.scenario }} \

--- a/.github/workflows/release_publish_github_artifacts.yaml
+++ b/.github/workflows/release_publish_github_artifacts.yaml
@@ -43,9 +43,8 @@ jobs:
           # Build resonate binary
           nix build ".#resonate"
 
-          # Copy and change permissions
+          # Copy into root
           cp ./result/bin/resonate resonate
-          chmod +x resonate
 
           # Compress binary
           tar -czvf "${TARBALL}" resonate


### PR DESCRIPTION
# Pull Request

## Summary

PR #291 introduced new CI failures stemming from restoring and executing the `resonate` binary. I'm not 100% sure that this PR will fix that issue but I do know that running `chmod +x` against the binary built with Nix is unnecessary, as the build process in Nix's standard environment handles that automatically.

## Changes

Removed a handful of now-unnecessary `chmod +x` statements in Actions workflows.

<!-- List the major changes introduced by this pull request. -->

## Related Issues

N/A


## Testing

Future post-merge CI runs will be the only real way to test, unfortunately.

## Screenshots (if applicable)

N/A

## Checklist
<!-- Please check each item when your PR is ready for review. -->

- [x] I have tested my changes thoroughly.
- [x] My code follows the project's coding standards.
- [x] I have updated the documentation (if applicable).
- [x] I have added relevant comments to the code.
- [x] I have resolved any merge conflicts.

## Reviewers
<!-- Mention any specific team members or individuals who should review this PR. -->
