### PR TITLE
Fix bug when creating a schedule in task

### DIFF
--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -14,15 +14,52 @@ import (
 
 func CreatePromise(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any], r *t_api.Request) (*t_api.Response, error) {
 	req := r.Payload.(*t_api.CreatePromiseRequest)
-	return createPromiseAndTask(c, r, req, nil)
+
+	cmd := &t_aio.CreatePromiseCommand{
+		Id:             req.Id,
+		Param:          req.Param,
+		Timeout:        req.Timeout,
+		IdempotencyKey: req.IdempotencyKey,
+		Tags:           req.Tags,
+		CreatedOn:      c.Time(),
+	}
+
+	completion, err := gocoro.SpawnAndAwait(c, createPromise(r.Metadata, cmd, nil))
+
+	if err != nil {
+		return nil, err
+	}
+
+	var status t_api.StatusCode
+
+	if completion.created {
+		status = t_api.StatusCreated
+	} else if (!req.Strict || completion.promise.State == promise.Pending) && completion.promise.IdempotencyKeyForCreate.Match(req.IdempotencyKey) {
+		status = t_api.StatusOK
+	} else {
+		status = t_api.StatusPromiseAlreadyExists
+	}
+
+	return &t_api.Response{
+		Status:   status,
+		Metadata: r.Metadata,
+		Payload:  &t_api.CreatePromiseResponse{Promise: completion.promise},
+	}, nil
 }
 
 func CreatePromiseAndTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any], r *t_api.Request) (*t_api.Response, error) {
 	req := r.Payload.(*t_api.CreatePromiseAndTaskRequest)
-	util.Assert(req.Promise.Id == req.Task.PromiseId, "promise ids must match")
-	util.Assert(req.Promise.Timeout == req.Task.Timeout, "timeouts must match")
 
-	return createPromiseAndTask(c, r, req.Promise, &t_aio.CreateTaskCommand{
+	cmd := &t_aio.CreatePromiseCommand{
+		Id:             req.Promise.Id,
+		Param:          req.Promise.Param,
+		Timeout:        req.Promise.Timeout,
+		IdempotencyKey: req.Promise.IdempotencyKey,
+		Tags:           req.Promise.Tags,
+		CreatedOn:      c.Time(),
+	}
+
+	completion, err := gocoro.SpawnAndAwait(c, createPromise(r.Metadata, cmd, &t_aio.CreateTaskCommand{
 		Id:        util.InvokeId(req.Task.PromiseId),
 		Recv:      nil,
 		Mesg:      &message.Mesg{Type: message.Invoke, Root: req.Task.PromiseId, Leaf: req.Task.PromiseId},
@@ -32,173 +69,36 @@ func CreatePromiseAndTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completio
 		Ttl:       req.Task.Ttl,
 		ExpiresAt: c.Time() + int64(req.Task.Ttl),
 		CreatedOn: c.Time(),
-	})
-}
-
-func createPromiseAndTask(
-	c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any],
-	r *t_api.Request,
-	req *t_api.CreatePromiseRequest,
-	taskCmd *t_aio.CreateTaskCommand,
-) (*t_api.Response, error) {
-	util.Assert(r.Kind() == t_api.CreatePromise || r.Kind() == t_api.CreatePromiseAndTask, "must be create promise or variant")
-
-	// response status
-	var status t_api.StatusCode
-
-	// response data
-	var p *promise.Promise
-	var t *task.Task
-
-	// first read the promise to see if it already exists
-	completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
-		Kind: t_aio.Store,
-		Tags: r.Metadata,
-		Store: &t_aio.StoreSubmission{
-			Transaction: &t_aio.Transaction{
-				Commands: []t_aio.Command{
-					&t_aio.ReadPromiseCommand{
-						Id: req.Id,
-					},
-				},
-			},
-		},
-	})
+	}))
 
 	if err != nil {
-		slog.Error("failed to read promise", "req", r, "err", err)
-		return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
+		return nil, err
 	}
 
-	util.Assert(completion.Store != nil, "completion must not be nil")
+	var status t_api.StatusCode
 
