### PR TITLE
Update release workflow to support arm64

### DIFF
--- a/.github/workflows/release_publish_github_artifacts.yaml
+++ b/.github/workflows/release_publish_github_artifacts.yaml
@@ -21,26 +21,30 @@ jobs:
         systems:
           - os: linux
             arch: x86_64
+            arch_grep: x86-64
             runner: ubuntu-22.04
           - os: linux
             arch: aarch64
-            runner: ubuntu-22.04
+            arch_grep: aarch64
+            runner: ubuntu-22.04-arm64
           - os: darwin
             arch: x86_64
-            runner: macos-12
+            arch_grep: x86_64
+            runner: macos-13
           - os: darwin
             arch: aarch64
-            runner: macos-12
+            arch_grep: arm64
+            runner: macos-14
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      
+
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v13
 
       - name: Use Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v7
-      
+
       - name: Build Resonate binary
         run: |
           TARBALL="resonate_${{ matrix.systems.os }}_${{ matrix.systems.arch }}.tar.gz"
@@ -51,6 +55,9 @@ jobs:
 
           # Copy into root
           cp ./result/bin/resonate resonate
+
+          # Verify binary
+          file resonate | grep "${{ matrix.systems.arch_grep }}"
 
           # Compress binary
           tar -czvf "${TARBALL}" resonate
@@ -68,6 +75,6 @@ jobs:
         run: |
           TARBALL="resonate_${{ matrix.systems.os }}_${{ matrix.systems.arch }}.tar.gz"
           TARBALL_CHECKSUM="${TARBALL}.sha256"
-          
+
           gh release upload ${{ inputs.tag }} "${TARBALL}" --clobber
           gh release upload ${{ inputs.tag }} "${TARBALL_CHECKSUM}" --clobber

--- a/.github/workflows/release_verify_artifacts.yaml
+++ b/.github/workflows/release_verify_artifacts.yaml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: 'The tag version to use for verification'
+        description: "The tag version to use for verification"
         required: true
         type: string
-        
+
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The tag version to use for verification'
+        description: "The tag version to use for verification"
         required: true
         type: string
 
@@ -19,20 +19,13 @@ permissions:
   contents: read
   packages: read
 
-jobs:
-  seed:
-    runs-on: ubuntu-22.04
-    steps:
-    - id: seed
-      name: Set random seed
-      run: echo seed=$RANDOM >> $GITHUB_OUTPUT
-    outputs:
-      seed: ${{ inputs.seed || steps.seed.outputs.seed }}
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
-      
+jobs:
   verify-github-image:
     runs-on: ubuntu-22.04
-    needs: [seed]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,25 +35,34 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
           # Pull the test image
-          docker pull ghcr.io/resonatehq/resonate:${{ inputs.tag }}
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}
 
           # Run the test image
-          docker run --rm ghcr.io/resonatehq/resonate:${{ inputs.tag }} dst run --seed ${{ needs.seed.outputs.seed }} --aio-store sqlite
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }} dst run
 
-  
   verify-github-release:
-    runs-on: ubuntu-22.04
-    needs: [seed]
+    runs-on: ${{ matrix.systems.runner }}
+    strategy:
+      matrix:
+        systems:
+          - file: resonate_linux_x86_64.tar.gz
+            runner: ubuntu-22.04
+          - file: resonate_linux_aarch64.tar.gz
+            runner: ubuntu-22.04-arm64
+          - file: resonate_darwin_x86_64.tar.gz
+            runner: macos-13
+          - file: resonate_darwin_aarch64.tar.gz
+            runner: macos-14
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Download and test GH release
         run: |
           # Download the release artifact
-          curl -L -O "https://github.com/resonatehq/resonate/releases/download/${{ inputs.tag }}/resonate_linux_x86_64.tar.gz"
+          curl -o resonate.tar.gz -L -O "https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/${{ matrix.systems.file }}"
 
           # Extract the artifact
-          tar -xzf resonate_linux_x86_64.tar.gz
+          tar -xzf resonate.tar.gz
 
           # Run the extracted artifact
-          ./resonate dst run --seed ${{ needs.seed.outputs.seed }} --aio-store sqlite
+          ./resonate dst run


### PR DESCRIPTION
The release was not being built on arm64 chip architecture for both linux and macos. Github now supports arm64 for macos by default, additionally we upgraded our github account to get access to a linux arm64 runner.

I added a step to verify the executable targets the correct architecture and expanded the verify step to run against all runners/artifacts.