### PR TITLE
Log non linearizable path when linearization check fails

### DIFF
--- a/cmd/dst/run.go
+++ b/cmd/dst/run.go
@@ -32,6 +32,7 @@ func RunDSTCmd() *cobra.Command {
 		timeout           time.Duration
 		scenario          string
 		visualizationPath string
+		verbose           bool
 
 		reqsPerTick     = util.NewRangeIntFlag(1, 25)
 		ids             = util.NewRangeIntFlag(1, 25)
@@ -167,6 +168,7 @@ func RunDSTCmd() *cobra.Command {
 				Ticks:              ticks,
 				Timeout:            timeout,
 				VisualizationPath:  visualizationPath,
+				Verbose:            verbose,
 				TimeElapsedPerTick: 1000, // ms
 				TimeoutTicks:       t,
 				ReqsPerTick:        func() int { return reqsPerTick.Resolve(r) },
@@ -206,6 +208,7 @@ func RunDSTCmd() *cobra.Command {
 	cmd.Flags().DurationVar(&timeout, "timeout", 1*time.Hour, "timeout")
 	cmd.Flags().StringVar(&scenario, "scenario", "default", "can be one of: default, fault, lazy")
 	cmd.Flags().StringVar(&visualizationPath, "visualization-path", "dst.html", "porcupine visualization file path")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "log additional information when run is non linearizable")
 	cmd.Flags().Var(reqsPerTick, "reqs-per-tick", "number of requests per tick")
 	cmd.Flags().Var(ids, "ids", "promise id set size")
 	cmd.Flags().Var(idempotencyKeys, "idempotency-keys", "idempotency key set size")


### PR DESCRIPTION
Thanks to anishathalye/porcupine#21 we can grab the longest linearizable path plus one additional operation (the first op that is not part of the linearizable path chronologically) to reproduce our DST logs including the error message. This information was lost in previous implementations of DST with porcupine.

When linearization fails, there may be multiple linearizable paths and multiple possible next operations. This implementation grabs the first non-linearizable path and the first possible next operation so the log is a "best effort" and should be taken with a grain of salt. As such the additional logs can be accessed behind the verbose flag.

```
go run ./... dst run -v
```