-	result := t_aio.AsQueryPromises(completion.Store.Results[0])
-	util.Assert(result.RowsReturned == 0 || result.RowsReturned == 1, "result must return 0 or 1 rows")
-
-	if result.RowsReturned == 0 {
-		promiseCmd := &t_aio.CreatePromiseCommand{
-			Id:             req.Id,
-			Param:          req.Param,
-			Timeout:        req.Timeout,
-			IdempotencyKey: req.IdempotencyKey,
-			Tags:           req.Tags,
-			CreatedOn:      c.Time(),
-		}
-
-		// if the promise does not exist, create it
-		completion, err := gocoro.SpawnAndAwait(c, createPromise(r.Metadata, promiseCmd, taskCmd))
-		if err != nil {
-			return nil, err
-		}
-		var promiseRowsAffected int64
-
-		switch v := completion.Store.Results[0].(type) {
-		case *t_aio.AlterPromisesResult:
-			promiseRowsAffected = v.RowsAffected
-		case *t_aio.AlterPromisesAndTasksResult:
-			promiseRowsAffected = v.PromiseRowsAffected
-			util.Assert(promiseRowsAffected == v.TaskRowsAffected, "number of promises and tasks affected must be equal.")
-		default:
-			panic("invalid type.")
-		}
-
-		if promiseRowsAffected == 0 {
-			// It's possible that the promise was created by another coroutine
-			// while we were creating. In that case, we should just retry.
-			return createPromiseAndTask(c, r, req, taskCmd)
-		}
-
-		// set status
+	if completion.created {
 		status = t_api.StatusCreated
-
-		// set promise
-		p = &promise.Promise{
-			Id:                      promiseCmd.Id,
-			State:                   promise.Pending,
-			Param:                   promiseCmd.Param,
-			Timeout:                 promiseCmd.Timeout,
-			IdempotencyKeyForCreate: promiseCmd.IdempotencyKey,
-			Tags:                    promiseCmd.Tags,
-			CreatedOn:               &promiseCmd.CreatedOn,
-		}
-
-		if r.Kind() == t_api.CreatePromiseAndTask {
-			util.Assert(taskCmd != nil, "create task cmd must not be nil")
-			t = &task.Task{
-				Id:            taskCmd.Id,
-				ProcessId:     taskCmd.ProcessId,
-				RootPromiseId: p.Id,
-				State:         taskCmd.State,
-				Recv:          taskCmd.Recv,
-				Mesg:          taskCmd.Mesg,
-				Timeout:       taskCmd.Timeout,
-				Counter:       1,
-				Attempt:       0,
-				Ttl:           taskCmd.Ttl,
-				ExpiresAt:     taskCmd.ExpiresAt,
-				CreatedOn:     &taskCmd.CreatedOn,
-			}
-		}
+	} else if (!req.Promise.Strict || completion.promise.State == promise.Pending) && completion.promise.IdempotencyKeyForCreate.Match(req.Promise.IdempotencyKey) {
+		status = t_api.StatusOK
 	} else {
-		p, err = result.Records[0].Promise()
-		if err != nil {
-			slog.Error("failed to parse promise record", "record", result.Records[0], "err", err)
-			return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
-		}
-
-		if p.State == promise.Pending && p.Timeout <= c.Time() {
-			cmd := &t_aio.UpdatePromiseCommand{
-				Id:             req.Id,
-				State:          promise.GetTimedoutState(p),
-				Value:          promise.Value{},
-				IdempotencyKey: nil,
-				CompletedOn:    p.Timeout,
-			}
-
-			ok, err := gocoro.SpawnAndAwait(c, completePromise(r.Metadata, cmd))
-			if err != nil {
-				return nil, err
-			}
-
-			if !ok {
-				// It's possible that the promise was created by another coroutine
-				// while we were timing out. In that case, we should just retry.
-				return createPromiseAndTask(c, r, req, taskCmd)
-			}
-
-			// set status to ok if not strict and idempotency keys match
-			if !req.Strict && p.IdempotencyKeyForCreate.Match(req.IdempotencyKey) {
-				status = t_api.StatusOK
-			} else {
-				status = t_api.StatusPromiseAlreadyExists
-			}
-
-			// update promise
-			p.State = cmd.State
-			p.Value = cmd.Value
-			p.IdempotencyKeyForComplete = cmd.IdempotencyKey
-			p.CompletedOn = &cmd.CompletedOn
-		} else if (!req.Strict || p.State == promise.Pending) && p.IdempotencyKeyForCreate.Match(req.IdempotencyKey) {
-			// switch status to ok if not strict and idempotency keys match
-			status = t_api.StatusOK
-		} else {
-			status = t_api.StatusPromiseAlreadyExists
-		}
+		status = t_api.StatusPromiseAlreadyExists
 	}
 
-	res := &t_api.Response{Status: status, Metadata: r.Metadata}
-
-	switch r.Kind() {
-	case t_api.CreatePromise:
-		res.Payload = &t_api.CreatePromiseResponse{Promise: p}
-	case t_api.CreatePromiseAndTask:
-		res.Payload = &t_api.CreatePromiseAndTaskResponse{Promise: p, Task: t}
-	}
-
-	return res, nil
+	return &t_api.Response{
+		Status:   status,
+		Metadata: r.Metadata,
+		Payload:  &t_api.CreatePromiseAndTaskResponse{Promise: completion.promise, Task: completion.task},
+	}, nil
 }
 
