### PR TITLE
DST horizontal partitioning

### DIFF
--- a/cmd/dst/run.go
+++ b/cmd/dst/run.go
@@ -33,6 +33,7 @@ func RunDSTCmd() *cobra.Command {
 		scenario          string
 		visualizationPath string
 		verbose           bool
+		printOps          bool
 
 		reqsPerTick     = util.NewRangeIntFlag(1, 25)
 		ids             = util.NewRangeIntFlag(1, 25)
@@ -170,6 +171,7 @@ func RunDSTCmd() *cobra.Command {
 				Timeout:            timeout,
 				VisualizationPath:  visualizationPath,
 				Verbose:            verbose,
+				PrintOps:           printOps,
 				TimeElapsedPerTick: 1000, // ms
 				TimeoutTicks:       t,
 				ReqsPerTick:        func() int { return reqsPerTick.Resolve(r) },
@@ -210,6 +212,7 @@ func RunDSTCmd() *cobra.Command {
 	cmd.Flags().StringVar(&scenario, "scenario", "default", "can be one of: default, fault, lazy")
 	cmd.Flags().StringVar(&visualizationPath, "visualization-path", "dst.html", "porcupine visualization file path")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "log additional information when run is non linearizable")
+	cmd.Flags().BoolVar(&printOps, "print-ops", true, "log the request/response pairs of a run.")
 	cmd.Flags().Var(reqsPerTick, "reqs-per-tick", "number of requests per tick")
 	cmd.Flags().Var(ids, "ids", "promise id set size")
 	cmd.Flags().Var(idempotencyKeys, "idempotency-keys", "idempotency key set size")

--- a/cmd/dst/run.go
+++ b/cmd/dst/run.go
@@ -220,6 +220,7 @@ func RunDSTCmd() *cobra.Command {
 
 	// bind config
 	_ = config.BindDST(cmd)
+	cmd.SilenceUsage = true
 
 	cmd.Flags().SortFlags = false
 

--- a/internal/app/coroutines/completeTask.go
+++ b/internal/app/coroutines/completeTask.go
@@ -47,7 +47,7 @@ func CompleteTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any],
 		}
 
 		if t.State == task.Completed || t.State == task.Timedout {
-			status = t_api.StatusTaskAlreadyCompleted
+			status = t_api.StatusOK
 		} else if t.State == task.Init || t.State == task.Enqueued {
 			status = t_api.StatusTaskInvalidState
 		} else if t.Counter != r.CompleteTask.Counter {

--- a/internal/app/coroutines/createCallback.go
+++ b/internal/app/coroutines/createCallback.go
@@ -66,7 +66,7 @@ func CreateCallback(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any
 
 			createdOn := c.Time()
 
-			callbackId := fmt.Sprintf("%s.%s", r.CreateCallback.PromiseId, r.CreateCallback.Id)
+			cbId := callbackId(r.CreateCallback.RootPromiseId, r.CreateCallback.PromiseId)
 			completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
 				Kind: t_aio.Store,
 				Tags: r.Tags,
@@ -76,7 +76,7 @@ func CreateCallback(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any
 							{
 								Kind: t_aio.CreateCallback,
 								CreateCallback: &t_aio.CreateCallbackCommand{
-									Id:        callbackId,
+									Id:        cbId,
 									PromiseId: r.CreateCallback.PromiseId,
 									Recv:      r.CreateCallback.Recv,
 									Mesg:      mesg,
@@ -104,7 +104,7 @@ func CreateCallback(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any
 			if result.RowsAffected == 1 {
 				status = t_api.StatusCreated
 				cb = &callback.Callback{
-					Id:        callbackId,
+					Id:        cbId,
 					PromiseId: r.CreateCallback.PromiseId,
 					Recv:      r.CreateCallback.Recv,
 					Mesg:      mesg,
@@ -137,4 +137,8 @@ func CreateCallback(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any
 
 	util.Assert(res != nil, "response must not be nil")
 	return res, nil
+}
+
+func callbackId(rootPromiseId, promiseId string) string {
+	return fmt.Sprintf("__resume:%s:%s", rootPromiseId, promiseId)
 }

--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -120,17 +120,18 @@ func createPromiseAndTask(
 			util.Assert(completion.Store.Results[1].Kind == t_aio.CreateTask, "completion must be create task")
 
 			t = &task.Task{
-				Id:        completion.Store.Results[1].CreateTask.LastInsertId,
-				ProcessId: taskCmd.ProcessId,
-				State:     taskCmd.State,
-				Recv:      taskCmd.Recv,
-				Mesg:      taskCmd.Mesg,
-				Timeout:   taskCmd.Timeout,
-				Counter:   1,
-				Attempt:   0,
-				Ttl:       taskCmd.Ttl,
-				ExpiresAt: taskCmd.ExpiresAt,
-				CreatedOn: &taskCmd.CreatedOn,
+				Id:            completion.Store.Results[1].CreateTask.LastInsertId,
+				ProcessId:     taskCmd.ProcessId,
+				RootPromiseId: p.Id,
+				State:         taskCmd.State,
+				Recv:          taskCmd.Recv,
+				Mesg:          taskCmd.Mesg,
+				Timeout:       taskCmd.Timeout,
+				Counter:       1,
+				Attempt:       0,
+				Ttl:           taskCmd.Ttl,
+				ExpiresAt:     taskCmd.ExpiresAt,
+				CreatedOn:     &taskCmd.CreatedOn,
 			}
 		}
 	} else {

--- a/internal/app/coroutines/createSubscription.go
+++ b/internal/app/coroutines/createSubscription.go
@@ -66,7 +66,7 @@ func CreateSubscription(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion,
 
 			createdOn := c.Time()
 
-			callbackId := fmt.Sprintf("%s.%s", r.CreateSubscription.PromiseId, r.CreateSubscription.Id)
+			callbackId := subscriptionId(r.CreateSubscription.PromiseId, r.CreateSubscription.Id)
 			completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
 				Kind: t_aio.Store,
 				Tags: r.Tags,
@@ -137,4 +137,8 @@ func CreateSubscription(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion,
 
 	util.Assert(res != nil, "response must not be nil")
 	return res, nil
+}
+
+func subscriptionId(promiseId, customId string) string {
+	return fmt.Sprintf("__notify:%s:%s", promiseId, customId)
 }

--- a/internal/app/subsystems/aio/sender/sender_dst.go
+++ b/internal/app/subsystems/aio/sender/sender_dst.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/resonatehq/resonate/internal/kernel/bus"
 	"github.com/resonatehq/resonate/internal/kernel/t_aio"
+	"github.com/resonatehq/resonate/pkg/message"
 )
 
 // Config
@@ -52,8 +53,17 @@ func (s *SenderDST) Process(sqes []*bus.SQE[t_aio.Submission, t_aio.Completion])
 	for i, sqe := range sqes {
 		var completion *t_aio.SenderCompletion
 
+		mesgType := sqe.Submission.Sender.Task.Mesg.Type
+
+		var obj any
+		if mesgType == message.Notify {
+			obj = sqe.Submission.Sender.Promise
+		} else {
+			obj = sqe.Submission.Sender.Task
+		}
+
 		select {
-		case s.backchannel <- sqe.Submission.Sender.Task:
+		case s.backchannel <- obj:
 			completion = &t_aio.SenderCompletion{
 				Success: s.r.Float64() < s.config.P,
 			}

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -995,7 +995,7 @@ func (w *PostgresStoreWorker) searchPromises(tx *sql.Tx, cmd *t_aio.SearchPromis
 	}, nil
 }
 
-func (w *PostgresStoreWorker) createPromise(tx *sql.Tx, stmt *sql.Stmt, cmd *t_aio.CreatePromiseCommand) (*t_aio.Result, error) {
+func (w *PostgresStoreWorker) createPromise(_ *sql.Tx, stmt *sql.Stmt, cmd *t_aio.CreatePromiseCommand) (*t_aio.Result, error) {
 	util.Assert(cmd.Param.Headers != nil, "param headers must not be nil")
 	util.Assert(cmd.Param.Data != nil, "param data must not be nil")
 	util.Assert(cmd.Tags != nil, "tags must not be nil")

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -362,7 +362,7 @@ const (
 	SET
 		state = 8, completed_on = $1 -- State = 8 -> Completed
 	WHERE
-		root_promise_id = $2 AND state in (1, 2) -- State in (Init, Enqueued)`
+		root_promise_id = $2 AND state in (1, 2, 4) -- State in (Init, Enqueued, Claimed)`
 
 	TASK_HEARTBEAT_STATEMENT = `
 	UPDATE

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -349,7 +349,7 @@ const (
 	SET
 		state = 8, completed_on = ? -- State 8 -> Completed
 	WHERE
-		root_promise_id = ? AND state in (1, 2) -- State in (Init, Enqueued)`
+		root_promise_id = ? AND state in (1, 2, 4) -- State in (Init, Enqueued, Claimed)`
 
 	TASK_HEARTBEAT_STATEMENT = `
 	UPDATE

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -4183,7 +4183,7 @@ var TestCases = []*testCase{
 						{
 							Id:            "foo.1",
 							ProcessId:     util.ToPointer("pid"),
-							State:         task.Completed, // Task should remain in Claimed state
+							State:         task.Completed,
 							RootPromiseId: "root",
 							Recv:          []byte("foo"),
 							Mesg:          []byte(`{"type":"resume","root":"root","leaf":"foo"}`),

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -2854,6 +2854,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.CreateTask,
 				CreateTask: &t_aio.CreateTaskCommand{
+					Id:        "1",
 					Recv:      []byte("foo"),
 					Mesg:      &message.Mesg{Type: message.Invoke, Root: "foo", Leaf: "foo"},
 					Timeout:   1,
@@ -2864,6 +2865,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.CreateTask,
 				CreateTask: &t_aio.CreateTaskCommand{
+					Id:        "2",
 					Recv:      []byte("bar"),
 					Mesg:      &message.Mesg{Type: message.Invoke, Root: "bar", Leaf: "bar"},
 					Timeout:   2,
@@ -2884,14 +2886,12 @@ var TestCases = []*testCase{
 				Kind: t_aio.CreateTask,
 				CreateTask: &t_aio.AlterTasksResult{
 					RowsAffected: 1,
-					LastInsertId: "1",
 				},
 			},
 			{
 				Kind: t_aio.CreateTask,
 				CreateTask: &t_aio.AlterTasksResult{
 					RowsAffected: 1,
-					LastInsertId: "2",
 				},
 			},
 			{
@@ -3013,7 +3013,7 @@ var TestCases = []*testCase{
 					RowsReturned: 3,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "2",
+							Id:            "foo.2",
 							Counter:       1,
 							State:         task.Init,
 							RootPromiseId: "bar",
@@ -3022,7 +3022,7 @@ var TestCases = []*testCase{
 							CreatedOn:     util.ToPointer[int64](0),
 						},
 						{
-							Id:            "3",
+							Id:            "foo.3",
 							Counter:       1,
 							State:         task.Init,
 							RootPromiseId: "baz",
@@ -3031,7 +3031,7 @@ var TestCases = []*testCase{
 							CreatedOn:     util.ToPointer[int64](0),
 						},
 						{
-							Id:            "1",
+							Id:            "foo.1",
 							Counter:       1,
 							State:         task.Init,
 							RootPromiseId: "foo",
@@ -3138,7 +3138,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Enqueued,
 					Counter:        2,
@@ -3159,7 +3159,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "5",
+					Id:             "pbar.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Enqueued,
 					Counter:        2,
@@ -3245,7 +3245,7 @@ var TestCases = []*testCase{
 					RowsReturned: 2,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "1",
+							Id:            "foo.1",
 							Counter:       1,
 							State:         task.Init,
 							RootPromiseId: "foo",
@@ -3254,7 +3254,7 @@ var TestCases = []*testCase{
 							CreatedOn:     util.ToPointer[int64](0),
 						},
 						{
-							Id:            "4",
+							Id:            "pbar.1",
 							Counter:       1,
 							State:         task.Init,
 							RootPromiseId: "pbar",
@@ -3277,7 +3277,7 @@ var TestCases = []*testCase{
 					RowsReturned: 1,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "4",
+							Id:            "pbar.1",
 							Counter:       1,
 							State:         task.Init,
 							RootPromiseId: "pbar",
@@ -3331,7 +3331,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Enqueued,
 					Counter:        2,
@@ -3346,7 +3346,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Claimed,
 					Counter:        3,
@@ -3361,7 +3361,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Claimed,
 					Counter:        4,
@@ -3376,7 +3376,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Completed,
 					Counter:        5,
@@ -3391,7 +3391,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Completed,
 					Counter:        6,
@@ -3406,7 +3406,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.ReadTask,
 				ReadTask: &t_aio.ReadTaskCommand{
-					Id: "1",
+					Id: "foo.1",
 				},
 			},
 		},
@@ -3465,7 +3465,7 @@ var TestCases = []*testCase{
 					RowsReturned: 1,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "1",
+							Id:            "foo.1",
 							ProcessId:     util.ToPointer("pid"),
 							State:         task.Completed,
 							RootPromiseId: "foo",
@@ -3688,13 +3688,13 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.ReadTask,
 				ReadTask: &t_aio.ReadTaskCommand{
-					Id: "1",
+					Id: "foo.1",
 				},
 			},
 			{
 				Kind: t_aio.ReadTask,
 				ReadTask: &t_aio.ReadTaskCommand{
-					Id: "2",
+					Id: "bar.1",
 				},
 			},
 		},
@@ -3759,7 +3759,7 @@ var TestCases = []*testCase{
 					RowsReturned: 1,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "1",
+							Id:            "foo.1",
 							State:         task.Completed,
 							RootPromiseId: "root1",
 							Recv:          []byte("foo"),
@@ -3780,7 +3780,7 @@ var TestCases = []*testCase{
 					RowsReturned: 1,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "2",
+							Id:            "bar.1",
 							State:         task.Init,
 							RootPromiseId: "root2",
 							Recv:          []byte("bar"),
@@ -3938,7 +3938,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Claimed, // Set task to Claimed state
 					Counter:        2,
@@ -3959,7 +3959,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.ReadTask,
 				ReadTask: &t_aio.ReadTaskCommand{
-					Id: "1",
+					Id: "foo.1",
 				},
 			},
 		},
@@ -4006,7 +4006,7 @@ var TestCases = []*testCase{
 					RowsReturned: 1,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "1",
+							Id:            "foo.1",
 							ProcessId:     util.ToPointer("pid"),
 							State:         task.Completed, // Task should remain in Claimed state
 							RootPromiseId: "root",
@@ -4061,7 +4061,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("pid"),
 					State:          task.Timedout, // Set task to Timeout state
 					Counter:        2,
@@ -4082,7 +4082,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.ReadTask,
 				ReadTask: &t_aio.ReadTaskCommand{
-					Id: "1",
+					Id: "foo.1",
 				},
 			},
 		},
@@ -4129,7 +4129,7 @@ var TestCases = []*testCase{
 					RowsReturned: 1,
 					Records: []*task.TaskRecord{
 						{
-							Id:            "1",
+							Id:            "foo.1",
 							ProcessId:     util.ToPointer("pid"),
 							State:         task.Timedout, // Task should remain in Timeout state
 							RootPromiseId: "root",
@@ -4193,7 +4193,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "1",
+					Id:             "foo.1",
 					ProcessId:      util.ToPointer("bar"),
 					State:          task.Claimed,
 					CurrentStates:  []task.State{task.Init},
@@ -4203,7 +4203,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "2",
+					Id:             "foo.2",
 					ProcessId:      util.ToPointer("bar"),
 					State:          task.Claimed,
 					CurrentStates:  []task.State{task.Init},
@@ -4213,7 +4213,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.UpdateTask,
 				UpdateTask: &t_aio.UpdateTaskCommand{
-					Id:             "3",
+					Id:             "foo.3",
 					ProcessId:      util.ToPointer("bar"),
 					State:          task.Completed,
 					CurrentStates:  []task.State{task.Init},

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -2849,6 +2849,181 @@ var TestCases = []*testCase{
 
 	// TASKS
 	{
+		name: "CreatePromiseAndTask",
+		commands: []*t_aio.Command{
+			{
+				Kind: t_aio.CreatePromiseAndTask,
+				CreatePromiseAndTask: &t_aio.CreatePromiseAndTaskCommand{
+					PromiseCommand: &t_aio.CreatePromiseCommand{
+						Id:      "foo",
+						Timeout: 1,
+						Param: promise.Value{
+							Headers: map[string]string{},
+							Data:    []byte{},
+						},
+						Tags:      map[string]string{},
+						CreatedOn: 1,
+					},
+					TaskCommand: &t_aio.CreateTaskCommand{
+						Id:        "__invoke:foo",
+						Recv:      []byte("foo"),
+						Mesg:      &message.Mesg{Type: message.Invoke, Root: "foo", Leaf: "foo"},
+						ProcessId: util.ToPointer("pid"),
+						State:     task.Claimed,
+						CreatedOn: 1,
+						Ttl:       2,
+						ExpiresAt: 2,
+						Timeout:   3,
+					},
+				},
+			},
+			{
+				Kind: t_aio.ReadPromise,
+				ReadPromise: &t_aio.ReadPromiseCommand{
+					Id: "foo",
+				},
+			},
+			{
+				Kind: t_aio.ReadTask,
+				ReadTask: &t_aio.ReadTaskCommand{
+					Id: "__invoke:foo",
+				},
+			},
+		},
+		expected: []*t_aio.Result{
+			{
+				Kind: t_aio.CreatePromiseAndTask,
+				CreatePromiseAndTask: &t_aio.AlterPromiseAndTaskResult{
+					PromiseRowsAffected: 1,
+					TaskRowsAffected:    1,
+				},
+			},
+			{
+				Kind: t_aio.ReadPromise,
+				ReadPromise: &t_aio.QueryPromisesResult{
+					RowsReturned: 1,
+					Records: []*promise.PromiseRecord{{
+						Id:           "foo",
+						State:        1,
+						ParamHeaders: []byte("{}"),
+						ParamData:    []byte{},
+						Timeout:      1,
+						Tags:         []byte("{}"),
+						CreatedOn:    util.ToPointer(int64(1)),
+					}},
+				},
+			},
+			{
+				Kind: t_aio.ReadTask,
+				ReadTask: &t_aio.QueryTasksResult{
+					RowsReturned: 1,
+					Records: []*task.TaskRecord{
+						{
+							Id:            "__invoke:foo",
+							ProcessId:     util.ToPointer("pid"),
+							State:         task.Claimed,
+							RootPromiseId: "foo",
+							Recv:          []byte("foo"),
+							Mesg:          []byte(`{"type":"invoke","root":"foo","leaf":"foo"}`),
+							Attempt:       0,
+							Counter:       1,
+							CreatedOn:     util.ToPointer[int64](1),
+							Ttl:           2,
+							ExpiresAt:     2,
+							Timeout:       3,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "CreatePromiseAndTask_PromiseAlreadyExists",
+		commands: []*t_aio.Command{
+			{
+				Kind: t_aio.CreatePromise,
+				CreatePromise: &t_aio.CreatePromiseCommand{
+					Id:        "foo",
+					Timeout:   1,
+					Param:     promise.Value{Headers: map[string]string{}, Data: []byte{}},
+					Tags:      map[string]string{},
+					CreatedOn: 1,
+				},
+			},
+			{
+				Kind: t_aio.CreatePromiseAndTask,
+				CreatePromiseAndTask: &t_aio.CreatePromiseAndTaskCommand{
+					PromiseCommand: &t_aio.CreatePromiseCommand{
+						Id:        "foo",
+						Timeout:   1,
+						Param:     promise.Value{Headers: map[string]string{}, Data: []byte{}},
+						Tags:      map[string]string{},
+						CreatedOn: 1,
+					},
+					TaskCommand: &t_aio.CreateTaskCommand{
+						Id:        "__invoke:foo",
+						Recv:      []byte("foo"),
+						Mesg:      &message.Mesg{Type: message.Invoke, Root: "foo", Leaf: "foo"},
+						ProcessId: util.ToPointer("pid"),
+						State:     task.Claimed,
+						CreatedOn: 1,
+						Ttl:       2,
+						ExpiresAt: 2,
+						Timeout:   3,
+					},
+				},
+			},
+			{
+				Kind: t_aio.ReadPromise,
+				ReadPromise: &t_aio.ReadPromiseCommand{
+					Id: "foo",
+				},
+			},
+			{
+				Kind: t_aio.ReadTask,
+				ReadTask: &t_aio.ReadTaskCommand{
+					Id: "__invoke:foo",
+				},
+			},
+		},
+		expected: []*t_aio.Result{
+			{
+				Kind: t_aio.CreatePromise,
+				CreatePromise: &t_aio.AlterPromisesResult{
+					RowsAffected: 1,
+				},
+			},
+			{
+				Kind: t_aio.CreatePromiseAndTask,
+				CreatePromiseAndTask: &t_aio.AlterPromiseAndTaskResult{
+					PromiseRowsAffected: 0,
+					TaskRowsAffected:    0,
+				},
+			},
+			{
+				Kind: t_aio.ReadPromise,
+				ReadPromise: &t_aio.QueryPromisesResult{
+					RowsReturned: 1,
+					Records: []*promise.PromiseRecord{{
+						Id:           "foo",
+						State:        1,
+						ParamHeaders: []byte("{}"),
+						ParamData:    []byte{},
+						Timeout:      1,
+						Tags:         []byte("{}"),
+						CreatedOn:    util.ToPointer(int64(1)),
+					}},
+				},
+			},
+			{
+				Kind: t_aio.ReadTask,
+				ReadTask: &t_aio.QueryTasksResult{
+					RowsReturned: 0,
+				},
+			},
+		},
+	},
+	{
 		name: "CreateTask",
 		commands: []*t_aio.Command{
 			{

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -3902,7 +3902,7 @@ var TestCases = []*testCase{
 		},
 	},
 	{
-		name: "CompleteTasks_ClaimedTaskNotCompleted",
+		name: "CompleteTasks_ClaimedTaskCompleted",
 		commands: []*t_aio.Command{
 			{
 				Kind: t_aio.CreatePromise,
@@ -3997,7 +3997,7 @@ var TestCases = []*testCase{
 			{
 				Kind: t_aio.CompleteTasks,
 				CompleteTasks: &t_aio.AlterTasksResult{
-					RowsAffected: 0, // No tasks should be completed
+					RowsAffected: 1,
 				},
 			},
 			{
@@ -4008,7 +4008,7 @@ var TestCases = []*testCase{
 						{
 							Id:            "1",
 							ProcessId:     util.ToPointer("pid"),
-							State:         task.Claimed, // Task should remain in Claimed state
+							State:         task.Completed, // Task should remain in Claimed state
 							RootPromiseId: "root",
 							Recv:          []byte("foo"),
 							Mesg:          []byte(`{"type":"resume","root":"root","leaf":"foo"}`),
@@ -4017,6 +4017,7 @@ var TestCases = []*testCase{
 							Ttl:           1,
 							ExpiresAt:     1,
 							CreatedOn:     util.ToPointer[int64](0),
+							CompletedOn:   util.ToPointer[int64](5),
 						},
 					},
 				},

--- a/internal/kernel/t_aio/store.go
+++ b/internal/kernel/t_aio/store.go
@@ -42,6 +42,7 @@ const (
 	CompleteTasks
 	UpdateTask
 	HeartbeatTasks
+	CreatePromiseAndTask
 
 	// LOCKS
 	ReadLock
@@ -99,6 +100,9 @@ func (k StoreKind) String() string {
 		return "UpdateTask"
 	case HeartbeatTasks:
 		return "HeartbeatTasks"
+	case CreatePromiseAndTask:
+		return "CreatePromiseAndTask"
+
 	// LOCKS
 	case ReadLock:
 		return "ReadLock"
@@ -159,14 +163,15 @@ type Command struct {
 	DeleteSchedule  *DeleteScheduleCommand
 
 	// TASKS
-	ReadTask          *ReadTaskCommand
-	ReadTasks         *ReadTasksCommand
-	ReadEnquableTasks *ReadEnqueueableTasksCommand
-	CreateTask        *CreateTaskCommand
-	CreateTasks       *CreateTasksCommand
-	CompleteTasks     *CompleteTasksCommand
-	UpdateTask        *UpdateTaskCommand
-	HeartbeatTasks    *HeartbeatTasksCommand
+	ReadTask             *ReadTaskCommand
+	ReadTasks            *ReadTasksCommand
+	ReadEnquableTasks    *ReadEnqueueableTasksCommand
+	CreateTask           *CreateTaskCommand
+	CreateTasks          *CreateTasksCommand
+	CompleteTasks        *CompleteTasksCommand
+	UpdateTask           *UpdateTaskCommand
+	HeartbeatTasks       *HeartbeatTasksCommand
+	CreatePromiseAndTask *CreatePromiseAndTaskCommand
 
 	// LOCKS
 	ReadLock       *ReadLockCommand
@@ -211,6 +216,7 @@ type Result struct {
 	CompleteTasks        *AlterTasksResult
 	UpdateTask           *AlterTasksResult
 	HeartbeatTasks       *AlterTasksResult
+	CreatePromiseAndTask *AlterPromiseAndTaskResult
 
 	// LOCKS
 	ReadLock       *QueryLocksResult
@@ -404,6 +410,11 @@ type HeartbeatTasksCommand struct {
 	Time      int64
 }
 
+type CreatePromiseAndTaskCommand struct {
+	PromiseCommand *CreatePromiseCommand
+	TaskCommand    *CreateTaskCommand
+}
+
 // Task results
 
 type QueryTasksResult struct {
@@ -413,6 +424,11 @@ type QueryTasksResult struct {
 
 type AlterTasksResult struct {
 	RowsAffected int64
+}
+
+type AlterPromiseAndTaskResult struct {
+	PromiseRowsAffected int64
+	TaskRowsAffected    int64
 }
 
 // Lock commands

--- a/internal/kernel/t_aio/store.go
+++ b/internal/kernel/t_aio/store.go
@@ -365,6 +365,7 @@ type ReadEnqueueableTasksCommand struct {
 }
 
 type CreateTaskCommand struct {
+	Id        string
 	Recv      []byte
 	Mesg      *message.Mesg
 	Timeout   int64
@@ -412,7 +413,6 @@ type QueryTasksResult struct {
 
 type AlterTasksResult struct {
 	RowsAffected int64
-	LastInsertId string
 }
 
 // Lock commands

--- a/internal/kernel/t_api/status.go
+++ b/internal/kernel/t_api/status.go
@@ -76,6 +76,8 @@ func (s StatusCode) String() string {
 		return "The specified lock was not found"
 	case StatusTaskNotFound:
 		return "The specified task was not found"
+	case StatusPromiseRecvNotFound:
+		return "The specified recv couldn't be found"
 	case StatusPromiseAlreadyExists:
 		return "The specified promise already exists"
 	case StatusScheduleAlreadyExists:

--- a/test/dst/bc_validator.go
+++ b/test/dst/bc_validator.go
@@ -82,7 +82,7 @@ func ValidateTasksWithSameRootPromiseId(model *Model, reqTime int64, _ int64, re
 				return model, fmt.Errorf("Invocation for a promise that is alredy completed.")
 			} else if *p.CompletedOn > *reqT.CreatedOn {
 				state = task.Completed
-				completedOn = util.ToPointer[int64](*p.CompletedOn)
+				completedOn = util.ToPointer(*p.CompletedOn)
 			}
 		}
 

--- a/test/dst/bc_validator.go
+++ b/test/dst/bc_validator.go
@@ -78,9 +78,9 @@ func ValidateTasksWithSameRootPromiseId(model *Model, reqTime int64, _ int64, re
 		completedOn := reqT.CompletedOn
 		if p != nil &&
 			p.State != promise.Pending {
-			if reqT.Mesg.Type == message.Invoke && *p.CompletedOn < *reqT.CreatedOn {
+			if reqT.Mesg.Type == message.Invoke && *p.CompletedOn <= *reqT.CreatedOn {
 				return model, fmt.Errorf("Invocation for a promise that is alredy completed.")
-			} else if *p.CompletedOn >= *reqT.CreatedOn {
+			} else if *p.CompletedOn > *reqT.CreatedOn {
 				state = task.Completed
 				completedOn = util.ToPointer[int64](*p.CompletedOn)
 			}

--- a/test/dst/bc_validator.go
+++ b/test/dst/bc_validator.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/rand"
 
+	"github.com/resonatehq/resonate/internal/util"
+	"github.com/resonatehq/resonate/pkg/message"
 	"github.com/resonatehq/resonate/pkg/promise"
 	"github.com/resonatehq/resonate/pkg/task"
 )
@@ -54,47 +56,65 @@ func ValidateNotify(model *Model, reqTime int64, resTime int64, req *Req) (*Mode
 	return model, nil
 }
 
-func ValidateTasksWithSameRootPromiseId(model *Model, _ int64, _ int64, req *Req) (*Model, error) {
+func ValidateTasksWithSameRootPromiseId(model *Model, reqTime int64, _ int64, req *Req) (*Model, error) {
 	if req.bc.Task != nil {
-		for _, stored := range *model.tasks {
-			if stored.value.Id == req.bc.Task.Id &&
-				(stored.value.Counter < req.bc.Task.Counter ||
-					stored.value.Attempt < req.bc.Task.Attempt) {
-				continue
-			}
-
-			if stored.value.RootPromiseId == req.bc.Task.RootPromiseId &&
-				stored.value.State != task.Completed &&
-				stored.value.ExpiresAt > req.time &&
-				stored.value.Timeout > req.time {
-				return model, fmt.Errorf("task '%s' for root promise  '%s' should not have been enqueued", req.bc.Task.Id, req.bc.Task.RootPromiseId)
-			}
-		}
 		reqT := req.bc.Task
 		stored := model.tasks.get(reqT.Id)
-		if stored == nil || stored.State != task.Completed {
-			// At this point we have verified that it was fine that this
-			// task was r-eenqueued. Is possible that a task was enqueued
-			// and then completed by completing the root promise, if that is the
-			// case just ignore that tasks
-			newT := &task.Task{
-				Id:            reqT.Id,
-				Counter:       reqT.Counter,
-				Timeout:       reqT.Timeout,
-				ProcessId:     reqT.ProcessId,
-				State:         reqT.State,
-				RootPromiseId: reqT.RootPromiseId,
-				Recv:          reqT.Recv,
-				Mesg:          reqT.Mesg,
-				Attempt:       reqT.Attempt,
-				Ttl:           reqT.Ttl,
-				ExpiresAt:     reqT.ExpiresAt,
-				CreatedOn:     reqT.CreatedOn,
-				CompletedOn:   reqT.CompletedOn,
-			}
-			model = model.Copy()
-			model.tasks.set(newT.Id, newT)
+		p := model.promises.get(req.bc.Task.RootPromiseId)
+
+		if stored != nil && stored.RootPromiseId != reqT.RootPromiseId {
+			return model, fmt.Errorf("Same task with different rootpromiseId: '%s'", req.bc.Task.Id)
 		}
+
+		if stored != nil && stored.State.In(task.Completed|task.Timedout) {
+			return model, nil
+		}
+
+		if stored != nil && stored.State == task.Claimed && stored.ExpiresAt > reqTime {
+			return model, nil
+		}
+
+		state := reqT.State
+		completedOn := reqT.CompletedOn
+		if p != nil &&
+			p.State != promise.Pending {
+			if reqT.Mesg.Type == message.Invoke && *p.CompletedOn < *reqT.CreatedOn {
+				return model, fmt.Errorf("Invocation for a promise that is alredy completed.")
+			} else if *p.CompletedOn >= *reqT.CreatedOn {
+				state = task.Completed
+				completedOn = util.ToPointer[int64](*p.CompletedOn)
+			}
+		}
+
+		for _, t := range *model.tasks {
+			if t.value.RootPromiseId != reqT.RootPromiseId ||
+				t.value.Mesg.Type != reqT.Mesg.Type ||
+				t.value.Id == reqT.Id {
+				continue
+			}
+			if !t.value.State.In(task.Completed|task.Timedout) &&
+				t.value.Timeout > reqTime {
+				return model, fmt.Errorf("Multiple tasks with same rootpromiseId '%s' active at the same time.", req.bc.Task.RootPromiseId)
+			}
+		}
+
+		newT := &task.Task{
+			Id:            reqT.Id,
+			Counter:       reqT.Counter,
+			Timeout:       reqT.Timeout,
+			ProcessId:     reqT.ProcessId,
+			State:         state,
+			RootPromiseId: reqT.RootPromiseId,
+			Recv:          reqT.Recv,
+			Mesg:          reqT.Mesg,
+			Attempt:       reqT.Attempt,
+			Ttl:           reqT.Ttl,
+			ExpiresAt:     reqT.ExpiresAt,
+			CreatedOn:     reqT.CreatedOn,
+			CompletedOn:   completedOn,
+		}
+		model = model.Copy()
+		model.tasks.set(newT.Id, newT)
 	}
 
 	return model, nil

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -341,10 +341,10 @@ func (d *DST) logError(partialLinearization []porcupine.Operation, lastOp porcup
 	res := lastOp.Output.(*Res)
 	var err error
 	if req.kind == Op {
-		model, err = d.Step(model, req.time, res.time, req.req, res.res, res.err)
+		_, err = d.Step(model, req.time, res.time, req.req, res.res, res.err)
 		fmt.Printf("Op(id=%s, t=%d|%d), req=%v, res=%v\n", req.req.Tags["id"], req.time, res.time, req.req, res.res)
 	} else {
-		model, err = d.BcStep(model, req.time, res.time, req)
+		_, err = d.BcStep(model, req.time, res.time, req)
 		var obj any
 		if req.bc.Task != nil {
 			obj = req.bc.Task
@@ -439,7 +439,7 @@ func (d *DST) Model() porcupine.Model {
 				} else if req.bc.Promise != nil {
 					return fmt.Sprintf("Backchannel | %s", req.bc.Promise)
 				} else {
-					return fmt.Sprintf("Backchannel | unknown(possible error)")
+					return "Backchannel | unknown(possible error)"
 				}
 			default:
 				panic(fmt.Sprintf("unknown request kind: %d", req.kind))

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -216,7 +216,7 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 
 				// The ProcessId is always the taskId, which means each task
 				// is always claimed by a different process, which means
-				// that when hearthbeating there will always be a single task at
+				// that when heartbeating there will always be a single task at
 				// most when heartbeating
 
 				// add claim req to generator

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -187,44 +187,6 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 						Input:    &Req{Op, reqTime, req, nil},
 						Output:   &Res{Op, resTime, res, err},
 					})
-
-					// Warning:
-					// A CreatePromiseAndTask request applies to two partitions, the
-					// promise partition and the task partition. Merging the
-					// partitions results in long checking time, so as a workaround
-					// we create an independent CreatePromise request. The mapping
-					// of requests to partitions is as follows:
-					// CreatePromise        -> p partition
-					// CreatePromiseAndTask -> t partition
-					if req.Kind == t_api.CreatePromiseAndTask {
-						j++
-
-						req = &t_api.Request{
-							Kind:          t_api.CreatePromise,
-							Tags:          req.Tags,
-							CreatePromise: req.CreatePromiseAndTask.Promise,
-						}
-
-						if res != nil {
-							res = &t_api.Response{
-								Kind: t_api.CreatePromise,
-								Tags: res.Tags,
-								CreatePromise: &t_api.CreatePromiseResponse{
-									Status:  res.CreatePromiseAndTask.Status,
-									Promise: res.CreatePromiseAndTask.Promise,
-								},
-							}
-						}
-
-						ops = append(ops, porcupine.Operation{
-							ClientId: int(j % d.config.MaxReqsPerTick),
-							Call:     reqTime,
-							Return:   resTime,
-							Input:    &Req{Op, reqTime, req, nil},
-							Output:   &Res{Op, resTime, res, err},
-						})
-					}
-
 					j++
 				},
 			})

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -33,6 +33,7 @@ type Config struct {
 	Timeout            time.Duration
 	VisualizationPath  string
 	Verbose            bool
+	PrintOps           bool
 	TimeElapsedPerTick int64
 	TimeoutTicks       int64
 	ReqsPerTick        func() int
@@ -156,8 +157,10 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 						resTime = resTime - 1 // subtract 1 to ensure tick timeframes don't overlap
 					}
 
-					// log
-					slog.Info("DST", "t", fmt.Sprintf("%d|%d", reqTime, resTime), "id", id, "req", req, "res", res, "err", err)
+					if d.config.PrintOps {
+						// log
+						slog.Info("DST", "t", fmt.Sprintf("%d|%d", reqTime, resTime), "id", id, "req", req, "res", res, "err", err)
+					}
 
 					// extract cursors for subsequent requests
 					if err == nil {

--- a/test/dst/generator.go
+++ b/test/dst/generator.go
@@ -121,6 +121,7 @@ func (g *Generator) GenerateReadPromise(r *rand.Rand, t int64) *t_api.Request {
 
 	return &t_api.Request{
 		Kind: t_api.ReadPromise,
+		Tags: map[string]string{"partitionId": id},
 		ReadPromise: &t_api.ReadPromiseRequest{
 			Id: id,
 		},
@@ -176,6 +177,7 @@ func (g *Generator) GenerateCreatePromise(r *rand.Rand, t int64) *t_api.Request 
 
 	return &t_api.Request{
 		Kind: t_api.CreatePromise,
+		Tags: map[string]string{"partitionId": id},
 		CreatePromise: &t_api.CreatePromiseRequest{
 			Id:             id,
 			IdempotencyKey: idempotencyKey,
@@ -197,6 +199,7 @@ func (g *Generator) GenerateCreatePromiseAndTask(r *rand.Rand, t int64) *t_api.R
 
 	return &t_api.Request{
 		Kind: t_api.CreatePromiseAndTask,
+		Tags: map[string]string{"partitionId": req.CreatePromise.Id},
 		CreatePromiseAndTask: &t_api.CreatePromiseAndTaskRequest{
 			Promise: req.CreatePromise,
 			Task: &t_api.CreateTaskRequest{
@@ -219,6 +222,7 @@ func (g *Generator) GenerateCompletePromise(r *rand.Rand, t int64) *t_api.Reques
 
 	return &t_api.Request{
 		Kind: t_api.CompletePromise,
+		Tags: map[string]string{"partitionId": id},
 		CompletePromise: &t_api.CompletePromiseRequest{
 			Id:             id,
 			IdempotencyKey: idempotencyKey,
@@ -239,6 +243,7 @@ func (g *Generator) GenerateCreateCallback(r *rand.Rand, t int64) *t_api.Request
 
 	return &t_api.Request{
 		Kind: t_api.CreateCallback,
+		Tags: map[string]string{"partitionId": promiseId},
 		CreateCallback: &t_api.CreateCallbackRequest{
 			Id:            id,
 			PromiseId:     promiseId,
@@ -258,6 +263,7 @@ func (g *Generator) GenerateCreateSubscription(r *rand.Rand, t int64) *t_api.Req
 
 	return &t_api.Request{
 		Kind: t_api.CreateSubscription,
+		Tags: map[string]string{"partitionId": promiseId},
 		CreateSubscription: &t_api.CreateSubscriptionRequest{
 			Id:        id,
 			PromiseId: promiseId,
@@ -274,6 +280,7 @@ func (g *Generator) GenerateReadSchedule(r *rand.Rand, t int64) *t_api.Request {
 
 	return &t_api.Request{
 		Kind: t_api.ReadSchedule,
+		Tags: map[string]string{"partitionId": id},
 		ReadSchedule: &t_api.ReadScheduleRequest{
 			Id: id,
 		},
@@ -313,6 +320,7 @@ func (g *Generator) GenerateCreateSchedule(r *rand.Rand, t int64) *t_api.Request
 
 	return &t_api.Request{
 		Kind: t_api.CreateSchedule,
+		Tags: map[string]string{"partitionId": id},
 		CreateSchedule: &t_api.CreateScheduleRequest{
 			Id:             id,
 			Description:    "",
@@ -332,6 +340,7 @@ func (g *Generator) GenerateDeleteSchedule(r *rand.Rand, t int64) *t_api.Request
 
 	return &t_api.Request{
 		Kind: t_api.DeleteSchedule,
+		Tags: map[string]string{"partitionId": id},
 		DeleteSchedule: &t_api.DeleteScheduleRequest{
 			Id: id,
 		},
@@ -348,6 +357,7 @@ func (g *Generator) GenerateAcquireLock(r *rand.Rand, t int64) *t_api.Request {
 
 	return &t_api.Request{
 		Kind: t_api.AcquireLock,
+		Tags: map[string]string{"partitionId": "___locks___"},
 		AcquireLock: &t_api.AcquireLockRequest{
 			ResourceId:  resourceId,
 			ExecutionId: executionId,
@@ -363,6 +373,7 @@ func (g *Generator) GenerateReleaseLock(r *rand.Rand, t int64) *t_api.Request {
 
 	return &t_api.Request{
 		Kind: t_api.ReleaseLock,
+		Tags: map[string]string{"partitionId": "___locks___"},
 		ReleaseLock: &t_api.ReleaseLockRequest{
 			ResourceId:  resourceId,
 			ExecutionId: executionId,
@@ -375,6 +386,7 @@ func (g *Generator) GenerateHeartbeatLocks(r *rand.Rand, t int64) *t_api.Request
 
 	return &t_api.Request{
 		Kind: t_api.HeartbeatLocks,
+		Tags: map[string]string{"partitionId": "___locks___"},
 		HeartbeatLocks: &t_api.HeartbeatLocksRequest{
 			ProcessId: processId,
 		},
@@ -387,7 +399,7 @@ func (g *Generator) GenerateClaimTask(r *rand.Rand, t int64) *t_api.Request {
 	req := g.pop(r, t_api.ClaimTask)
 
 	if req != nil {
-		g.nextTasks(r, req.ClaimTask.Id, req.ClaimTask.ProcessId, req.ClaimTask.Counter)
+		g.nextTasks(r, req.ClaimTask.Id, req.ClaimTask.ProcessId, req.ClaimTask.Counter, req.Tags)
 	}
 
 	return req
@@ -450,7 +462,7 @@ func (g *Generator) pop(r *rand.Rand, kind t_api.Kind) *t_api.Request {
 	return req
 }
 
-func (g *Generator) nextTasks(r *rand.Rand, id string, pid string, counter int) {
+func (g *Generator) nextTasks(r *rand.Rand, id string, pid string, counter int, reqTags map[string]string) {
 	// seed the "next" requests,
 	// sometimes we deliberately do nothing
 	for i := 0; i < r.Intn(3); i++ {
@@ -458,6 +470,7 @@ func (g *Generator) nextTasks(r *rand.Rand, id string, pid string, counter int) 
 		case 0:
 			g.AddRequest(&t_api.Request{
 				Kind: t_api.ClaimTask,
+				Tags: reqTags,
 				ClaimTask: &t_api.ClaimTaskRequest{
 					Id:        id,
 					ProcessId: pid,
@@ -468,6 +481,7 @@ func (g *Generator) nextTasks(r *rand.Rand, id string, pid string, counter int) 
 		case 1:
 			g.AddRequest(&t_api.Request{
 				Kind: t_api.CompleteTask,
+				Tags: reqTags,
 				CompleteTask: &t_api.CompleteTaskRequest{
 					Id:      id,
 					Counter: counter,
@@ -476,6 +490,7 @@ func (g *Generator) nextTasks(r *rand.Rand, id string, pid string, counter int) 
 		case 2:
 			g.AddRequest(&t_api.Request{
 				Kind: t_api.HeartbeatTasks,
+				Tags: reqTags,
 				HeartbeatTasks: &t_api.HeartbeatTasksRequest{
 					ProcessId: pid,
 				},

--- a/test/dst/generator.go
+++ b/test/dst/generator.go
@@ -311,12 +311,15 @@ func (g *Generator) GenerateCreateSchedule(r *rand.Rand, t int64) *t_api.Request
 	id := g.scheduleId(r)
 	cron := fmt.Sprintf("%d * * * *", r.Intn(60))
 	tags := g.tags(r)
+	// do not create schedules that can invoke promises.
+	delete(tags, "resonate:invoke")
 	idempotencyKey := g.idempotencyKey(r)
 
 	promiseTimeout := RangeInt63n(r, t, g.ticks*g.timeElapsedPerTick)
 	promiseHeaders := g.headers(r)
 	promiseData := g.dataSet[r.Intn(len(g.dataSet))]
 	promiseTags := g.tags(r)
+	delete(promiseTags, "resonate:invoke")
 
 	return &t_api.Request{
 		Kind: t_api.CreateSchedule,

--- a/test/dst/validator.go
+++ b/test/dst/validator.go
@@ -686,7 +686,7 @@ func (v *Validator) ValidateCompleteTask(model *Model, reqTime int64, resTime in
 			return model, fmt.Errorf("task '%s' does not exist", req.CompleteTask.Id)
 		}
 		if !t.State.In(task.Completed|task.Timedout) && t.Timeout >= resTime {
-			// This could happen if the promise timetout
+			// This could happen if the promise timedout
 			p := model.promises.get(t.RootPromiseId)
 			if !promise.GetTimedoutState(p).In(promise.Pending) && resTime >= p.Timeout {
 				model = model.Copy()

--- a/test/dst/validator.go
+++ b/test/dst/validator.go
@@ -681,7 +681,7 @@ func (v *Validator) ValidateCompleteTask(model *Model, reqTime int64, resTime in
 		model = model.Copy()
 		model.tasks.set(req.CompleteTask.Id, res.CompleteTask.Task)
 		return model, nil
-	case t_api.StatusTaskAlreadyCompleted:
+	case t_api.StatusOK:
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", req.CompleteTask.Id)
 		}
@@ -700,7 +700,7 @@ func (v *Validator) ValidateCompleteTask(model *Model, reqTime int64, resTime in
 					IdempotencyKeyForComplete: p.IdempotencyKeyForComplete,
 					Tags:                      p.Tags,
 					CreatedOn:                 p.CreatedOn,
-					CompletedOn:               &reqTime,
+					CompletedOn:               util.ToPointer(p.Timeout),
 					SortId:                    p.SortId,
 				}
 				model.promises.set(p.Id, &newP)

--- a/test/dst/validator.go
+++ b/test/dst/validator.go
@@ -128,12 +128,6 @@ func (v *Validator) ValidateCreatePromise(model *Model, reqTime int64, resTime i
 }
 
 func (v *Validator) ValidateCreatePromiseAndTask(model *Model, reqTime int64, resTime int64, req *t_api.Request, res *t_api.Response) (*Model, error) {
-	// Do NOT validate the create promise, as a workaround we create a
-	// "duplicate" CreatePromise request and map the requests as
-	// follows:
-	// CreatePromise        -> p partition
-	// CreatePromiseAndTask -> t partition
-
 	switch res.CreatePromiseAndTask.Status {
 	case t_api.StatusCreated:
 		if model.tasks.get(res.CreatePromiseAndTask.Task.Id) != nil {
@@ -144,7 +138,12 @@ func (v *Validator) ValidateCreatePromiseAndTask(model *Model, reqTime int64, re
 		model.tasks.set(res.CreatePromiseAndTask.Task.Id, res.CreatePromiseAndTask.Task)
 	}
 
-	return model, nil
+	promiseRes := &t_api.CreatePromiseResponse{
+		Status:  res.CreatePromiseAndTask.Status,
+		Promise: res.CreatePromiseAndTask.Promise,
+	}
+
+	return v.validateCreatePromise(model, reqTime, resTime, req.CreatePromiseAndTask.Promise, promiseRes)
 }
 
 func (v *Validator) validateCreatePromise(model *Model, reqTime int64, resTime int64, req *t_api.CreatePromiseRequest, res *t_api.CreatePromiseResponse) (*Model, error) {


### PR DESCRIPTION
This PR contains several related changes to be able to make the DST run faster and enable validations between promises and tasks.

- Make DST do horizontal partitions based on the rootPromiseId
- Add many validations between tasks and promises as well as adjusting some others
- Make a complete promise operation also complete all related tasks including the current claimed task
- General small changes to the way we print and report DST results to make it easier to debug.
- Make trying to complete a task that is already completed return a StatusOk response
- Create a single CreatePromiseAndTask command that is aware of not creating a task in case a promise was not being able to be created.