### PR TITLE
Build static binary on Linux with Nix

### DIFF
--- a/.github/workflows/dst.yaml
+++ b/.github/workflows/dst.yaml
@@ -27,7 +27,8 @@ jobs:
     
     - name: Build resonate binary
       run: |
-        nix develop --command go build -o resonate
+        nix build ".#resonate"
+        cp ./result/bin/resonate resonate
 
     - name: Cache resonate binary
       uses: actions/cache/save@v4

--- a/.github/workflows/dst.yaml
+++ b/.github/workflows/dst.yaml
@@ -27,8 +27,7 @@ jobs:
     
     - name: Build resonate (Nix)
       run: |
-        nix build ".#resonate"
-        cp ./result/bin/resonate resonate
+        nix develop --command go build -o resonate
 
     - name: Cache resonate binary
       uses: actions/cache/save@v4

--- a/.github/workflows/dst.yaml
+++ b/.github/workflows/dst.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Use Magic Nix Cache
       uses: DeterminateSystems/magic-nix-cache-action@v4
     
-    - name: Build resonate (Nix)
+    - name: Build resonate binary
       run: |
         nix develop --command go build -o resonate
 

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,12 @@
             "-s"
             "-w"
             "-extldflags=-static"
+            "-linkmode=external"
           ];
+
+          buildInputs = pkgs.lib.optionals
+            (pkgs.stdenv.hostPlatform.isLinux)
+            (with pkgs; [ glibc glibc.static ]);
 
           # Provides the `installShellCompletion` shell function
           nativeBuildInputs = with pkgs; [ installShellFiles ];

--- a/flake.nix
+++ b/flake.nix
@@ -84,16 +84,18 @@
           # Required for SQLite on Linux
           CGO_ENABLED = 1;
 
-          # Make the binary static
+          # Make the binary static on Linux
           ldflags = [
             "-s"
             "-w"
+          ] ++ pkgs.lib.optional (pkgs.stdenv.isLinux) [
             "-extldflags=-static"
             "-linkmode=external"
           ];
 
-          buildInputs = pkgs.lib.optionals
-            (pkgs.stdenv.hostPlatform.isLinux)
+          # Use glibc on Linux
+          buildInputs = pkgs.lib.optional
+            (pkgs.stdenv.isLinux)
             (with pkgs; [ glibc glibc.static ]);
 
           # Provides the `installShellCompletion` shell function

--- a/flake.nix
+++ b/flake.nix
@@ -81,8 +81,15 @@
           src = self;
           modules = ./gomod2nix.toml;
 
-          # Required for SQLite
+          # Required for SQLite on Linux
           CGO_ENABLED = 1;
+
+          # Make the binary static
+          ldflags = [
+            "-s"
+            "-w"
+            "-extldflags=-static"
+          ];
 
           # Provides the `installShellCompletion` shell function
           nativeBuildInputs = with pkgs; [ installShellFiles ];


### PR DESCRIPTION
# Pull Request

## Summary

PR #291 inadvertently introduced an issue in CI where the Linux binary for the Resonate server wasn't statically linked. This PR fixes that.

## Changes

Make glibc available at build time for Nix builds on Linux.

## Related Issues

N/A

## Testing

I successfully tested the changes in CI in [my fork](https://github.com/lucperkins/resonate).

You can see the results here:

https://github.com/lucperkins/resonate/actions/runs/8725916769

The `main` in my fork used for this run is identical to the `HEAD` in this PR. See e6724f2907669a0dc0edebb16ed06ebf5c0b52c1.

## Screenshots (if applicable)

N/A

## Checklist
<!-- Please check each item when your PR is ready for review. -->

- [x] I have tested my changes thoroughly.
- [x] My code follows the project's coding standards.
- [x] I have updated the documentation (if applicable).
- [x] I have added relevant comments to the code.
- [x] I have resolved any merge conflicts.

## Reviewers
<!-- Mention any specific team members or individuals who should review this PR. -->