-func createPromise(tags map[string]string, promiseCmd *t_aio.CreatePromiseCommand, taskCmd *t_aio.CreateTaskCommand, additionalCmds ...t_aio.Command) gocoro.CoroutineFunc[*t_aio.Submission, *t_aio.Completion, *t_aio.Completion] {
+type promiseAndTask struct {
+	created bool
+	promise *promise.Promise
+	task    *task.Task
+}
+
+func createPromise(tags map[string]string, promiseCmd *t_aio.CreatePromiseCommand, taskCmd *t_aio.CreateTaskCommand, additionalCmds ...t_aio.Command) gocoro.CoroutineFunc[*t_aio.Submission, *t_aio.Completion, *promiseAndTask] {
 	if promiseCmd.Param.Headers == nil {
 		promiseCmd.Param.Headers = map[string]string{}
 	}
@@ -209,95 +109,164 @@ func createPromise(tags map[string]string, promiseCmd *t_aio.CreatePromiseComman
 		promiseCmd.Tags = map[string]string{}
 	}
 
-	return func(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, *t_aio.Completion]) (*t_aio.Completion, error) {
-		commands := []t_aio.Command{}
-
-		// check router to see if a task needs to be created
+	return func(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, *promiseAndTask]) (*promiseAndTask, error) {
+		// first read the promise to see if it already exists
 		completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
-			Kind: t_aio.Router,
-			Tags: tags,
-			Router: &t_aio.RouterSubmission{
-				Promise: &promise.Promise{
-					Id:                      promiseCmd.Id,
-					State:                   promise.Pending,
-					Param:                   promiseCmd.Param,
-					Timeout:                 promiseCmd.Timeout,
-					IdempotencyKeyForCreate: promiseCmd.IdempotencyKey,
-					Tags:                    promiseCmd.Tags,
-					CreatedOn:               &promiseCmd.CreatedOn,
-				},
-			},
-		})
-
-		if err != nil {
-			slog.Warn("failed to match promise", "cmd", promiseCmd, "err", err)
-		}
-
-		if taskCmd != nil && (err != nil || !completion.Router.Matched) {
-			slog.Error("failed to match promise with router when creating a task", "cmd", promiseCmd)
-			return nil, t_api.NewError(t_api.StatusPromiseRecvNotFound, err)
-		}
-
-		var cmd t_aio.Command = promiseCmd
-
-		if err == nil && completion.Router.Matched {
-			util.Assert(completion.Router.Recv != nil, "recv must not be nil")
-
-			// If there is a taskCmd just update the Recv otherwise create a tasks for the match
-			if taskCmd != nil {
-				// Note: we are mutating the taskCmd that is already merged with the createPromiseCmd
-				taskCmd.Recv = completion.Router.Recv
-			} else {
-				taskCmd = &t_aio.CreateTaskCommand{
-					Id:        util.InvokeId(promiseCmd.Id),
-					Recv:      completion.Router.Recv,
-					Mesg:      &message.Mesg{Type: message.Invoke, Root: promiseCmd.Id, Leaf: promiseCmd.Id},
-					Timeout:   promiseCmd.Timeout,
-					State:     task.Init,
-					CreatedOn: promiseCmd.CreatedOn,
-				}
-			}
-
-			cmd = &t_aio.CreatePromiseAndTaskCommand{
-				PromiseCommand: promiseCmd,
-				TaskCommand:    taskCmd,
-			}
-		}
-
-		// Add the main command
-		commands = append(commands, cmd)
-		// add additional commands
-		commands = append(commands, additionalCmds...)
-
-		// yield commands
-		completion, err = gocoro.YieldAndAwait(c, &t_aio.Submission{
 			Kind: t_aio.Store,
 			Tags: tags,
 			Store: &t_aio.StoreSubmission{
 				Transaction: &t_aio.Transaction{
-					Commands: commands,
+					Commands: []t_aio.Command{
+						&t_aio.ReadPromiseCommand{
+							Id: promiseCmd.Id,
+						},
+					},
 				},
 			},
 		})
 
 		if err != nil {
-			slog.Error("failed to create promise", "err", err)
+			slog.Error("failed to read promise", "cmd", promiseCmd, "err", err)
 			return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
 		}
 
 		util.Assert(completion.Store != nil, "completion must not be nil")
