### PR TITLE
feat(version): append commit hash on build via ldflags

### DIFF
--- a/.github/workflows/release_check_version.yaml
+++ b/.github/workflows/release_check_version.yaml
@@ -34,7 +34,6 @@ jobs:
         run: |
           # Extract resonate version
           RESONATE_VERSION=$(./resonate -v | awk '{print $3}')
-          RESONATE_VERSION="v${RESONATE_VERSION}"
 
           # Compare versions
           if [ "$RESONATE_VERSION" != "$GITHUB_REF_VERSION" ]; then

--- a/.github/workflows/release_publish_github_image.yaml
+++ b/.github/workflows/release_publish_github_image.yaml
@@ -65,6 +65,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          build-args: |
+            COMMIT_HASH="${{ github.sha }}"
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 # Build. 
 FROM cgr.dev/chainguard/go AS builder
 
+ARG COMMIT_HASH
+
 WORKDIR /app
 COPY . .
 
-RUN CGO_ENABLED=1 GOOS=linux go build -o resonate . 
+RUN CGO_ENABLED=1 \
+    GOOS=linux \
+    go \
+    build \
+    -ldflags="-X github.com/resonatehq/resonate/internal/version.commit=${COMMIT_HASH}" \
+    -o resonate .
 
 # Distribute. 
 FROM cgr.dev/chainguard/glibc-dynamic

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,8 @@ import (
 	"github.com/resonatehq/resonate/cmd/quickstart"
 	"github.com/resonatehq/resonate/cmd/schedules"
 	"github.com/resonatehq/resonate/cmd/serve"
+	versioncmd "github.com/resonatehq/resonate/cmd/version"
+	"github.com/resonatehq/resonate/internal/version"
 	"github.com/resonatehq/resonate/pkg/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -22,7 +24,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:     "resonate",
 	Short:   "Durable promises",
-	Version: "0.5.6", // This needs to be bumped when new versions are released.
+	Version: version.Full(),
 }
 
 func init() {
@@ -43,6 +45,7 @@ func init() {
 	rootCmd.AddCommand(dst.NewCmd())
 	rootCmd.AddCommand(serve.ServeCmd())
 	rootCmd.AddCommand(quickstart.NewCmd())
+	rootCmd.AddCommand(versioncmd.NewCmd())
 
 	// Set default output
 	rootCmd.SetOut(os.Stdout)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,20 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/resonatehq/resonate/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "version",
+		Short: "Print the version for resonate",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("resonate version %s\n", version.Full())
+		},
+	}
+	return cmd
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,8 @@
     let
       # Version inference
       lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
-      version = "${builtins.substring 0 8 lastModifiedDate}-${self.shortRev or "dirty"}";
+      shortRev = "${self.shortRev or "dirty"}";
+      version = "${builtins.substring 0 8 lastModifiedDate}-${shortRev}";
 
       # Helpers for producing system-specific outputs
       supportedSystems = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" "aarch64-linux" ];
@@ -77,6 +78,7 @@
         # The Resonate server
         resonate = pkgs.buildGoApplication rec {
           pname = "resonate";
+          inherit shortRev;
           inherit version;
           src = self;
           modules = ./gomod2nix.toml;
@@ -88,6 +90,7 @@
           ldflags = [
             "-s"
             "-w"
+            "-X github.com/resonatehq/resonate/internal/version.commit=$(shortRev)"
           ] ++ pkgs.lib.optional (pkgs.stdenv.isLinux) [
             "-extldflags=-static"
             "-linkmode=external"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// current version
+const (
+	coreVersion = "0.5.7"
+	prerelease  = "alpha"
+)
+
+// Provisioned by ldflags
+var commit string
+
+// Core return the core version.
+func Core() string {
+	return coreVersion
+}
+
+// Short return the version with pre-release, if available.
+func Short() string {
+	if prerelease != "" {
+		return fmt.Sprintf("%s-%s-%s", coreVersion, prerelease, time.Now().Format("20060102"))
+	}
+
+	return coreVersion
+}
+
+// Full return the full version including pre-release, commit hash, runtime os and arch.
+func Full() string {
+	if commit != "" && commit[:1] != " " {
+		commit = " " + commit
+	}
+
+	return fmt.Sprintf("v%s%s %s/%s", Short(), commit, runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
This PR follows up the attempts on #301 and  #302.

It standardize resonate binary version to:

`resonate version v<VERSION>[-<PRE_RELEASE>-<TIMESTAMP>][ COMMIT_HASH] <GOOS>/<GOARCH>`

where:

- `VERSION`: the release version
- `PRE_RELEASE`: can be any arbitrary string, e.g. `alpha`, `beta`, `rc.1`, etc
- `TIMESTAMP`: the yyyymmdd of build IF this is not a GA release
- `COMMIT_HASH`: short revision IF this is a GA release
- `GOOS`: underlying OS this binary built on
- `GOARCH`: underlying Architecture this binary built on

This also adds a new `version` subcommand for convenience and to not give an error on `resonate version` for folks with muscle memory for it.

Two manual intervention is needed for this workflow:

1. At the beginning of a release cycle:
   - bump `coreVersion` in `internal/version/version.go` to next logical release
   - set `prerelease` to `alpha` (or `dev`, or similar) in `internal/version/version.go`
2. At the end of a release cycle (beta, RC, GA):
   - set `prerlease` to `""` in `internal/version/version.go` for GA, or just leave it as is for the rest

The rest will be calculated, or generated on the fly.

Fixes: #298