### PR TITLE
Remove printing of a struct with a pointer in it

### DIFF
--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -232,7 +232,7 @@ func createPromise(tags map[string]string, promiseCmd *t_aio.CreatePromiseComman
 		}
 
 		if taskCmd != nil && (err != nil || !completion.Router.Matched) {
-			slog.Error("failed to match promise when creating a task", "cmd", promiseCmd, "taskCmd", taskCmd)
+			slog.Error("failed to match promise when creating a task", "cmd", promiseCmd)
 			return nil, t_api.NewError(t_api.StatusPromiseRecvNotFound, err)
 		}
 


### PR DESCRIPTION
This should fix the diff between postgress and sqlite runs in our latests dst runs.