-		util.Assert(len(completion.Store.Results) == len(commands), "completion must have same number of results as commands")
 
-		switch v := completion.Store.Results[0].(type) {
-		case *t_aio.AlterPromisesAndTasksResult:
-			util.Assert(v.PromiseRowsAffected == 0 || v.PromiseRowsAffected == 1, "Creating promise result must return 0 or 1 rows")
-			util.Assert(v.TaskRowsAffected == v.PromiseRowsAffected, "If not promise was created a task must have not been created")
-		case *t_aio.AlterPromisesResult:
-			util.Assert(v.RowsAffected == 0 || v.RowsAffected == 1, "CreatePromise result must return 0 or 1 rows")
-		default:
-			panic("First result must be CreatePromise or CreatePromiseAndTask")
+		result := t_aio.AsQueryPromises(completion.Store.Results[0])
+		util.Assert(result.RowsReturned == 0 || result.RowsReturned == 1, "result must return 0 or 1 rows")
+
+		// response data
+		var p *promise.Promise
+		var t *task.Task
+
+		if result.RowsReturned == 0 {
+			commands := []t_aio.Command{}
+
+			p = &promise.Promise{
+				Id:                      promiseCmd.Id,
+				State:                   promise.Pending,
+				Param:                   promiseCmd.Param,
+				Timeout:                 promiseCmd.Timeout,
+				IdempotencyKeyForCreate: promiseCmd.IdempotencyKey,
+				Tags:                    promiseCmd.Tags,
+				CreatedOn:               &promiseCmd.CreatedOn,
+			}
+
+			// first, check the router to see if a task needs to be created
+			completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
+				Kind: t_aio.Router,
+				Tags: tags,
+				Router: &t_aio.RouterSubmission{
+					Promise: p,
+				},
+			})
+
+			if err != nil {
+				slog.Warn("failed to match promise", "cmd", promiseCmd, "err", err)
+			}
+
+			if err == nil && completion.Router.Matched {
+				util.Assert(completion.Router.Recv != nil, "recv must not be nil")
+
+				if taskCmd != nil {
+					// just set the recv
+					taskCmd.Recv = completion.Router.Recv
+				} else {
+					// add the task command
+					taskCmd = &t_aio.CreateTaskCommand{
+						Id:        util.InvokeId(promiseCmd.Id),
+						Recv:      completion.Router.Recv,
+						Mesg:      &message.Mesg{Type: message.Invoke, Root: promiseCmd.Id, Leaf: promiseCmd.Id},
+						Timeout:   promiseCmd.Timeout,
+						State:     task.Init,
+						CreatedOn: promiseCmd.CreatedOn,
+					}
+				}
+
+				// add a create promise and task command
+				commands = append(commands, &t_aio.CreatePromiseAndTaskCommand{
+					PromiseCommand: promiseCmd,
+					TaskCommand:    taskCmd,
+				})
+
+				t = &task.Task{
+					Id:            taskCmd.Id,
+					ProcessId:     taskCmd.ProcessId,
+					RootPromiseId: p.Id,
+					State:         taskCmd.State,
+					Recv:          taskCmd.Recv,
+					Mesg:          taskCmd.Mesg,
+					Timeout:       taskCmd.Timeout,
+					Counter:       1,
+					Attempt:       0,
+					Ttl:           taskCmd.Ttl,
+					ExpiresAt:     taskCmd.ExpiresAt,
+					CreatedOn:     &taskCmd.CreatedOn,
+				}
+			} else {
+				// add create promise command
+				commands = append(commands, promiseCmd)
+			}
+
+			completion, err = gocoro.YieldAndAwait(c, &t_aio.Submission{
+				Kind: t_aio.Store,
+				Tags: tags,
+				Store: &t_aio.StoreSubmission{
+					Transaction: &t_aio.Transaction{
+						Commands: append(commands, additionalCmds...),
+					},
+				},
+			})
+
+			if err != nil {
+				slog.Error("failed to create promise", "err", err)
+				return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
+			}
+
+			util.Assert(completion.Store != nil, "completion must not be nil")
+			util.Assert(len(completion.Store.Results) == len(commands)+len(additionalCmds), "completion must have same number of results as commands")
+			result := t_aio.AsAlterPromises(completion.Store.Results[0])
+
+			if result.RowsAffected == 0 {
+				// It's possible that the promise was created by another coroutine
+				// while we were creating. In that case, we should just retry.
+				return gocoro.SpawnAndAwait(c, createPromise(tags, promiseCmd, taskCmd, additionalCmds...))
+			}
+
+			return &promiseAndTask{created: true, promise: p, task: t}, nil
 		}
 
