### PR TITLE
Fix Bash script in release-artifacts-nix workflow

### DIFF
--- a/.github/workflows/release_publish_github_artifacts.yaml
+++ b/.github/workflows/release_publish_github_artifacts.yaml
@@ -50,7 +50,7 @@ jobs:
           tar -czvf "${TARBALL}" resonate
 
           # Create checksum
-          sha256sum "${TARBALL}" > "${TARBALL_CHECKSUM}
+          sha256sum "${TARBALL}" > "${TARBALL_CHECKSUM}"
 
       - name: Upload binary
         env:


### PR DESCRIPTION
# Pull Request

## Summary

Fixes the broken release workflow, which was throwing this error:

```
/home/runner/work/_temp/ee6e2ef9-84c7-4232-b777-41174ac4d836.sh: line 14: unexpected EOF while looking for matching `"'
```

## Changes

Adds a missing quotation mark.

## Related Issues

N/A

## Testing

N/A

## Screenshots (if applicable)

N/A

## Checklist
<!-- Please check each item when your PR is ready for review. -->

- [ ] I have tested my changes thoroughly.
- [x] My code follows the project's coding standards.
- [x] I have updated the documentation (if applicable).
- [ ] I have added relevant comments to the code.
- [x] I have resolved any merge conflicts.

## Reviewers
<!-- Mention any specific team members or individuals who should review this PR. -->
