### PR TITLE
chore(port): expose port for poller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 COPY --from=builder /app/resonate .
 
 EXPOSE 8001
+EXPOSE 8002
 EXPOSE 50051
 
 ENTRYPOINT ["./resonate"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ./resonate.yml:/root/resonate.yml
     ports:
       - "8001:8001"
+      - "8002:8002"
       - "50051:50051"
     depends_on:
       - postgres


### PR DESCRIPTION
In this PR expose the poller port in `docker-compose.yml` file and the `Dockerfile`.