### PR TITLE
Expose rootPromiseId on task

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -12,9 +12,9 @@ type Task struct {
 	Id            string          `json:"id"`
 	Counter       int             `json:"counter"`
 	Timeout       int64           `json:"timeout"`
+	RootPromiseId string          `json:"rootPromiseId"`
 	ProcessId     *string         `json:"processId,omitempty"`
 	State         State           `json:"-"`
-	RootPromiseId string          `json:"-"`
 	Recv          json.RawMessage `json:"-"`
 	Mesg          *message.Mesg   `json:"-"`
 	Attempt       int             `json:"-"`


### PR DESCRIPTION
This will be included in the messages
```
data: {
  "href": {"claim": "http://[::]:8001/tasks/claim/__resume:bar:foo/1"," complete":"http://[::]:8001/tasks/complete/__resume:bar:foo/1", "heartbeat":"http://[::]:8001/tasks/heartbeat/__resume:bar:foo/1"},
  "task": {"id": "__resume:bar:foo", "counter": 1, "timeout": 1752157091506, "rootPromiseId": "bar", "createdOn": 1752070716871},
  "type": "resume"
}
```