### PR TITLE
add: limit while scheduling promises

### DIFF
--- a/cmd/dst/run.go
+++ b/cmd/dst/run.go
@@ -269,10 +269,12 @@ func RunDSTCmd() *cobra.Command {
 	cmd.Flags().Var(&util.RangeIntFlag{Min: 1, Max: 1000}, "system-notification-cache-size", "max number of notifications to keep in cache")
 	cmd.Flags().Var(&util.RangeIntFlag{Min: 1, Max: 1000}, "system-submission-batch-size", "size of the completion queue buffered channel")
 	cmd.Flags().Var(&util.RangeIntFlag{Min: 1, Max: 1000}, "system-completion-batch-size", "max number of completions to process on each tick")
+	cmd.Flags().Var(&util.RangeIntFlag{Min: 1, Max: 10000}, "system-schedule-batch-size", "max number of schedules to process on each tick")
 
 	_ = viper.BindPFlag("dst.system.notificationCacheSize", cmd.Flags().Lookup("system-notification-cache-size"))
 	_ = viper.BindPFlag("dst.system.submissionBatchSize", cmd.Flags().Lookup("system-submission-batch-size"))
 	_ = viper.BindPFlag("dst.system.completionBatchSize", cmd.Flags().Lookup("system-completion-batch-size"))
+	_ = viper.BindPFlag("system.scheduleBatchSize", cmd.Flags().Lookup("system-schedule-batch-size"))
 
 	cmd.Flags().SortFlags = false
 

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -260,12 +260,12 @@ func ServeCmd() *cobra.Command {
 	cmd.Flags().Int("system-notification-cache-size", 100, "max number of notifications to keep in cache")
 	cmd.Flags().Int("system-submission-batch-size", 100, "max number of submissions to process on each tick")
 	cmd.Flags().Int("system-completion-batch-size", 100, "max number of completions to process on each tick")
-	cmd.Flags().Int("system-max-schedules-size", 10000, "max number of schedules to process on each tick")
+	cmd.Flags().Int("system-schedule-batch-size", 10000, "max number of schedules to process on each tick")
 
 	_ = viper.BindPFlag("system.notificationCacheSize", cmd.Flags().Lookup("system-notification-cache-size"))
 	_ = viper.BindPFlag("system.submissionBatchSize", cmd.Flags().Lookup("system-submission-batch-size"))
 	_ = viper.BindPFlag("system.completionBatchSize", cmd.Flags().Lookup("system-completion-batch-size"))
-	_ = viper.BindPFlag("system.maxSchedulesSize", cmd.Flags().Lookup("system-max-schedules-size"))
+	_ = viper.BindPFlag("system.scheduleBatchSize", cmd.Flags().Lookup("system-schedule-batch-size"))
 	// metrics
 	cmd.Flags().Int("metrics-port", 9090, "prometheus metrics server port")
 	_ = viper.BindPFlag("metrics.port", cmd.Flags().Lookup("metrics-port"))

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -260,11 +260,12 @@ func ServeCmd() *cobra.Command {
 	cmd.Flags().Int("system-notification-cache-size", 100, "max number of notifications to keep in cache")
 	cmd.Flags().Int("system-submission-batch-size", 100, "max number of submissions to process on each tick")
 	cmd.Flags().Int("system-completion-batch-size", 100, "max number of completions to process on each tick")
+	cmd.Flags().Int("system-max-schedules-size", 10000, "max number of schedules to process on each tick")
 
 	_ = viper.BindPFlag("system.notificationCacheSize", cmd.Flags().Lookup("system-notification-cache-size"))
 	_ = viper.BindPFlag("system.submissionBatchSize", cmd.Flags().Lookup("system-submission-batch-size"))
 	_ = viper.BindPFlag("system.completionBatchSize", cmd.Flags().Lookup("system-completion-batch-size"))
-
+	_ = viper.BindPFlag("system.maxSchedulesSize", cmd.Flags().Lookup("system-max-schedules-size"))
 	// metrics
 	cmd.Flags().Int("metrics-port", 9090, "prometheus metrics server port")
 	_ = viper.BindPFlag("metrics.port", cmd.Flags().Lookup("metrics-port"))

--- a/internal/app/coroutines/schedulePromises.go
+++ b/internal/app/coroutines/schedulePromises.go
@@ -35,7 +35,7 @@ func SchedulePromises(t int64, config *system.Config) *Coroutine {
 							Kind: t_aio.ReadSchedules,
 							ReadSchedules: &t_aio.ReadSchedulesCommand{
 								NextRunTime: c.Time(),
-								Limit:       int64(config.MaxSchedulesSize),
+								Limit:       int64(config.ScheduleBatchSize),
 							},
 						},
 					},

--- a/internal/app/coroutines/schedulePromises.go
+++ b/internal/app/coroutines/schedulePromises.go
@@ -35,6 +35,7 @@ func SchedulePromises(t int64, config *system.Config) *Coroutine {
 							Kind: t_aio.ReadSchedules,
 							ReadSchedules: &t_aio.ReadSchedulesCommand{
 								NextRunTime: c.Time(),
+								Limit:       int64(config.MaxSchedulesSize),
 							},
 						},
 					},

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -206,7 +206,9 @@ const (
 	WHERE
 		next_run_time <= $1
 	ORDER BY
-		next_run_time ASC, sort_id ASC`
+		next_run_time ASC, sort_id ASC
+	LIMIT
+		$2`
 
 	SCHEDULE_SEARCH_STATEMENT = `
 	SELECT
@@ -1292,7 +1294,7 @@ func (w *PostgresStoreWorker) readSchedule(tx *sql.Tx, cmd *t_aio.ReadScheduleCo
 }
 
 func (w *PostgresStoreWorker) readSchedules(tx *sql.Tx, cmd *t_aio.ReadSchedulesCommand) (*t_aio.Result, error) {
-	rows, err := tx.Query(SCHEDULE_SELECT_ALL_STATEMENT, cmd.NextRunTime)
+	rows, err := tx.Query(SCHEDULE_SELECT_ALL_STATEMENT, cmd.NextRunTime, cmd.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -191,7 +191,9 @@ const (
 	WHERE
 		next_run_time <= ?
 	ORDER BY
-		next_run_time ASC, sort_id ASC`
+		next_run_time ASC, sort_id ASC
+	LIMIT
+		?`
 
 	SCHEDULE_SEARCH_STATEMENT = `
 	SELECT
@@ -1263,7 +1265,7 @@ func (w *SqliteStoreWorker) readSchedule(tx *sql.Tx, cmd *t_aio.ReadScheduleComm
 }
 
 func (w *SqliteStoreWorker) readSchedules(tx *sql.Tx, cmd *t_aio.ReadSchedulesCommand) (*t_aio.Result, error) {
-	rows, err := tx.Query(SCHEDULE_SELECT_ALL_STATEMENT, cmd.NextRunTime)
+	rows, err := tx.Query(SCHEDULE_SELECT_ALL_STATEMENT, cmd.NextRunTime, cmd.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -2551,6 +2551,7 @@ var TestCases = []*testCase{
 				Kind: t_aio.ReadSchedules,
 				ReadSchedules: &t_aio.ReadSchedulesCommand{
 					NextRunTime: 2500,
+					Limit:       2,
 				},
 			},
 		},

--- a/internal/kernel/system/system.go
+++ b/internal/kernel/system/system.go
@@ -19,15 +19,16 @@ type Config struct {
 	NotificationCacheSize int
 	SubmissionBatchSize   int
 	CompletionBatchSize   int
-	MaxSchedulesSize      int
+	ScheduleBatchSize     int
 }
 
 func (c *Config) String() string {
 	return fmt.Sprintf(
-		"Config(ncs=%d, sbs=%d, cbs=%d)",
+		"Config(ncs=%d, sbs=%d, cbs=%d, sbs=%d)",
 		c.NotificationCacheSize,
 		c.SubmissionBatchSize,
 		c.CompletionBatchSize,
+		c.ScheduleBatchSize,
 	)
 }
 

--- a/internal/kernel/system/system.go
+++ b/internal/kernel/system/system.go
@@ -19,6 +19,7 @@ type Config struct {
 	NotificationCacheSize int
 	SubmissionBatchSize   int
 	CompletionBatchSize   int
+	MaxSchedulesSize      int
 }
 
 func (c *Config) String() string {

--- a/internal/kernel/t_aio/store.go
+++ b/internal/kernel/t_aio/store.go
@@ -339,6 +339,7 @@ type ReadScheduleCommand struct {
 
 type ReadSchedulesCommand struct {
 	NextRunTime int64
+	Limit       int64
 }
 
 type SearchSchedulesCommand struct {


### PR DESCRIPTION
This PR addresses the concerns of this issue https://github.com/resonatehq/resonate/issues/169. 

More information: right now the kernel processes schedules from the databases every 10 ms and creates promises for execution. It finds out the list of promises to be scheduled by executing the READ_ALL_SCHEDULES query against the respective database. This is prone to occur when the system is under high stress as the query can degrade performance when there are a huge number of promises to be scheduled. Instead, this PR ensures that only a limited number of them are scheduled without the system getting overwhelmed. 

Testing
1. I've run the local build and put log statements for recording the number of results in the readSchedules method and I was able to verify that the number of scheduled promises is pegged at the limit. 
2. Unit tests 