-		return completion, nil
+		p, err = result.Records[0].Promise()
+		if err != nil {
+			slog.Error("failed to parse promise record", "record", result.Records[0], "err", err)
+			return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
+		}
+
+		if p.State == promise.Pending && p.Timeout <= c.Time() {
+			ok, err := gocoro.SpawnAndAwait(c, completePromise(tags, &t_aio.UpdatePromiseCommand{
+				Id:             promiseCmd.Id,
+				State:          promise.GetTimedoutState(p),
+				Value:          promise.Value{},
+				IdempotencyKey: nil,
+				CompletedOn:    p.Timeout,
+			}))
+			if err != nil {
+				return nil, err
+			}
+
+			if !ok {
+				// It's possible that the promise was created by another coroutine
+				// while we were creating. In that case, we should just retry.
+				return gocoro.SpawnAndAwait(c, createPromise(tags, promiseCmd, taskCmd, additionalCmds...))
+			}
+
+			// update promise
+			p.State = promise.GetTimedoutState(p)
+			p.Value = promise.Value{}
+			p.IdempotencyKeyForComplete = nil
+			p.CompletedOn = &p.Timeout
+		}
+
+		return &promiseAndTask{created: false, promise: p, task: t}, nil
 	}
 }

--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -95,7 +95,7 @@ func createPromiseAndTask(
 		switch v := completion.Store.Results[0].(type) {
 		case *t_aio.AlterPromisesResult:
 			promiseRowsAffected = v.RowsAffected
-		case *t_aio.AlterPromiseAndTaskResult:
+		case *t_aio.AlterPromisesAndTasksResult:
 			promiseRowsAffected = v.PromiseRowsAffected
 			util.Assert(promiseRowsAffected == v.TaskRowsAffected, "number of promises and tasks affected must be equal.")
 		default:
@@ -289,7 +289,7 @@ func createPromise(tags map[string]string, promiseCmd *t_aio.CreatePromiseComman
 		util.Assert(len(completion.Store.Results) == len(commands), "completion must have same number of results as commands")
 
 		switch v := completion.Store.Results[0].(type) {
-		case *t_aio.AlterPromiseAndTaskResult:
+		case *t_aio.AlterPromisesAndTasksResult:
 			util.Assert(v.PromiseRowsAffected == 0 || v.PromiseRowsAffected == 1, "Creating promise result must return 0 or 1 rows")
 			util.Assert(v.TaskRowsAffected == v.PromiseRowsAffected, "If not promise was created a task must have not been created")
 		case *t_aio.AlterPromisesResult:

--- a/internal/app/coroutines/schedulePromises.go
+++ b/internal/app/coroutines/schedulePromises.go
@@ -43,7 +43,7 @@ func SchedulePromises(config *system.Config, metadata map[string]string) gocoro.
 		result := t_aio.AsQuerySchedules(completion.Store.Results[0])
 		util.Assert(result != nil, "result must not be nil")
 
-		awaiting := make([]gocoroPromise.Awaitable[*t_aio.Completion], len(result.Records))
+		awaiting := make([]gocoroPromise.Awaitable[*promiseAndTask], len(result.Records))
 		commands := make([]*t_aio.CreatePromiseCommand, len(result.Records))
 
 		for i, r := range result.Records {
@@ -101,8 +101,7 @@ func SchedulePromises(config *system.Config, metadata map[string]string) gocoro.
 				continue
 			}
 
-			createPromiseRes := t_aio.AsAlterPromises(completion.Store.Results[0])
-			if createPromiseRes.RowsAffected == 0 {
+			if !completion.created {
 				slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
 			}
 		}

--- a/internal/app/coroutines/schedulePromises.go
+++ b/internal/app/coroutines/schedulePromises.go
@@ -114,7 +114,7 @@ func SchedulePromises(config *system.Config, metadata map[string]string) gocoro.
 					slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
 				}
 			default:
-				panic("First result must be AlterPromises or AlterPromiseAndTask")
+				panic("First result must be CreatePromise or CreatePromiseAndTask")
 			}
 
 		}

--- a/internal/app/coroutines/schedulePromises.go
+++ b/internal/app/coroutines/schedulePromises.go
@@ -101,14 +101,13 @@ func SchedulePromises(config *system.Config, metadata map[string]string) gocoro.
 				continue
 			}
 
