### PR TITLE
Remove required for timeout and ttl fields

### DIFF
--- a/internal/app/coroutines/schedulePromises.go
+++ b/internal/app/coroutines/schedulePromises.go
@@ -108,7 +108,7 @@ func SchedulePromises(config *system.Config, tags map[string]string) gocoro.Coro
 			}
 
 			if completion.Store.Results[0].CreatePromise.RowsAffected == 0 {
-				slog.Warn("promise '%s' for schedule '%s' already exists", commands[i].Id, result.Records[i].Id)
+				slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
 			}
 		}
 

--- a/internal/app/subsystems/api/api.go
+++ b/internal/app/subsystems/api/api.go
@@ -161,6 +161,11 @@ func (a *API) SearchSchedules(id string, tags map[string]string, limit int, curs
 		tags = map[string]string{}
 	}
 
+	// set default limit
+	if limit == 0 {
+		limit = 100
+	}
+
 	// validate limit
 	if limit < 1 || limit > 100 {
 		return nil, RequestValidationError(errors.New("The field limit must be between 1 and 100."))

--- a/internal/app/subsystems/api/http/callback.go
+++ b/internal/app/subsystems/api/http/callback.go
@@ -18,7 +18,7 @@ type createCallbackHeader struct {
 type createCallbackBody struct {
 	PromiseId     string          `json:"promiseId" binding:"required"`
 	RootPromiseId string          `json:"rootPromiseId" binding:"required"`
-	Timeout       int64           `json:"timeout" binding:"required"`
+	Timeout       int64           `json:"timeout"`
 	Recv          json.RawMessage `json:"recv" binding:"required"`
 }
 

--- a/internal/app/subsystems/api/http/lock.go
+++ b/internal/app/subsystems/api/http/lock.go
@@ -17,7 +17,7 @@ type acquireLockBody struct {
 	ResourceId  string `json:"resourceId" binding:"required"`
 	ExecutionId string `json:"executionId" binding:"required"`
 	ProcessId   string `json:"processId" binding:"required"`
-	Ttl         int64  `json:"ttl" binding:"required"`
+	Ttl         int64  `json:"ttl"`
 }
 
 func (s *server) acquireLock(c *gin.Context) {

--- a/internal/app/subsystems/api/http/promise.go
+++ b/internal/app/subsystems/api/http/promise.go
@@ -114,7 +114,7 @@ type createPromiseHeader struct {
 type createPromiseBody struct {
 	Id      string            `json:"id" binding:"required"`
 	Param   promise.Value     `json:"param"`
-	Timeout int64             `json:"timeout" binding:"required"`
+	Timeout int64             `json:"timeout"`
 	Tags    map[string]string `json:"tags,omitempty"`
 }
 
@@ -162,7 +162,7 @@ type createPromiseAndTaskBody struct {
 
 type createPromiseTaskBody struct {
 	ProcessId string          `json:"processId" binding:"required"`
-	Ttl       int             `json:"ttl" binding:"required"`
+	Ttl       int             `json:"ttl"`
 	Recv      json.RawMessage `json:"recv" binding:"required"`
 }
 
@@ -222,7 +222,7 @@ type createPromiseAndCallbackBody struct {
 
 type createPromiseCallbackBody struct {
 	RootPromiseId string          `json:"rootPromiseId" binding:"required"`
-	Timeout       int64           `json:"timeout" binding:"required"`
+	Timeout       int64           `json:"timeout"`
 	Recv          json.RawMessage `json:"recv" binding:"required"`
 }
 

--- a/internal/app/subsystems/api/http/schedule.go
+++ b/internal/app/subsystems/api/http/schedule.go
@@ -47,7 +47,7 @@ type searchSchedulesHeader struct {
 type searchSchedulesParams struct {
 	Id     *string           `form:"id" json:"id,omitempty" binding:"omitempty,min=1"`
 	Tags   map[string]string `form:"tags" json:"tags,omitempty"`
-	Limit  *int              `form:"limit" json:"limit,omitempty" binding:"omitempty,gt=0,lte=100"`
+	Limit  *int              `form:"limit" json:"limit,omitempty" binding:"omitempty,gte=0,lte=100"`
 	Cursor *string           `form:"cursor" json:"cursor,omitempty"`
 }
 

--- a/internal/app/subsystems/api/http/schedule.go
+++ b/internal/app/subsystems/api/http/schedule.go
@@ -110,7 +110,7 @@ type createScheduleBody struct {
 	Cron           string            `json:"cron" binding:"required"`
 	Tags           map[string]string `json:"tags,omitempty"`
 	PromiseId      string            `json:"promiseId" binding:"required"`
-	PromiseTimeout int64             `json:"promiseTimeout" binding:"required"`
+	PromiseTimeout int64             `json:"promiseTimeout"`
 	PromiseParam   promise.Value     `json:"promiseParam,omitempty"`
 	PromiseTags    map[string]string `json:"promiseTags,omitempty"`
 }

--- a/internal/app/subsystems/api/http/task.go
+++ b/internal/app/subsystems/api/http/task.go
@@ -21,7 +21,7 @@ type claimTaskBody struct {
 	Id        string `json:"id" binding:"required"`
 	Counter   int    `json:"counter" binding:"required"`
 	ProcessId string `json:"processId" binding:"required"`
-	Ttl       int    `json:"ttl" binding:"required"`
+	Ttl       int    `json:"ttl"`
 }
 
 func (s *server) claimTask(c *gin.Context) {

--- a/internal/app/subsystems/api/test/cases.go
+++ b/internal/app/subsystems/api/test/cases.go
@@ -1700,13 +1700,51 @@ var TestCases = []*testCase{
 		},
 	},
 	{
-		Name: "SearchSchedulesInvalidLimit",
+		Name: "SearchSchedulesDefaultLimit",
+		Req: &t_api.Request{
+			Kind: t_api.SearchSchedules,
+			Tags: map[string]string{"id": "SearchSchedulesDefaultLimit", "name": "SearchSchedules"},
+			SearchSchedules: &t_api.SearchSchedulesRequest{
+				Id:    "*",
+				Tags:  map[string]string{},
+				Limit: 100,
+			},
+		},
+		Res: &t_api.Response{
+			Kind: t_api.SearchSchedules,
+			SearchSchedules: &t_api.SearchSchedulesResponse{
+				Status:    t_api.StatusOK,
+				Schedules: []*schedule.Schedule{},
+				Cursor:    nil,
+			},
+		},
+		Http: &httpTestCase{
+			Req: &httpTestCaseRequest{
+				Method: "GET",
+				Path:   "schedules?id=*",
+				Headers: map[string]string{
+					"Request-Id": "SearchSchedulesDefaultLimit",
+				},
+			},
+			Res: &httpTestCaseResponse{
+				Code: 200,
+			},
+		},
+		Grpc: &grpcTestCase{
+			Req: &pb.SearchSchedulesRequest{
+				Id:        "*",
+				RequestId: "SearchSchedulesDefaultLimit",
+			},
+		},
+	},
+	{
+		Name: "SearchSchedulesInvalidLimitLower",
 		Req:  nil,
 		Res:  nil,
 		Http: &httpTestCase{
 			Req: &httpTestCaseRequest{
 				Method: "GET",
-				Path:   "schedules?id=*&limit=0",
+				Path:   "schedules?id=*&limit=-1",
 			},
 			Res: &httpTestCaseResponse{
 				Code: 400,
@@ -1715,13 +1753,13 @@ var TestCases = []*testCase{
 		Grpc: &grpcTestCase{
 			Req: &pb.SearchSchedulesRequest{
 				Id:    "*",
-				Limit: 0,
+				Limit: -1,
 			},
 			Code: codes.InvalidArgument,
 		},
 	},
 	{
-		Name: "SearchSchedulesInvalidLimit",
+		Name: "SearchSchedulesInvalidLimitUpper",
 		Req:  nil,
 		Res:  nil,
 		Http: &httpTestCase{


### PR DESCRIPTION
The struct tag binding "required" excludes setting 0, which is valid for both ttl and timeout.