### PR TITLE
add claim, complete and heartbeat tasks to cli

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/resonatehq/resonate/cmd/quickstart"
 	"github.com/resonatehq/resonate/cmd/schedules"
 	"github.com/resonatehq/resonate/cmd/serve"
+	"github.com/resonatehq/resonate/cmd/tasks"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -37,6 +38,7 @@ func init() {
 	rootCmd.AddCommand(dst.NewCmd())
 	rootCmd.AddCommand(serve.ServeCmd())
 	rootCmd.AddCommand(quickstart.NewCmd())
+	rootCmd.AddCommand(tasks.NewCmd())
 
 	// Set default output
 	rootCmd.SetOut(os.Stdout)

--- a/cmd/tasks/claim.go
+++ b/cmd/tasks/claim.go
@@ -1,0 +1,72 @@
+package tasks
+
+import (
+	"time"
+
+	"github.com/resonatehq/gocoro"
+	"github.com/resonatehq/resonate/internal/app/coroutines"
+	"github.com/resonatehq/resonate/internal/kernel/t_aio"
+	"github.com/resonatehq/resonate/internal/kernel/t_api"
+	"github.com/spf13/cobra"
+)
+
+var claimTaskExample = `
+# Claim a task
+resonate tasks claim --id foo --counter 1 --process-id bar --ttl 1m`
+
+// ClaimTask sets up the CLI command for claiming a task using provided task information.
+// It takes a gocoro.Coroutine as an argument which allows asynchronous task handling.
+func ClaimTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any]) *cobra.Command {
+
+	var (
+		// Command-line flags for user input
+		id        string
+		counter   int
+		processID string
+		ttl       time.Duration
+	)
+
+	// Define the cobra command for `claim`
+	cmd := &cobra.Command{
+		Use:     "claim <id> <counter> <processID> <ttl>",
+		Short:   "Claim Task",
+		Example: claimTaskExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Build the request for claiming a task with the user's input
+			req := &t_api.Request{
+				ClaimTask: &t_api.ClaimTaskRequest{
+					Id:        id,
+					Counter:   counter,
+					ProcessId: processID,
+					Ttl:       int(ttl.Seconds()),
+				},
+			}
+
+			// Build the request for claiming a task
+			resp, err := coroutines.ClaimTask(c, req)
+
+			// Handle errors during task claiming
+			if err != nil {
+				cmd.PrintErrf("Error claiming task: %v\n", err)
+				return
+			}
+
+			// If successful, display the claimed task information
+			cmd.Printf("Claimed Task: %+v\n", resp.ClaimTask)
+		},
+	}
+
+	// Define flags that allow users to pass values from the command line
+	cmd.Flags().StringVar(&id, "id", "", "Task ID")
+	cmd.Flags().IntVar(&counter, "counter", 1, "Task counter")
+	cmd.Flags().StringVar(&processID, "process-id", "", "Process ID")
+	cmd.Flags().DurationVar(&ttl, "ttl", 1*time.Minute, "Time to live (e.g: 1m, 30s)")
+
+	// Mark certain flags as required so the user must provide them
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("counter")
+	cmd.MarkFlagRequired("process-id")
+	cmd.MarkFlagRequired("ttl")
+
+	return cmd
+}

--- a/cmd/tasks/claim.go
+++ b/cmd/tasks/claim.go
@@ -21,7 +21,6 @@ func ClaimTaskCmd(c client.Client) *cobra.Command {
 		counter   int           // Counter for the task claim
 		processId string        // Unique process ID identifying the claimer
 		ttl       time.Duration // Time to live for the task claim
-		requestId string        // Unique tracking ID for the request
 	)
 
 	// Define the cobra command
@@ -45,9 +44,7 @@ func ClaimTaskCmd(c client.Client) *cobra.Command {
 			}
 
 			// Create parameters for the claim task request