-			r := completion.Store.Results[0]
-			switch r.String() {
-			case "AlterPromiseAndTask":
+			switch r := completion.Store.Results[0].(type) {
+			case *t_aio.AlterPromisesAndTasksResult:
 				createPromiseAndTaskRes := t_aio.AsAlterPromiseAndTask(r)
 				if createPromiseAndTaskRes.PromiseRowsAffected == 0 {
 					slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
 				}
-			case "AlterPromises":
+			case *t_aio.AlterPromisesResult:
 				createPromiseRes := t_aio.AsAlterPromises(r)
 				if createPromiseRes.RowsAffected == 0 {
 					slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
@@ -116,7 +115,6 @@ func SchedulePromises(config *system.Config, metadata map[string]string) gocoro.
 			default:
 				panic("First result must be CreatePromise or CreatePromiseAndTask")
 			}
-
 		}
 		return nil, nil
 	}

--- a/internal/app/coroutines/schedulePromises.go
+++ b/internal/app/coroutines/schedulePromises.go
@@ -101,19 +101,9 @@ func SchedulePromises(config *system.Config, metadata map[string]string) gocoro.
 				continue
 			}
 
-			switch r := completion.Store.Results[0].(type) {
-			case *t_aio.AlterPromisesAndTasksResult:
-				createPromiseAndTaskRes := t_aio.AsAlterPromiseAndTask(r)
-				if createPromiseAndTaskRes.PromiseRowsAffected == 0 {
-					slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
-				}
-			case *t_aio.AlterPromisesResult:
-				createPromiseRes := t_aio.AsAlterPromises(r)
-				if createPromiseRes.RowsAffected == 0 {
-					slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
-				}
-			default:
-				panic("First result must be CreatePromise or CreatePromiseAndTask")
+			createPromiseRes := t_aio.AsAlterPromises(completion.Store.Results[0])
+			if createPromiseRes.RowsAffected == 0 {
+				slog.Warn("promise to be scheduled already exists", "promise", commands[i].Id, "schedule", result.Records[i].Id)
 			}
 		}
 		return nil, nil

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -984,7 +984,7 @@ func (w *PostgresStoreWorker) createPromise(_ *sql.Tx, stmt *sql.Stmt, cmd *t_ai
 	}, nil
 }
 
