### PR TITLE
Fix lazy promise transitions

### DIFF
--- a/.github/workflows/dst.yaml
+++ b/.github/workflows/dst.yaml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [default, fault]
+        scenario: [default, fault, lazy]
         store: [sqlite, postgres]
         run: [1, 2]
 
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [default, fault]
+        scenario: [default, fault, lazy]
         store: [sqlite, postgres, sqlite/postgres]
         include:
         - store: sqlite

--- a/internal/app/coroutines/completePromise.go
+++ b/internal/app/coroutines/completePromise.go
@@ -74,10 +74,16 @@ func CompletePromise(metadata *metadata.Metadata, req *t_api.Request, res func(*
 						completedState := promise.GetTimedoutState(p)
 						util.Assert(completedState == promise.Timedout || completedState == promise.Resolved, "completedState must be Timedout or Resolved")
 
+						// If not strict, status is OK
+						status := t_api.StatusPromiseAlreadyTimedOut
+						if !req.CompletePromise.Strict {
+							status = t_api.StatusOK
+						}
+
 						res(&t_api.Response{
 							Kind: req.Kind,
 							CompletePromise: &t_api.CompletePromiseResponse{
-								Status: t_api.StatusPromiseAlreadyTimedOut,
+								Status: status,
 								Promise: &promise.Promise{
 									Id:    p.Id,
 									State: completedState,

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -36,6 +36,7 @@ type Scenario struct {
 	Kind           Kind
 	Default        *DefaultScenario
 	FaultInjection *FaultInjectionScenario
+	LazyTimeout    *LazyTimeoutScenario
 }
 
 type Kind string
@@ -43,6 +44,7 @@ type Kind string
 const (
 	Default        Kind = "default"
 	FaultInjection Kind = "fault"
+	LazyTimeout    Kind = "lazy"
 )
 
 type DefaultScenario struct{}
@@ -50,6 +52,8 @@ type DefaultScenario struct{}
 type FaultInjectionScenario struct {
 	P float64
 }
+
+type LazyTimeoutScenario struct{}
 
 func New(config *Config) *DST {
 	return &DST{


### PR DESCRIPTION
A promise cannot be guarenteed to be transitioned from pending to timedout when requests come in after the timeout time. To compensate for this, we lazily transition promises on request if we see that the promise should be timedout, but is not. This rarely taken code path had two bugs.

1. On create promise request, a promise that is lazily timedout should return a 200 if strict is false and the idempotency keys match.

2. On complete promise request, a promise that is lazily timedout should return a 200 if strict is false.

This PR also introduces a lazy scenario to DST to test the lazy code path. When this scenario is executed, we disable the time out promises coroutine and search promises request.