### PR TITLE
fix(postgres): query bug, one too many args

### DIFF
--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -160,12 +160,11 @@ const (
 		($1::int IS NULL OR sort_id < $1) AND
 		id LIKE $2 AND
 		state & $3 != 0 AND
-		$4::text IS NULL AND
-		($5::jsonb IS NULL OR tags @> $5)
+		($4::jsonb IS NULL OR tags @> $4)
 	ORDER BY
 		sort_id DESC
 	LIMIT
-		$6`
+		$5`
 
 	PROMISE_INSERT_STATEMENT = `
 	INSERT INTO promises


### PR DESCRIPTION
Fixes https://github.com/resonatehq/resonate/issues/311
<img width="1512" alt="Screenshot 2024-05-06 at 9 45 07 PM" src="https://github.com/resonatehq/resonate/assets/65991626/bb225700-405c-42f6-a282-f2f48fa4a3f8">


Fixes https://github.com/resonatehq/resonate/issues/312
<img width="1512" alt="Screenshot 2024-05-06 at 9 45 56 PM" src="https://github.com/resonatehq/resonate/assets/65991626/5e0c1f58-f1ac-4a03-bbf7-49036b985b6b">