-			params := &v1.ClaimTaskParams{
-				RequestId: &requestId, // Optional tracking ID
-			}
+			params := &v1.ClaimTaskParams{}
 
 			// Create the body for the claim task request
 			body := v1.ClaimTaskJSONRequestBody{
@@ -80,7 +77,6 @@ func ClaimTaskCmd(c client.Client) *cobra.Command {
 	cmd.Flags().IntVarP(&counter, "counter", "c", 0, "The task counter")
 	cmd.Flags().StringVarP(&processId, "process-id", "p", "", "Unique process ID that identifies the claimer")
 	cmd.Flags().DurationVarP(&ttl, "ttl", "t", 0, "Time to live in milliseconds")
-	cmd.Flags().StringVarP(&requestId, "request-id", "r", "", "Unique tracking ID")
 
 	// Mark flags as required
 	_ = cmd.MarkFlagRequired("id")

--- a/cmd/tasks/complete.go
+++ b/cmd/tasks/complete.go
@@ -1,0 +1,63 @@
+package tasks
+
+import (
+	"github.com/resonatehq/gocoro"
+	"github.com/resonatehq/resonate/internal/app/coroutines"
+	"github.com/resonatehq/resonate/internal/kernel/t_aio"
+	"github.com/resonatehq/resonate/internal/kernel/t_api"
+	"github.com/spf13/cobra"
+)
+
+var completeTaskExample = `
+# Complete a task
+resonate tasks complete --id foo --counter 1`
+
+// CompleteTask sets up the CLI command to complete a task.
+func CompleteTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any]) *cobra.Command {
+	var (
+		id      string
+		counter int
+	)
+
+	// Define the cobra command for `complete`
+	cmd := &cobra.Command{
+		Use:     "complete <id>",
+		Short:   "Mark a task as complete",
+		Example: completeTaskExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Build the request for completing a task
+			req := &t_api.Request{
+				CompleteTask: &t_api.CompleteTaskRequest{
+					Id:      id,
+					Counter: counter,
+				},
+			}
+
+			// Invoke the coroutine to complete the task
+			resp, err := coroutines.CompleteTask(c, req)
+
+			// Handle errors during task completion
+			if err != nil {
+				cmd.PrintErrf("Error completing task: %v\n", err)
+				return
+			}
+
+			// Output the response, including the task completion status
+			cmd.Printf("Task completion status: %s\n", resp.CompleteTask.Status)
+			if resp.CompleteTask.Status == t_api.StatusCreated {
+				cmd.Printf("Task '%s' marked as completed\n", id)
+			}
+		},
+	}
+
+	// Define flags for user input
+	cmd.Flags().StringVar(&id, "id", "", "Task ID")
+	cmd.Flags().IntVar(&counter, "counter", 1, "Counter")
+
+	// Mark required flags
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("counter")
+
+	// Return the command to be added to the CLI app
+	return cmd
+}

