### PR TITLE
Create callback request returns 200

### DIFF
--- a/internal/app/coroutines/createCallback.go
+++ b/internal/app/coroutines/createCallback.go
@@ -108,7 +108,9 @@ func CreateCallback(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any
 				Kind: t_api.CreateCallback,
 				Tags: r.Tags,
 				CreateCallback: &t_api.CreateCallbackResponse{
-					Status:  t_api.ForbiddenStatus(p.State),
+					// ok indicates that the promise is completed and the process
+					// may continue
+					Status:  t_api.StatusOK,
 					Promise: p,
 				},
 			}

--- a/internal/kernel/t_api/status.go
+++ b/internal/kernel/t_api/status.go
@@ -3,7 +3,6 @@ package t_api
 import (
 	"fmt"
 
-	"github.com/resonatehq/resonate/pkg/promise"
 	"google.golang.org/grpc/codes"
 )
 
@@ -103,21 +102,6 @@ func (s ResponseStatus) GRPC() codes.Code {
 		return codes.NotFound
 	default:
 		panic(fmt.Sprintf("invalid status: %d", s))
-	}
-}
-
-func ForbiddenStatus(state promise.State) ResponseStatus {
-	switch state {
-	case promise.Resolved:
-		return StatusPromiseAlreadyResolved
-	case promise.Rejected:
-		return StatusPromiseAlreadyRejected
-	case promise.Canceled:
-		return StatusPromiseAlreadyCanceled
-	case promise.Timedout:
-		return StatusPromiseAlreadyTimedout
-	default:
-		panic(fmt.Sprintf("invalid promise state: %s", state))
 	}
 }
 

--- a/test/dst/validator.go
+++ b/test/dst/validator.go
@@ -274,7 +274,7 @@ func (v *Validator) ValidateCreateCallback(model *Model, reqTime int64, resTime 
 		model = model.Copy()
 		model.callbacks.set(res.CreateCallback.Callback.Id, res.CreateCallback.Callback)
 		return model, nil
-	case t_api.StatusPromiseAlreadyResolved, t_api.StatusPromiseAlreadyRejected, t_api.StatusPromiseAlreadyCanceled, t_api.StatusPromiseAlreadyTimedout:
+	case t_api.StatusOK:
 		if p == nil {
 			return model, fmt.Errorf("promise '%s' exists", req.CreateCallback.PromiseId)
 		}


### PR DESCRIPTION
When a request to create a callback is made against a promise that is already completed, the response will contain a 200 code along with the promise information. The caller can use this information to immediately continue. The 200 response code contrasts to a 201 that is returned in the case where the promise is pending and a callback is created.