### PR TITLE
Remove magic-nix-cache-action

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -107,9 +107,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
-
       - name: Build server and harness
         run: |
           nix build ".#resonate"
@@ -144,9 +141,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
-
-      - name: Use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
 
       - name: semgrep
         run: |

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -22,9 +22,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
-
       - name: Update gomod2nix.toml (if go.mod has changed)
         run: |
           nix develop --command gomod2nix

--- a/.github/workflows/dst.yaml
+++ b/.github/workflows/dst.yaml
@@ -26,9 +26,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
-
       - name: Build resonate binary
         run: |
           nix build ".#resonate"

--- a/.github/workflows/release_check_version.yaml
+++ b/.github/workflows/release_check_version.yaml
@@ -17,9 +17,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
-
       - name: Build Resonate binary
         run: |
           # Build resonate binary

--- a/.github/workflows/release_publish_github_artifacts.yaml
+++ b/.github/workflows/release_publish_github_artifacts.yaml
@@ -42,9 +42,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
-
       - name: Build Resonate binary
         run: |
           TARBALL="resonate_${{ matrix.systems.os }}_${{ matrix.systems.arch }}.tar.gz"


### PR DESCRIPTION
For reasons spelled out [here](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/), the `magic-nix-cache-action` has been EOLed. This Action hasn't had any effect for over two months but I figure it's better to outright remove it.