--- a/cmd/tasks/complete.go
+++ b/cmd/tasks/complete.go
@@ -12,25 +12,27 @@ import (
 // Example command usage for completing a task
 var completeTasksExample = `
 # Complete a task 
-resonate tasks complete --id foo --counter 1`
+resonate tasks complete foo --counter 1`
 
 // CompleteTaskCmd returns a cobra command for completing a task.
 func CompleteTaskCmd(c client.Client) *cobra.Command {
 	var (
-		id      string // Task ID to complete
-		counter int    // Counter for the task completion
+		counter int // Counter for the task completion
 	)
 
 	// Define the cobra command
 	cmd := &cobra.Command{
-		Use:     "complete",
+		Use:     "complete <id>",
 		Short:   "Complete a task",
 		Example: completeTasksExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate required flags
-			if id == "" {
-				return errors.New("id is required")
+			if len(args) != 1 {
+				return errors.New("must specify an id")
 			}
+
+			id := args[0]
+
 			if counter <= 0 {
 				return errors.New("counter is required")
 			}
@@ -49,14 +51,11 @@ func CompleteTaskCmd(c client.Client) *cobra.Command {
 			}
 
 			// Handle the response based on the status code
-			if res.StatusCode() == 204 {
+			if res.StatusCode() == 201 {
 				cmd.Printf("Task completed: %s\n", id)
-			} else if res.StatusCode() == 403 {
-				return errors.New("task cannot be completed, invalid counter or state")
-			} else if res.StatusCode() == 404 {
-				return errors.New("task not found")
 			} else {
 				cmd.PrintErrln(res.Status(), string(res.Body))
+				return nil
 			}
 
 			return nil // Return nil if no error occurred
@@ -64,7 +63,6 @@ func CompleteTaskCmd(c client.Client) *cobra.Command {
 	}
 
 	// Define command flags
-	cmd.Flags().StringVarP(&id, "id", "i", "", "The task ID")
 	cmd.Flags().IntVarP(&counter, "counter", "c", 0, "The task counter")
 
 	// Mark flags as required

--- a/cmd/tasks/heartbeat.go
+++ b/cmd/tasks/heartbeat.go
@@ -1,0 +1,1 @@
+package tasks

--- a/cmd/tasks/heartbeat.go
+++ b/cmd/tasks/heartbeat.go
@@ -1,1 +1,76 @@
 package tasks
+
+import (
+	"context"
+	"errors"
+
+	"github.com/resonatehq/resonate/pkg/client"
+	v1 "github.com/resonatehq/resonate/pkg/client/v1"
+	"github.com/spf13/cobra"
+)
+
+// Example command usage for sending a heartbeat to a task
+var heartbeatTasksExample = `
+# Heartbeat a task 
+resonate tasks heartbeat --id foo --counter 1 --request-id bar`
+
+// HeartbeatTaskCmd returns a cobra command for sending a heartbeat to a task.
+func HeartbeatTaskCmd(c client.Client) *cobra.Command {
+	var (
+		id        string // Task ID to send a heartbeat
+		counter   int    // Counter for the heartbeat
+		requestId string // Unique tracking ID for the request
+	)
+
+	// Define the cobra command
+	cmd := &cobra.Command{
+		Use:     "heartbeat",
+		Short:   "Send a heartbeat to a task",
+		Example: heartbeatTasksExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate required flags
+			if id == "" {
+				return errors.New("id is required")
+			}
+			if counter <= 0 {
+				return errors.New("counter is required")
+			}
+
+			// Create parameters for the request
+			params := &v1.HeartbeatTaskGetParams{
+				RequestId: &requestId, // Set the request ID in the parameters
+			}
+
+			// Call the client method to send the heartbeat (GET request with path params)
+			res, err := c.V1().HeartbeatTaskGetWithResponse(context.TODO(), id, counter, params)
+
+			if err != nil {
+				return err // Return any errors from the request
+			}
+
+			// Handle the response based on the status code
+			if res.StatusCode() == 204 {
+				cmd.Printf("Heartbeat sent for task: %s\n", id)
+			} else if res.StatusCode() == 403 {
+				return errors.New("task cannot be heartbeated, invalid counter or state")
+			} else if res.StatusCode() == 404 {
+				return errors.New("task not found")
+			} else {
+				cmd.PrintErrln(res.Status(), string(res.Body))
+			}
+
+			return nil // Return nil if no error occurred
+		},
+	}
+
+	// Define command flags
+	cmd.Flags().StringVarP(&id, "id", "i", "", "The task ID")
+	cmd.Flags().IntVarP(&counter, "counter", "c", 0, "The task counter")
+	cmd.Flags().StringVarP(&requestId, "request-id", "r", "", "Unique tracking ID")
+
+	// Mark flags as required
+	_ = cmd.MarkFlagRequired("id")
+	_ = cmd.MarkFlagRequired("counter")
+
+	return cmd // Return the constructed command
+}

--- a/cmd/tasks/heartbeat.go
+++ b/cmd/tasks/heartbeat.go
@@ -12,26 +12,28 @@ import (
 // Example command usage for sending a heartbeat to a task
 var heartbeatTasksExample = `
 # Heartbeat a task 
-resonate tasks heartbeat --id foo --counter 1 --request-id bar`
+resonate tasks heartbeat foo --counter 1 --request-id bar`
 
 // HeartbeatTaskCmd returns a cobra command for sending a heartbeat to a task.
 func HeartbeatTaskCmd(c client.Client) *cobra.Command {
 	var (
-		id        string // Task ID to send a heartbeat
 		counter   int    // Counter for the heartbeat
 		requestId string // Unique tracking ID for the request
 	)
 
 	// Define the cobra command
 	cmd := &cobra.Command{
-		Use:     "heartbeat",
+		Use:     "heartbeat <id>",
 		Short:   "Send a heartbeat to a task",
 		Example: heartbeatTasksExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate required flags
-			if id == "" {
-				return errors.New("id is required")
+			if len(args) != 1 {
+				return errors.New("must specify an id")
 			}
+
+			id := args[0]
+
 			if counter <= 0 {
 				return errors.New("counter is required")
 			}
@@ -49,14 +51,11 @@ func HeartbeatTaskCmd(c client.Client) *cobra.Command {
 			}
 
 			// Handle the response based on the status code
-			if res.StatusCode() == 204 {
+			if res.StatusCode() == 200 {
 				cmd.Printf("Heartbeat sent for task: %s\n", id)
-			} else if res.StatusCode() == 403 {
-				return errors.New("task cannot be heartbeated, invalid counter or state")
-			} else if res.StatusCode() == 404 {
-				return errors.New("task not found")
 			} else {
 				cmd.PrintErrln(res.Status(), string(res.Body))
+				return nil
 			}
 
 			return nil // Return nil if no error occurred
@@ -64,7 +63,6 @@ func HeartbeatTaskCmd(c client.Client) *cobra.Command {
 	}
 
 	// Define command flags
-	cmd.Flags().StringVarP(&id, "id", "i", "", "The task ID")
 	cmd.Flags().IntVarP(&counter, "counter", "c", 0, "The task counter")
 	cmd.Flags().StringVarP(&requestId, "request-id", "r", "", "Unique tracking ID")
 

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -1,0 +1,1 @@
+package tasks

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -1,1 +1,43 @@
 package tasks
+
+import (
+	"github.com/resonatehq/resonate/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+// NewCmd returns the root command for the `tasks` module.
+func NewCmd() *cobra.Command {
+	var (
+		c        = client.New()
+		server   string
+		username string
+		password string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "tasks",
+		Aliases: []string{"task"},
+		Short:   "Resonate tasks",
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if username != "" || password != "" {
+				c.SetBasicAuth(username, password)
+			}
+			return c.Setup(server)
+		},
+	}
+
+	// Add subcommands
+	cmd.AddCommand(ClaimTaskCmd(c))     // Claim task subcommand
+	cmd.AddCommand(CompleteTaskCmd(c))  // Complete task subcommand
+	cmd.AddCommand(HeartbeatTaskCmd(c)) // Heartbeat task subcommand
+
+	// Flags
+	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "Resonate server URL")
+	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "Basic auth username")
+	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "Basic auth password")
+
+	return cmd
+}


### PR DESCRIPTION
- This PR is linked to issue #436 . I've implemented the claim and complete task.
- Need some help in the following areas:
  1. found an endpoint for hearbeatTasks.go (https://github.com/resonatehq/resonate/blob/main/internal/app/coroutines/heartbeatTasks.go) but according to the documentation (https://resonatehq.github.io/resonate/#tag/Tasks/operation/completeTask), its a post request requiring just the process-id. Unable to find the endpoint to map id and counter with
  2. If this implementation is correct, I need to pass a type that implements `gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any]`. In tasks.go i need to register these commands in order for them to work. I've so far figured out that gocoro.newCoroutine with signature `func[T, TNext, TReturn any](f CoroutineFunc[T, TNext, TReturn], r map[string]any) *coroutine[T, TNext, TReturn]` creates a coroutine that implements this type. But i'm unable to figure out what to pass in place of f and r