-func (w *PostgresStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.Stmt, taskStmt *sql.Stmt, cmd *t_aio.CreatePromiseAndTaskCommand) (*t_aio.AlterPromiseAndTaskResult, error) {
+func (w *PostgresStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.Stmt, taskStmt *sql.Stmt, cmd *t_aio.CreatePromiseAndTaskCommand) (*t_aio.AlterPromisesAndTasksResult, error) {
 	promiseResult, err := w.createPromise(tx, promiseStmt, cmd.PromiseCommand)
 	if err != nil {
 		return nil, err
@@ -992,7 +992,7 @@ func (w *PostgresStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.
 
 	// Couldn't create a promise
 	if promiseResult.RowsAffected == 0 {
-		return &t_aio.AlterPromiseAndTaskResult{}, nil
+		return &t_aio.AlterPromisesAndTasksResult{}, nil
 	}
 
 	taskResult, err := w.createTask(tx, taskStmt, cmd.TaskCommand)
@@ -1000,7 +1000,7 @@ func (w *PostgresStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.
 		return nil, err
 	}
 
-	return &t_aio.AlterPromiseAndTaskResult{
+	return &t_aio.AlterPromisesAndTasksResult{
 		PromiseRowsAffected: promiseResult.RowsAffected,
 		TaskRowsAffected:    taskResult.RowsAffected,
 	}, nil

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -941,7 +941,7 @@ func (w *SqliteStoreWorker) createPromise(tx *sql.Tx, stmt *sql.Stmt, cmd *t_aio
 	}, nil
 }
 
-func (w *SqliteStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.Stmt, TaskStmt *sql.Stmt, cmd *t_aio.CreatePromiseAndTaskCommand) (*t_aio.AlterPromiseAndTaskResult, error) {
+func (w *SqliteStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.Stmt, TaskStmt *sql.Stmt, cmd *t_aio.CreatePromiseAndTaskCommand) (*t_aio.AlterPromisesAndTasksResult, error) {
 	promiseResult, err := w.createPromise(tx, promiseStmt, cmd.PromiseCommand)
 	if err != nil {
 		return nil, err
@@ -949,7 +949,7 @@ func (w *SqliteStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.St
 
 	// Couldn't create a promise
 	if promiseResult.RowsAffected == 0 {
-		return &t_aio.AlterPromiseAndTaskResult{
+		return &t_aio.AlterPromisesAndTasksResult{
 			PromiseRowsAffected: 0,
 			TaskRowsAffected:    0,
 		}, nil
@@ -960,7 +960,7 @@ func (w *SqliteStoreWorker) createPromiseAndTask(tx *sql.Tx, promiseStmt *sql.St
 		return nil, err
 	}
 
-	return &t_aio.AlterPromiseAndTaskResult{
+	return &t_aio.AlterPromisesAndTasksResult{
 		PromiseRowsAffected: promiseResult.RowsAffected,
 		TaskRowsAffected:    taskResult.RowsAffected,
 	}, nil

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -2142,9 +2142,8 @@ var TestCases = []*testCase{
 			},
 		},
 		expected: []t_aio.Result{
-			&t_aio.AlterPromisesAndTasksResult{
-				PromiseRowsAffected: 1,
-				TaskRowsAffected:    1,
+			&t_aio.AlterPromisesResult{
+				RowsAffected: 1,
 			},
 			&t_aio.QueryPromisesResult{
 				RowsReturned: 1,
@@ -2220,9 +2219,8 @@ var TestCases = []*testCase{
 			&t_aio.AlterPromisesResult{
 				RowsAffected: 1,
 			},
-			&t_aio.AlterPromisesAndTasksResult{
-				PromiseRowsAffected: 0,
-				TaskRowsAffected:    0,
+			&t_aio.AlterPromisesResult{
+				RowsAffected: 0,
 			},
 			&t_aio.QueryPromisesResult{
 				RowsReturned: 1,

--- a/internal/app/subsystems/aio/store/test/cases.go
+++ b/internal/app/subsystems/aio/store/test/cases.go
@@ -2142,7 +2142,7 @@ var TestCases = []*testCase{
 			},
 		},
 		expected: []t_aio.Result{
-			&t_aio.AlterPromiseAndTaskResult{
+			&t_aio.AlterPromisesAndTasksResult{
 				PromiseRowsAffected: 1,
 				TaskRowsAffected:    1,
 			},
@@ -2220,7 +2220,7 @@ var TestCases = []*testCase{
 			&t_aio.AlterPromisesResult{
 				RowsAffected: 1,
 			},
-			&t_aio.AlterPromiseAndTaskResult{
+			&t_aio.AlterPromisesAndTasksResult{
 				PromiseRowsAffected: 0,
 				TaskRowsAffected:    0,
 			},

--- a/internal/kernel/t_aio/store.go
+++ b/internal/kernel/t_aio/store.go
@@ -411,15 +411,6 @@ func (r *AlterTasksResult) String() string {
 	return "AlterTasks"
 }
 
-type AlterPromisesAndTasksResult struct {
-	PromiseRowsAffected int64
-	TaskRowsAffected    int64
-}
-
-func (r *AlterPromisesAndTasksResult) String() string {
-	return "AlterPromiseAndTask"
-}
-
 type QueryLocksResult struct {
 	RowsReturned int64
 	Records      []*lock.LockRecord
@@ -437,16 +428,16 @@ func (r *AlterLocksResult) String() string {
 	return "AlterLocks"
 }
 
-func (r *QueryPromisesResult) isResult()         {}
-func (r *AlterPromisesResult) isResult()         {}
-func (r *AlterCallbacksResult) isResult()        {}
-func (r *QuerySchedulesResult) isResult()        {}
-func (r *AlterSchedulesResult) isResult()        {}
-func (r *QueryTasksResult) isResult()            {}
-func (r *AlterTasksResult) isResult()            {}
-func (r *AlterPromisesAndTasksResult) isResult() {}
-func (r *QueryLocksResult) isResult()            {}
-func (r *AlterLocksResult) isResult()            {}
+func (r *QueryPromisesResult) isResult()  {}
+func (r *AlterPromisesResult) isResult()  {}
+func (r *AlterCallbacksResult) isResult() {}
+func (r *QuerySchedulesResult) isResult() {}
+func (r *AlterSchedulesResult) isResult() {}
+func (r *QueryTasksResult) isResult()     {}
+func (r *AlterTasksResult) isResult()     {}
+
+func (r *QueryLocksResult) isResult() {}
+func (r *AlterLocksResult) isResult() {}
 
 func AsQueryPromises(r Result) *QueryPromisesResult {
 	return r.(*QueryPromisesResult)
@@ -469,9 +460,7 @@ func AsQueryTasks(r Result) *QueryTasksResult {
 func AsAlterTasks(r Result) *AlterTasksResult {
 	return r.(*AlterTasksResult)
 }
-func AsAlterPromiseAndTask(r Result) *AlterPromisesAndTasksResult {
-	return r.(*AlterPromisesAndTasksResult)
-}
+
 func AsQueryLocks(r Result) *QueryLocksResult {
 	return r.(*QueryLocksResult)
 }

--- a/internal/kernel/t_aio/store.go
+++ b/internal/kernel/t_aio/store.go
@@ -411,12 +411,12 @@ func (r *AlterTasksResult) String() string {
 	return "AlterTasks"
 }
 
-type AlterPromiseAndTaskResult struct {
+type AlterPromisesAndTasksResult struct {
 	PromiseRowsAffected int64
 	TaskRowsAffected    int64
 }
 
-func (r *AlterPromiseAndTaskResult) String() string {
+func (r *AlterPromisesAndTasksResult) String() string {
 	return "AlterPromiseAndTask"
 }
 
@@ -437,16 +437,16 @@ func (r *AlterLocksResult) String() string {
 	return "AlterLocks"
 }
 
-func (r *QueryPromisesResult) isResult()       {}
-func (r *AlterPromisesResult) isResult()       {}
-func (r *AlterCallbacksResult) isResult()      {}
-func (r *QuerySchedulesResult) isResult()      {}
-func (r *AlterSchedulesResult) isResult()      {}
-func (r *QueryTasksResult) isResult()          {}
-func (r *AlterTasksResult) isResult()          {}
-func (r *AlterPromiseAndTaskResult) isResult() {}
-func (r *QueryLocksResult) isResult()          {}
-func (r *AlterLocksResult) isResult()          {}
+func (r *QueryPromisesResult) isResult()         {}
+func (r *AlterPromisesResult) isResult()         {}
+func (r *AlterCallbacksResult) isResult()        {}
+func (r *QuerySchedulesResult) isResult()        {}
+func (r *AlterSchedulesResult) isResult()        {}
+func (r *QueryTasksResult) isResult()            {}
+func (r *AlterTasksResult) isResult()            {}
+func (r *AlterPromisesAndTasksResult) isResult() {}
+func (r *QueryLocksResult) isResult()            {}
+func (r *AlterLocksResult) isResult()            {}
 
 func AsQueryPromises(r Result) *QueryPromisesResult {
 	return r.(*QueryPromisesResult)
@@ -469,8 +469,8 @@ func AsQueryTasks(r Result) *QueryTasksResult {
 func AsAlterTasks(r Result) *AlterTasksResult {
 	return r.(*AlterTasksResult)
 }
-func AsAlterPromiseAndTask(r Result) *AlterPromiseAndTaskResult {
-	return r.(*AlterPromiseAndTaskResult)
+func AsAlterPromiseAndTask(r Result) *AlterPromisesAndTasksResult {
+	return r.(*AlterPromisesAndTasksResult)
 }
 func AsQueryLocks(r Result) *QueryLocksResult {
 	return r.(*QueryLocksResult)

--- a/test/dst/generator.go
+++ b/test/dst/generator.go
@@ -299,15 +299,12 @@ func (g *Generator) GenerateCreateSchedule(r *rand.Rand, t int64) *t_api.Request
 	id := g.scheduleId(r)
 	cron := fmt.Sprintf("%d * * * *", r.Intn(60))
 	tags := g.tags(r)
-	// do not create schedules that can invoke promises.
-	delete(tags, "resonate:invoke")
 	idempotencyKey := g.idempotencyKey(r)
 
 	promiseTimeout := RangeInt63n(r, t, g.ticks*g.timeElapsedPerTick)
 	promiseHeaders := g.headers(r)
 	promiseData := g.dataSet[r.Intn(len(g.dataSet))]
 	promiseTags := g.tags(r)
-	delete(promiseTags, "resonate:invoke")
 
 	return &t_api.Request{
 		Metadata: map[string]string{"partitionId": id},


### PR DESCRIPTION
I'm not sure how we can tests this. But I'd love to add some tests for it.

`schedulePromises` was not taking into account  the possibility of creating a promise+tasks. While the function `createPromise` does return one or the other, `schedulePromise` didn't differentiate between both possibilities

- [`createPromise`](https://github.com/resonatehq/resonate/blob/8b2d36ad9b95c8b64d54300c77b029c78e45797f/internal/app/coroutines/createPromise.go#L291)