### PR TITLE
feat(timers): enabling simple timers

### DIFF
--- a/internal/app/coroutines/completePromise.go
+++ b/internal/app/coroutines/completePromise.go
@@ -71,13 +71,16 @@ func CompletePromise(metadata *metadata.Metadata, req *t_api.Request, res func(*
 							return
 						}
 
+						completedState := promise.GetTimedoutState(p)
+						util.Assert(completedState == promise.Timedout || completedState == promise.Resolved, "completedState must be Timedout or Resolved")
+
 						res(&t_api.Response{
 							Kind: req.Kind,
 							CompletePromise: &t_api.CompletePromiseResponse{
 								Status: t_api.StatusPromiseAlreadyTimedOut,
 								Promise: &promise.Promise{
 									Id:    p.Id,
-									State: promise.Timedout,
+									State: completedState,
 									Param: p.Param,
 									Value: promise.Value{
 										Headers: map[string]string{},

--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -155,13 +155,16 @@ func CreatePromise(metadata *metadata.Metadata, req *t_api.Request, res func(*t_
 						return
 					}
 
+					completedState := promise.GetTimedoutState(p)
+					util.Assert(completedState == promise.Timedout || completedState == promise.Resolved, "completedState must be Timedout or Resolved")
+
 					res(&t_api.Response{
 						Kind: t_api.CreatePromise,
 						CreatePromise: &t_api.CreatePromiseResponse{
 							Status: status,
 							Promise: &promise.Promise{
 								Id:    p.Id,
-								State: promise.Timedout,
+								State: completedState,
 								Param: p.Param,
 								Value: promise.Value{
 									Headers: map[string]string{},

--- a/internal/app/coroutines/readPromise.go
+++ b/internal/app/coroutines/readPromise.go
@@ -63,13 +63,16 @@ func ReadPromise(metadata *metadata.Metadata, req *t_api.Request, res func(*t_ap
 						return
 					}
 
+					completedState := promise.GetTimedoutState(p)
+					util.Assert(completedState == promise.Timedout || completedState == promise.Resolved, "completedState must be Timedout or Resolved")
+
 					res(&t_api.Response{
 						Kind: t_api.ReadPromise,
 						ReadPromise: &t_api.ReadPromiseResponse{
 							Status: t_api.StatusOK,
 							Promise: &promise.Promise{
 								Id:    p.Id,
-								State: promise.Timedout,
+								State: completedState,
 								Param: p.Param,
 								Value: promise.Value{
 									Headers: map[string]string{},

--- a/internal/app/coroutines/timeoutPromise.go
+++ b/internal/app/coroutines/timeoutPromise.go
@@ -12,12 +12,8 @@ import (
 
 func TimeoutPromise(metadata *metadata.Metadata, p *promise.Promise, retry *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission], res func(error)) *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission] {
 	return scheduler.NewCoroutine(metadata, func(c *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission]) {
-		completedState := promise.Timedout
-		if v, ok := p.Tags["resonate:timeout"]; ok {
-			if v == "true" {
-				completedState = promise.Resolved
-			}
-		}
+		completedState := promise.GetTimedoutState(p)
+		util.Assert(completedState == promise.Timedout || completedState == promise.Resolved, "completedState must be Timedout or Resolved")
 
 		completion, err := c.Yield(&t_aio.Submission{
 			Kind: t_aio.Store,

--- a/internal/app/coroutines/timeoutPromise.go
+++ b/internal/app/coroutines/timeoutPromise.go
@@ -12,10 +12,10 @@ import (
 
 func TimeoutPromise(metadata *metadata.Metadata, p *promise.Promise, retry *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission], res func(error)) *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission] {
 	return scheduler.NewCoroutine(metadata, func(c *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission]) {
-		completeState := promise.Timedout
+		completedState := promise.Timedout
 		if v, ok := p.Tags["resonate:timeout"]; ok {
 			if v == "true" {
-				completeState = promise.Resolved
+				completedState = promise.Resolved
 			}
 		}
 
@@ -28,7 +28,7 @@ func TimeoutPromise(metadata *metadata.Metadata, p *promise.Promise, retry *sche
 							Kind: t_aio.UpdatePromise,
 							UpdatePromise: &t_aio.UpdatePromiseCommand{
 								Id:    p.Id,
-								State: completeState,
+								State: completedState,
 								Value: promise.Value{
 									Headers: map[string]string{},
 									Data:    []byte{},

--- a/internal/app/coroutines/timeoutPromise.go
+++ b/internal/app/coroutines/timeoutPromise.go
@@ -10,8 +10,6 @@ import (
 	"github.com/resonatehq/resonate/pkg/promise"
 )
 
-// TODO: this is to time out a single promise.
-// just change behavior of this coroutine depending on the promise tag: resonate:timeout.
 func TimeoutPromise(metadata *metadata.Metadata, p *promise.Promise, retry *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission], res func(error)) *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission] {
 	return scheduler.NewCoroutine(metadata, func(c *scheduler.Coroutine[*t_aio.Completion, *t_aio.Submission]) {
 		completeState := promise.Timedout

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -48,6 +48,7 @@ const (
 
 	CREATE INDEX IF NOT EXISTS idx_promises_sort_id ON promises(sort_id);
 	CREATE INDEX IF NOT EXISTS idx_promises_invocation ON promises(invocation);
+	CREATE INDEX IF NOT EXISTS idx_promises_timeout ON promises((tags->>'resonate:timeout'));
 
 	CREATE TABLE IF NOT EXISTS schedules (
 		id                    TEXT,

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -186,7 +186,10 @@ const (
 	UPDATE
 		promises
 	SET
-		state = 16, completed_on = timeout
+		state = CASE
+					WHEN tags ->> 'resonate:timeout' IS NOT NULL AND tags ->> 'resonate:timeout' = 'true' THEN 2 
+					ELSE 16
+				END
 	WHERE
 		state = 1 AND timeout <= $1`
 

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -40,14 +40,13 @@ const (
 		idempotency_key_for_create   TEXT,
 		idempotency_key_for_complete TEXT,
 		tags                         JSONB,
-		invocation                   TEXT GENERATED ALWAYS AS (tags->>'resonate:invocation') STORED,
 		created_on                   BIGINT,
 		completed_on                 BIGINT,
 		PRIMARY KEY(id)
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_promises_sort_id ON promises(sort_id);
-	CREATE INDEX IF NOT EXISTS idx_promises_invocation ON promises(invocation);
+	CREATE INDEX IF NOT EXISTS idx_promises_invocation ON promises((tags->>'resonate:invocation'));
 	CREATE INDEX IF NOT EXISTS idx_promises_timeout ON promises((tags->>'resonate:timeout'));
 
 	CREATE TABLE IF NOT EXISTS schedules (
@@ -161,7 +160,7 @@ const (
 		($1::int IS NULL OR sort_id < $1) AND
 		id LIKE $2 AND
 		state & $3 != 0 AND
-		($4::text IS NULL OR invocation = $4) AND
+		$4::text IS NULL AND
 		($5::jsonb IS NULL OR tags @> $5)
 	ORDER BY
 		sort_id DESC
@@ -1103,13 +1102,7 @@ func (w *PostgresStoreWorker) searchPromises(tx *sql.Tx, cmd *t_aio.SearchPromis
 	}
 
 	// tags
-	var invocation *string
 	var tags *string
-
-	if v, ok := cmd.Tags["resonate:invocation"]; ok {
-		invocation = &v
-		delete(cmd.Tags, "resonate:invocation")
-	}
 
 	if len(cmd.Tags) > 0 {
 		t, err := json.Marshal(cmd.Tags)
@@ -1120,8 +1113,16 @@ func (w *PostgresStoreWorker) searchPromises(tx *sql.Tx, cmd *t_aio.SearchPromis
 		tags = util.ToPointer(string(t))
 	}
 
+	args := []any{
+		cmd.SortId,
+		id,
+		mask,
+		tags,
+		cmd.Limit,
+	}
+
 	// select
-	rows, err := tx.Query(PROMISE_SEARCH_STATEMENT, cmd.SortId, id, mask, invocation, tags, cmd.Limit)
+	rows, err := tx.Query(PROMISE_SEARCH_STATEMENT, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -40,13 +40,12 @@ const (
 		idempotency_key_for_create   TEXT,
 		idempotency_key_for_complete TEXT,
 		tags                         BLOB,
-		invocation                   TEXT GENERATED ALWAYS AS (json_extract(tags, '$.resonate:invocation')) STORED,
 		created_on                   INTEGER,
 		completed_on                 INTEGER
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_promises_id ON promises(id);
-	CREATE INDEX IF NOT EXISTS idx_promises_invocation ON promises(invocation);
+	CREATE INDEX IF NOT EXISTS idx_promises_invocation ON promises(json_extract(tags, '$.resonate:invocation'));
 	CREATE INDEX IF NOT EXISTS idx_promises_timeout ON promises(json_extract(tags, '$.resonate:timeout'));
 
 	CREATE TABLE IF NOT EXISTS schedules (
@@ -145,8 +144,7 @@ const (
 	WHERE
 		(? IS NULL OR sort_id < ?) AND
 		id LIKE ? AND
-		state & ? != 0 AND
-		(? IS NULL OR invocation = ?)
+		state & ? != 0
 		%s
 	ORDER BY
 		sort_id DESC
@@ -1062,39 +1060,32 @@ func (w *SqliteStoreWorker) searchPromises(tx *sql.Tx, cmd *t_aio.SearchPromises
 	}
 
 	// tags
-	var invocation *string
 	placeholders := []string{}
-	placeholderVars := []any{}
+	placeholderArgs := []any{}
 
 	for k, v := range cmd.Tags {
-		if k == "resonate:invocation" {
-			invocation = &v
-			continue
-		}
-
 		placeholders = append(placeholders, "json_extract(tags, ?) = ?")
-		placeholderVars = append(placeholderVars, "$."+k, v)
+		placeholderArgs = append(placeholderArgs, "$."+k, v)
 	}
 
-	vars := []any{
+	args := []any{
 		cmd.SortId,
 		cmd.SortId,
 		id,
 		mask,
-		invocation,
-		invocation,
 	}
 
-	vars = append(vars, placeholderVars...)
-	vars = append(vars, cmd.Limit)
+	args = append(args, placeholderArgs...)
+	args = append(args, cmd.Limit)
 
+	// Dynamic placeholders for tags.
 	var placeholder string
 	if len(placeholders) > 0 {
 		placeholder = "AND " + strings.Join(placeholders, " AND ")
 	}
 
 	// select
-	rows, err := tx.Query(fmt.Sprintf(PROMISE_SEARCH_STATEMENT, placeholder), vars...)
+	rows, err := tx.Query(fmt.Sprintf(PROMISE_SEARCH_STATEMENT, placeholder), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -47,6 +47,7 @@ const (
 
 	CREATE INDEX IF NOT EXISTS idx_promises_id ON promises(id);
 	CREATE INDEX IF NOT EXISTS idx_promises_invocation ON promises(invocation);
+	CREATE INDEX IF NOT EXISTS idx_promises_timeout ON promises(json_extract(tags, '$.resonate:timeout'));
 
 	CREATE TABLE IF NOT EXISTS schedules (
 		id                    TEXT UNIQUE,

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -171,7 +171,11 @@ const (
 	UPDATE
 		promises
 	SET
-		state = 16, completed_on = timeout
+		state = CASE
+					WHEN json_extract(tags, '$.resonate:timeout') IS NOT NULL AND json_extract(tags, '$.resonate:timeout') = 'true' THEN 2
+					ELSE 16
+				END, 
+		completed_on = timeout
 	WHERE
 		state = 1 AND timeout <= ?`
 

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -3435,6 +3435,12 @@ var TestCases = []*testCase{
 					Limit:  5,
 				},
 			},
+			{
+				Kind: t_aio.ReadPromise,
+				ReadPromise: &t_aio.ReadPromiseCommand{
+					Id: "foo",
+				},
+			},
 		},
 		expected: []*t_aio.Result{
 			{
@@ -3571,6 +3577,22 @@ var TestCases = []*testCase{
 						},
 						// foo is not here because it was resolved.
 					},
+				},
+			},
+			{
+				Kind: t_aio.ReadPromise,
+				ReadPromise: &t_aio.QueryPromisesResult{
+					RowsReturned: 1,
+					Records: []*promise.PromiseRecord{{
+						Id:           "foo",
+						State:        2,
+						ParamHeaders: []byte("{}"),
+						ParamData:    []byte{},
+						Timeout:      2,
+						Tags:         []byte("{\"resonate:timeout\":\"true\"}"),
+						CreatedOn:    util.ToPointer(int64(1)),
+						CompletedOn:  util.ToPointer(int64(2)),
+					}},
 				},
 			},
 		},

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -3317,7 +3317,9 @@ var TestCases = []*testCase{
 						Headers: map[string]string{},
 						Data:    []byte{},
 					},
-					Tags:      map[string]string{},
+					Tags: map[string]string{
+						"resonate:timeout": "true",
+					},
 					CreatedOn: 1,
 				},
 			},
@@ -3542,8 +3544,8 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.SearchPromises,
 				SearchPromises: &t_aio.QueryPromisesResult{
-					RowsReturned: 3,
-					LastSortId:   1,
+					RowsReturned: 2,
+					LastSortId:   2,
 					Records: []*promise.PromiseRecord{
 						{
 							Id:           "baz",
@@ -3567,17 +3569,7 @@ var TestCases = []*testCase{
 							Tags:         []byte("{}"),
 							SortId:       2,
 						},
-						{
-							Id:           "foo",
-							State:        16,
-							ParamHeaders: []byte("{}"),
-							ParamData:    []byte{},
-							Timeout:      2,
-							CreatedOn:    util.ToPointer(int64(1)),
-							CompletedOn:  util.ToPointer(int64(2)),
-							Tags:         []byte("{}"),
-							SortId:       1,
-						},
+						// foo is not here because it was resolved.
 					},
 				},
 			},

--- a/internal/kernel/t_aio/store.go
+++ b/internal/kernel/t_aio/store.go
@@ -399,6 +399,9 @@ type DeleteTimeoutCommand struct {
 	Id string
 }
 
+// This timeout promises command takes into account 'regular' and 'timeout' promises.
+// Regular promises are those that have their state updated to REJECTED_TIMEDOUT when the timeout is reached.
+// Timeout promises are those that have their state udpated to COMPLETED when the timeout is reached.
 type TimeoutPromisesCommand struct {
 	Time int64
 }

--- a/internal/kernel/t_aio/store.go
+++ b/internal/kernel/t_aio/store.go
@@ -401,7 +401,7 @@ type DeleteTimeoutCommand struct {
 
 // This timeout promises command takes into account 'regular' and 'timeout' promises.
 // Regular promises are those that have their state updated to REJECTED_TIMEDOUT when the timeout is reached.
-// Timeout promises are those that have their state udpated to COMPLETED when the timeout is reached.
+// Timeout promises are those that have their state updated to RESOLVED when the timeout is reached.
 type TimeoutPromisesCommand struct {
 	Time int64
 }

--- a/pkg/promise/promise.go
+++ b/pkg/promise/promise.go
@@ -107,3 +107,14 @@ func (v Value) String() string {
 		string(v.Data),
 	)
 }
+
+func GetTimedoutState(p *Promise) State {
+	completedState := Timedout
+	if v, ok := p.Tags["resonate:timeout"]; ok {
+		if v == "true" {
+			completedState = Resolved
+		}
+	}
+
+	return completedState
+}

--- a/pkg/promise/promise.go
+++ b/pkg/promise/promise.go
@@ -39,11 +39,11 @@ func (p *Promise) String() string {
 type State int
 
 const (
-	Pending State = 1 << iota
-	Resolved
-	Rejected
-	Canceled
-	Timedout
+	Pending  State = 1 << iota // 1
+	Resolved                   // 2
+	Rejected                   // 4
+	Canceled                   // 8
+	Timedout                   // 16
 )
 
 func (s State) String() string {

--- a/pkg/promise/promise_test.go
+++ b/pkg/promise/promise_test.go
@@ -1,0 +1,48 @@
+package promise
+
+import (
+	"testing"
+)
+
+func TestGetTimedoutState(t *testing.T) {
+	testCases := []struct {
+		name     string
+		promise  Promise
+		expected State
+	}{
+		{
+			name: "Timeout without resonate:timeout tag",
+			promise: Promise{
+				Tags: map[string]string{},
+			},
+			expected: Timedout,
+		},
+		{
+			name: "Timeout with resonate:timeout=false tag",
+			promise: Promise{
+				Tags: map[string]string{
+					"resonate:timeout": "false",
+				},
+			},
+			expected: Timedout,
+		},
+		{
+			name: "Resolved with resonate:timeout=true tag",
+			promise: Promise{
+				Tags: map[string]string{
+					"resonate:timeout": "true",
+				},
+			},
+			expected: Resolved,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetTimedoutState(&tc.promise)
+			if result != tc.expected {
+				t.Errorf("Expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/test/dst/generator.go
+++ b/test/dst/generator.go
@@ -184,6 +184,16 @@ func (g *Generator) GenerateCreatePromise(r *rand.Rand, t int64) *t_api.Request 
 	timeout := RangeInt63n(r, t, g.ticks*g.timeElapsedPerTick)
 	strict := r.Intn(2) == 0
 
+	// Create a simple timeout promise (deep copy so it's not shared with other generator functions).
+	if tags != nil && RandBool(r) {
+		tempTags := make(map[string]string, len(tags)+1)
+		for k, v := range tags {
+			tempTags[k] = v
+		}
+		tempTags["resonate:timeout"] = "true"
+		tags = tempTags
+	}
+
 	return &t_api.Request{
 		Kind: t_api.CreatePromise,
 		CreatePromise: &t_api.CreatePromiseRequest{

--- a/test/dst/model.go
+++ b/test/dst/model.go
@@ -226,7 +226,7 @@ func (m *Model) ValidateSearchPromises(reqTime int64, resTime int64, req *t_api.
 			}
 			for k, v := range req.SearchPromises.Tags {
 				if _v, ok := p.Tags[k]; !ok || v != _v {
-					return fmt.Errorf("unexpected tag '%s:%s', expected '%s:%s'", k, _v, k, v)
+					return fmt.Errorf("promise %s has unexpected tag '%s:%s', expected '%s:%s'", p.Id, k, _v, k, v)
 				}
 			}
 
@@ -405,7 +405,7 @@ func (m *Model) ValidateSearchSchedules(reqTime int64, resTime int64, req *t_api
 			}
 			for k, v := range req.SearchSchedules.Tags {
 				if _v, ok := s.Tags[k]; !ok || v != _v {
-					return fmt.Errorf("unexpected tag '%s:%s', expected '%s:%s'", k, _v, k, v)
+					return fmt.Errorf("schedule %s has unexpected tag '%s:%s', expected '%s:%s'", s.Id, k, _v, k, v)
 				}
 			}
 


### PR DESCRIPTION
### Changes 

This PR introduces a new `resonate:timeout` tag. 

### Context

The new tag enables distinct behaviors between vanilla promises and simple timeout promises: 

- When a vanilla promise timeouts, its state will be updated to REJECTED_TIMEDOUT
- When a simple timeout promise timeouts, its state will be updated to RESOLVED

This distinction will allow events to be tied to the timeout of a promise. 
