### PR TITLE
Add string for StatusCallbackInvalidPromise

### DIFF
--- a/internal/kernel/t_api/status.go
+++ b/internal/kernel/t_api/status.go
@@ -51,6 +51,8 @@ func (s StatusCode) String() string {
 		return "The request was successful"
 	case StatusFieldValidationError:
 		return "The request is invalid"
+	case StatusCallbackInvalidPromise:
+		return "The promise and root promise must be different"
 	case StatusPromiseAlreadyResolved:
 		return "The promise has already been resolved"
 	case StatusPromiseAlreadyRejected:


### PR DESCRIPTION
I came across this one by sheer dumb luck. DST doesn't find the issue because the strings are only used in the http subsystem for error responses.