### PR TITLE
Standardize all Linux Actions runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/dst.yaml
+++ b/.github/workflows/dst.yaml
@@ -37,7 +37,7 @@ jobs:
         key: resonate-${{ github.sha }}
 
   seed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - id: seed
       name: Set random seed
@@ -46,7 +46,7 @@ jobs:
       seed: ${{ inputs.seed || steps.seed.outputs.seed }}
 
   dst:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build, seed]
     timeout-minutes: 150
 
@@ -113,7 +113,7 @@ jobs:
         path: logs.txt
 
   diff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build, seed, dst]
 
     strategy:

--- a/.github/workflows/release_verify_artifacts.yaml
+++ b/.github/workflows/release_verify_artifacts.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   seed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - id: seed
       name: Set random seed
@@ -31,7 +31,7 @@ jobs:
 
       
   verify-github-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [seed]
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
 
   
   verify-github-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [seed]
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Pull Request

## Summary

PR #291 introduced some CI failures that PI #293 didn't resolve. I have a hunch that the issue here is that one workflow is using `ubuntu-22.04` while the "downstream" workflow is using `ubuntu-latest`, which is causing an issue where the binary isn't being properly cached/restored.

Even if this does not fix the issue, it's a reasonable bit of housekeeping, as it's always worth standardizing runners.

## Changes

Standardized the Actions runner for all Linux workflows to `ubuntu-22.04`.

## Related Issues

CI issues in #291

## Testing

N/A

## Screenshots (if applicable)

N/A

## Checklist
<!-- Please check each item when your PR is ready for review. -->

- [x] I have tested my changes thoroughly.
- [x] My code follows the project's coding standards.
- [x] I have updated the documentation (if applicable).
- [x] I have added relevant comments to the code.
- [x] I have resolved any merge conflicts.

## Reviewers
<!-- Mention any specific team members or individuals who should review this PR. -->
