### PR TITLE
various dst fixes

### DIFF
--- a/cmd/dst/issue.go
+++ b/cmd/dst/issue.go
@@ -43,7 +43,7 @@ const issueFmt = `# DST Failed
 
 **Command**
 ~~~
-go run ./... dst run --seed %d --ticks %d --scenario %s --aio-store %s
+go run ./... dst run --seed %d --ticks %d --scenario %s --aio-store-%s-enable
 ~~~
 
 **Logs**

--- a/internal/app/coroutines/dropTask.go
+++ b/internal/app/coroutines/dropTask.go
@@ -12,6 +12,10 @@ import (
 
 func DropTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any], r *t_api.Request) (*t_api.Response, error) {
 	req := r.Payload.(*t_api.DropTaskRequest)
+
+	var status t_api.StatusCode
+	var t *task.Task
+
 	completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
 		Kind: t_aio.Store,
 		Tags: r.Metadata,
@@ -30,85 +34,85 @@ func DropTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any], r *
 		return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
 	}
 
-	readResult := t_aio.AsQueryTasks(completion.Store.Results[0])
-	util.Assert(readResult.RowsReturned == 0 || readResult.RowsReturned == 1, "result must return 0 or 1 rows")
+	util.Assert(completion.Store != nil, "completion must not be nil")
+	result := t_aio.AsQueryTasks(completion.Store.Results[0])
+	util.Assert(result.RowsReturned == 0 || result.RowsReturned == 1, "result must return 0 or 1 rows")
 
-	if readResult.RowsReturned == 0 {
-		return &t_api.Response{
-			Status:   t_api.StatusTaskNotFound,
-			Metadata: r.Metadata,
-			Payload:  &t_api.DropTaskResponse{},
-		}, nil
-	}
+	if result.RowsReturned == 1 {
+		t, err = result.Records[0].Task()
+		if err != nil {
+			slog.Error("failed to parse task", "req", r, "err", err)
+			return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
+		}
 
-	t, err := readResult.Records[0].Task()
-	if err != nil {
-		slog.Error("failed to parse task", "req", r, "err", err)
-		return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
-	}
-
-	// Only try to drop task that are Claimed, otherwise the intended
-	// effect of droping a task is already done.
-	if t.State != task.Claimed {
-		return &t_api.Response{
-			Status:   t_api.StatusOK,
-			Metadata: r.Metadata,
-			Payload:  &t_api.DropTaskResponse{},
-		}, nil
-	}
-
-	if t.Counter != req.Counter {
-		return &t_api.Response{
-			Status:   t_api.StatusTaskInvalidCounter,
-			Metadata: r.Metadata,
-			Payload:  &t_api.DropTaskResponse{},
-		}, nil
-	}
-
-	// When updating the task we don't want to reset the counter
-	// instead increase the counter by one in case the client tries
-	// to claim the same old task again. Resetting the counter
-	// to 1 will cause that nodes with stale tasks could claim them.
-	completion, err = gocoro.YieldAndAwait(c, &t_aio.Submission{
-		Kind: t_aio.Store,
-		Tags: r.Metadata,
-		Store: &t_aio.StoreSubmission{
-			Transaction: &t_aio.Transaction{
-				Commands: []t_aio.Command{
-					&t_aio.UpdateTaskCommand{
-						Id:             req.Id,
-						ProcessId:      nil,
-						State:          task.Init,
-						Counter:        req.Counter + 1,
-						Attempt:        0,
-						Ttl:            0,
-						ExpiresAt:      0,
-						CurrentStates:  []task.State{task.Claimed},
-						CurrentCounter: req.Counter,
+		if t.State.In(task.Init | task.Enqueued | task.Completed | task.Timedout) {
+			status = t_api.StatusOK
+		} else if t.Counter != req.Counter {
+			status = t_api.StatusTaskInvalidCounter
+		} else {
+			// When updating the task we don't want to reset the counter
+			// instead increase the counter by one in case the client tries
+			// to claim the same old task again. Resetting the counter
+			// to 1 would mean that nodes with stale tasks could claim them.
+			completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
+				Kind: t_aio.Store,
+				Tags: r.Metadata,
+				Store: &t_aio.StoreSubmission{
+					Transaction: &t_aio.Transaction{
+						Commands: []t_aio.Command{
+							&t_aio.UpdateTaskCommand{
+								Id:             req.Id,
+								ProcessId:      nil,
+								State:          task.Init,
+								Counter:        req.Counter + 1,
+								Attempt:        0,
+								Ttl:            0,
+								ExpiresAt:      0,
+								CurrentStates:  []task.State{task.Claimed},
+								CurrentCounter: req.Counter,
+							},
+						},
 					},
 				},
-			},
-		},
-	})
+			})
+			if err != nil {
+				slog.Error("failed to drop task", "req", r, "err", err)
+				return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
+			}
 
-	if err != nil {
-		slog.Error("failed to drop task", "req", r, "err", err)
-		return nil, t_api.NewError(t_api.StatusAIOStoreError, err)
-	}
+			util.Assert(completion.Store != nil, "completion must not be nil")
+			result := t_aio.AsAlterTasks(completion.Store.Results[0])
+			util.Assert(result.RowsAffected == 0 || result.RowsAffected == 1, "result must return 0 or 1 rows")
 
-	util.Assert(completion.Store != nil, "completion must not be nil")
-	updateResult := t_aio.AsAlterTasks(completion.Store.Results[0])
-	util.Assert(updateResult.RowsAffected == 0 || updateResult.RowsAffected == 1, "result must return 0 or 1 rows")
+			if result.RowsAffected == 1 {
+				// set status
+				status = t_api.StatusCreated
 
-	if updateResult.RowsAffected == 1 {
-		return &t_api.Response{
-			Status:   t_api.StatusCreated,
-			Metadata: r.Metadata,
-			Payload:  &t_api.DropTaskResponse{},
-		}, nil
+				// update task
+				t.ProcessId = nil
+				t.State = task.Init
+				t.Counter = req.Counter + 1
+				t.Attempt = 0
+				t.Ttl = 0
+				t.ExpiresAt = 0
+			} else {
+				// It's possible that the task was modified by another coroutine
+				// while we were trying to complete. In that case, we should just retry.
+				return DropTask(c, r)
+			}
+		}
 	} else {
-		// It's possible that the task was modified by another coroutine
-		// while we were trying to update it. In that case, we should just retry.
-		return DropTask(c, r)
+		status = t_api.StatusTaskNotFound
 	}
+
+	util.Assert(status != 0, "status must be set")
+	util.Assert(status != t_api.StatusCreated || t != nil, "task must be non nil if status created")
+
+	return &t_api.Response{
+		Status:   status,
+		Metadata: r.Metadata,
+		Payload: &t_api.DropTaskResponse{
+			Task: t,
+		},
+	}, nil
 }

--- a/internal/kernel/t_api/response.go
+++ b/internal/kernel/t_api/response.go
@@ -189,10 +189,11 @@ func (r *CompleteTaskResponse) String() string {
 func (r *CompleteTaskResponse) Kind() Kind { return CompleteTask }
 
 type DropTaskResponse struct {
+	Task *task.Task `json:"task,omitempty"`
 }
 
 func (r *DropTaskResponse) String() string {
-	return "DropTask()"
+	return fmt.Sprintf("DropTask(task=%v)", r.Task)
 }
 
 func (r *DropTaskResponse) Kind() Kind { return DropTask }

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -321,7 +321,7 @@ func (d *DST) logError(partialLinearization []porcupine.Operation, lastOp porcup
 		if req.kind == Op {
 			model, err = d.Step(model, req.time, res.time, req.req, res.res, res.err)
 		} else {
-			model, err = d.BcStep(model, req.time, res.time, req)
+			model, err = d.StepBc(model, req.time, res.time, req)
 		}
 		util.Assert(err == nil, "Only the last operation must result in error")
 	}
@@ -333,7 +333,7 @@ func (d *DST) logError(partialLinearization []porcupine.Operation, lastOp porcup
 		_, err = d.Step(model, req.time, res.time, req.req, res.res, res.err)
 		fmt.Printf("Op(id=%s, t=%d|%d), req=%v, res=%v\n", req.req.Metadata["id"], req.time, res.time, req.req, res.res)
 	} else {
-		_, err = d.BcStep(model, req.time, res.time, req)
+		_, err = d.StepBc(model, req.time, res.time, req)
 		var obj any
 		if req.bc.Task != nil {
 			obj = req.bc.Task
@@ -390,7 +390,7 @@ func (d *DST) Model() porcupine.Model {
 				}
 				return true, updatedModel
 			case Bc:
-				updatedModel, err := d.BcStep(model, req.time, res.time, req)
+				updatedModel, err := d.StepBc(model, req.time, res.time, req)
 				if err != nil {
 					return false, model
 				}
@@ -668,7 +668,7 @@ func (d *DST) Step(model *Model, reqTime int64, resTime int64, req *t_api.Reques
 	return d.validator.Validate(model, reqTime, resTime, req, res)
 }
 
-func (d *DST) BcStep(model *Model, reqTime int64, resTime int64, req *Req) (*Model, error) {
+func (d *DST) StepBc(model *Model, reqTime int64, resTime int64, req *Req) (*Model, error) {
 	util.Assert(req.kind == Bc, "Backchannel step can only be taken if req is of kind Bc")
 	if req.bc.Task == nil && req.bc.Promise == nil {
 		return model, nil

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/anishathalye/porcupine"
@@ -101,7 +102,6 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 
 	// promises
 	d.Add(t_api.ReadPromise, d.generator.GenerateReadPromise, d.validator.ValidateReadPromise)
-
 	d.Add(t_api.CreatePromise, d.generator.GenerateCreatePromise, d.validator.ValidateCreatePromise)
 	d.Add(t_api.CreatePromiseAndTask, d.generator.GenerateCreatePromiseAndTask, d.validator.ValidateCreatePromiseAndTask)
 	d.Add(t_api.CompletePromise, d.generator.GenerateCompletePromise, d.validator.ValidateCompletePromise)
@@ -138,14 +138,14 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 		time := d.Time(t)
 
 		for _, req := range d.generator.Generate(r, time, d.config.ReqsPerTick()) {
-			id := strconv.FormatInt(i, 10)
 			req := req
 			reqTime := time
 
 			if req.Metadata == nil {
 				req.Metadata = make(map[string]string)
 			}
-			req.Metadata["id"] = id
+
+			req.Metadata["id"] = strconv.FormatInt(i, 10)
 			req.Metadata["name"] = req.Kind().String()
 
 			api.EnqueueSQE(&bus.SQE[t_api.Request, t_api.Response]{
@@ -158,26 +158,7 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 
 					if d.config.PrintOps {
 						// log
-						slog.Info("DST", "t", fmt.Sprintf("%d|%d", reqTime, resTime), "id", id, "req", req, "res", res, "err", err)
-
-					}
-
-					// extract cursors for subsequent requests
-					if err == nil {
-						switch v := res.Payload.(type) {
-						case *t_api.SearchPromisesResponse:
-							if v.Cursor != nil {
-								d.generator.AddRequest(&t_api.Request{
-									Payload: v.Cursor.Next,
-								})
-							}
-						case *t_api.SearchSchedulesResponse:
-							if v.Cursor != nil {
-								d.generator.AddRequest(&t_api.Request{
-									Payload: v.Cursor.Next,
-								})
-							}
-						}
+						slog.Info("DST", "t", fmt.Sprintf("%d|%d", reqTime, resTime), "req", req, "res", res, "err", err)
 					}
 
 					// add operation to porcupine
@@ -203,6 +184,12 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 
 			switch obj := obj.(type) {
 			case *task.Task:
+				// skip scheduled promises, this is a little hacky but we know
+				// that scheduled promises start with an 's'
+				if strings.HasPrefix(obj.RootPromiseId, "s") {
+					continue
+				}
+
 				bc = &Backchannel{
 					Task: obj,
 				}
@@ -212,10 +199,9 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 				// our model has been updated via the backchannel
 				counter := obj.Counter - r.Intn(2)
 
-				// The ProcessId is always the taskId, which means each task
-				// is always claimed by a different process, which means
-				// that when heartbeating there will always be a single task at
-				// most when heartbeating
+				// The processId is always the taskId, which means each task
+				// is always claimed by a unique process. When heartbeating there
+				// will be most a single task.
 
 				// add claim req to generator
 				d.generator.AddRequest(&t_api.Request{
@@ -228,6 +214,12 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 					},
 				})
 			case *promise.Promise:
+				// skip scheduled promises, this is a little hacky but we know
+				// that scheduled promises start with an 's'
+				if strings.HasPrefix(obj.Id, "s") {
+					continue
+				}
+
 				bc = &Backchannel{
 					Promise: obj,
 				}
@@ -301,7 +293,7 @@ func (d *DST) logPossibleError(history porcupine.LinearizationInfo) {
 	for i, partiton := range d.partitions {
 		util.Assert(len(linearizationsPartitions[i]) > 0, "partition must have at least one linearization")
 
-		// take the first (and we assumee, by empiric evidence, only linearization)
+		// take the first (and we assume, by empiric evidence, only linearization)
 		linearization := linearizationsPartitions[i][0]
 
 		// if the linearization includes all the operations in the partiton all good
@@ -706,10 +698,8 @@ func (d *DST) String() string {
 func partition(req *Req) string {
 	switch req.kind {
 	case Op:
-		partition, exists := req.req.Metadata["partitionId"]
-		if !exists {
-			panic(fmt.Sprintf("Missing partitionId for request %v", req.req))
-		}
+		partition, ok := req.req.Metadata["partitionId"]
+		util.Assert(ok, "partition id must be set")
 		return partition
 	case Bc:
 		if req.bc.Task != nil {

--- a/test/dst/model.go
+++ b/test/dst/model.go
@@ -69,6 +69,15 @@ func (s *Store[I, T]) copy() *Store[I, T] {
 	return &copied
 }
 
+func (s *Store[I, T]) all() []T {
+	var values []T
+	for _, item := range *s {
+		values = append(values, item.value)
+	}
+
+	return values
+}
+
 func (s *Store[I, T]) get(id I) T {
 	i := sort.Search(len(*s), func(i int) bool {
 		return (*s)[i].id >= id

--- a/test/dst/validator.go
+++ b/test/dst/validator.go
@@ -66,7 +66,7 @@ func (v *Validator) ValidateReadPromise(model *Model, reqTime int64, resTime int
 			if resPromise.State == promise.GetTimedoutState(p) && resTime >= p.Timeout {
 				model = model.Copy()
 				model.promises.set(readPromiseReq.Id, resPromise)
-				completeRelatedTasks(model, p.Id, reqTime)
+				return model, nil
 			} else {
 				return model, fmt.Errorf("invalid state transition (%s -> %s) for promise '%s'", p.State, resPromise.State, readPromiseReq.Id)
 			}
@@ -168,7 +168,6 @@ func (v *Validator) validateCreatePromise(model *Model, reqTime int64, resTime i
 		// update model state
 		model = model.Copy()
 		model.promises.set(req.Id, res.Promise)
-
 		return model, nil
 	case t_api.StatusOK:
 		if p == nil {
@@ -179,7 +178,7 @@ func (v *Validator) validateCreatePromise(model *Model, reqTime int64, resTime i
 			if res.Promise.State == promise.GetTimedoutState(p) && resTime >= p.Timeout {
 				model = model.Copy()
 				model.promises.set(req.Id, res.Promise)
-				completeRelatedTasks(model, p.Id, reqTime)
+				return model, nil
 			} else {
 				return model, fmt.Errorf("invalid state transition (%s -> %s) for promise '%s'", p.State, res.Promise.State, req.Id)
 			}
@@ -226,7 +225,6 @@ func (v *Validator) ValidateCompletePromise(model *Model, reqTime int64, resTime
 		// update model state
 		model = model.Copy()
 		model.promises.set(completePromiseReq.Id, resPromise)
-		completeRelatedTasks(model, p.Id, reqTime)
 		return model, nil
 	case t_api.StatusOK:
 		if p == nil {
@@ -240,7 +238,7 @@ func (v *Validator) ValidateCompletePromise(model *Model, reqTime int64, resTime
 			if resPromise.State == promise.GetTimedoutState(p) && resTime >= p.Timeout {
 				model = model.Copy()
 				model.promises.set(completePromiseReq.Id, resPromise)
-				completeRelatedTasks(model, p.Id, reqTime)
+				return model, nil
 			} else {
 				return model, fmt.Errorf("invalid state transition (%s -> %s) for promise '%s'", p.State, resPromise.State, completePromiseReq.Id)
 			}
@@ -332,7 +330,6 @@ func (v *Validator) ValidateCreateCallback(model *Model, reqTime int64, resTime 
 		if resTime >= p.Timeout {
 			model = model.Copy()
 			model.promises.set(p.Id, createCallbackRes.Promise)
-			completeRelatedTasks(model, p.Id, reqTime)
 			return model, nil
 		}
 
@@ -552,47 +549,25 @@ func (v *Validator) ValidateClaimTask(model *Model, reqTime int64, resTime int64
 		if t.State != task.Claimed {
 			return model, fmt.Errorf("task '%s' not claimed", claimTaskReq.Id)
 		}
+
+		model = model.Copy()
+		model.tasks.set(claimTaskReq.Id, claimTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskAlreadyCompleted:
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", claimTaskReq.Id)
 		}
-		if !t.State.In(task.Completed|task.Timedout) && t.Timeout >= resTime {
-			// This could happen if the promise timetout
-			p := model.promises.get(t.RootPromiseId)
-			if p == nil {
-				return model, nil
-			}
 
-			if !promise.GetTimedoutState(p).In(promise.Pending) && resTime >= p.Timeout {
-				model = model.Copy()
-				newP := promise.Promise{
-					Id:                        p.Id,
-					State:                     promise.GetTimedoutState(p),
-					Param:                     p.Param,
-					Value:                     p.Value,
-					Timeout:                   p.Timeout,
-					IdempotencyKeyForCreate:   p.IdempotencyKeyForCreate,
-					IdempotencyKeyForComplete: p.IdempotencyKeyForComplete,
-					Tags:                      p.Tags,
-					CreatedOn:                 p.CreatedOn,
-					CompletedOn:               util.ToPointer(p.Timeout),
-					SortId:                    p.SortId,
-				}
-				model.promises.set(p.Id, &newP)
-				completeRelatedTasks(model, p.Id, reqTime)
-			} else {
-				return model, fmt.Errorf("task '%s' state not completed", claimTaskReq.Id)
-			}
-		}
+		model = model.Copy()
+		model.tasks.set(claimTaskReq.Id, claimTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskInvalidCounter:
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", claimTaskReq.Id)
 		}
-		if claimTaskReq.Counter == t.Counter && t.ExpiresAt >= resTime {
-			return model, fmt.Errorf("task '%s' counter match (%d == %d)", claimTaskReq.Id, claimTaskReq.Counter, t.Counter)
-		}
+
+		model = model.Copy()
+		model.tasks.set(claimTaskReq.Id, claimTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskNotFound:
 		if t != nil {
@@ -625,37 +600,19 @@ func (v *Validator) ValidateCompleteTask(model *Model, reqTime int64, resTime in
 		model.tasks.set(completeTaskReq.Id, completeTaskRes.Task)
 		return model, nil
 	case t_api.StatusOK:
+		p := model.promises.get(t.RootPromiseId)
+
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", completeTaskReq.Id)
 		}
-		if !t.State.In(task.Completed|task.Timedout) && t.Timeout >= resTime {
-			// This could happen if the promise timedout
-			p := model.promises.get(t.RootPromiseId)
-			if p == nil {
-				return model, nil
-			}
 
-			if !promise.GetTimedoutState(p).In(promise.Pending) && resTime >= p.Timeout {
-				model = model.Copy()
-				newP := promise.Promise{
-					Id:                        p.Id,
-					State:                     promise.GetTimedoutState(p),
-					Param:                     p.Param,
-					Value:                     p.Value,
-					Timeout:                   p.Timeout,
-					IdempotencyKeyForCreate:   p.IdempotencyKeyForCreate,
-					IdempotencyKeyForComplete: p.IdempotencyKeyForComplete,
-					Tags:                      p.Tags,
-					CreatedOn:                 p.CreatedOn,
-					CompletedOn:               util.ToPointer(p.Timeout),
-					SortId:                    p.SortId,
-				}
-				model.promises.set(p.Id, &newP)
-				completeRelatedTasks(model, p.Id, reqTime)
-			} else {
-				return model, fmt.Errorf("task '%s' state not completed", completeTaskReq.Id)
-			}
+		// TODO: provide description
+		if !t.State.In(task.Completed|task.Timedout) && p != nil && p.State == promise.Pending && t.ExpiresAt >= resTime && resTime >= p.Timeout {
+			return model, fmt.Errorf("nah")
 		}
+
+		model = model.Copy()
+		model.tasks.set(completeTaskReq.Id, completeTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskInvalidCounter:
 		if t == nil {
@@ -664,11 +621,17 @@ func (v *Validator) ValidateCompleteTask(model *Model, reqTime int64, resTime in
 		if completeTaskReq.Counter == t.Counter && t.ExpiresAt >= resTime {
 			return model, fmt.Errorf("task '%s' counter match (%d == %d)", completeTaskReq.Id, completeTaskReq.Counter, t.Counter)
 		}
+
+		model = model.Copy()
+		model.tasks.set(completeTaskReq.Id, completeTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskInvalidState:
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", completeTaskReq.Id)
 		}
+
+		model = model.Copy()
+		model.tasks.set(completeTaskReq.Id, completeTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskNotFound:
 		if t != nil {
@@ -682,6 +645,7 @@ func (v *Validator) ValidateCompleteTask(model *Model, reqTime int64, resTime in
 
 func (v *Validator) ValidateDropTask(model *Model, reqTime int64, resTime int64, req *t_api.Request, res *t_api.Response) (*Model, error) {
 	dropTaskReq := req.Payload.(*t_api.DropTaskRequest)
+	dropTaskRes := res.Payload.(*t_api.DropTaskResponse)
 	t := model.tasks.get(dropTaskReq.Id)
 
 	switch res.Status {
@@ -689,45 +653,41 @@ func (v *Validator) ValidateDropTask(model *Model, reqTime int64, resTime int64,
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", dropTaskReq.Id)
 		}
-
 		if t.State != task.Claimed {
-			return model, fmt.Errorf("task '%s' was not in claim state when droping it", dropTaskReq.Id)
+			return model, fmt.Errorf("task '%s' state not claimed", dropTaskReq.Id)
 		}
+		if dropTaskReq.Counter != t.Counter {
+			return model, fmt.Errorf("task '%s' counter mismatch (%d != %d)", dropTaskReq.Id, dropTaskReq.Counter, t.Counter)
+		}
+
 		model = model.Copy()
-		new_t := *t
-		new_t.State = task.Init
-		new_t.Counter = t.Counter + 1
-		model.tasks.set(dropTaskReq.Id, &new_t)
+		model.tasks.set(dropTaskReq.Id, dropTaskRes.Task)
 		return model, nil
 	case t_api.StatusOK:
+		p := model.promises.get(t.RootPromiseId)
+
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", dropTaskReq.Id)
 		}
 
-		// Is possible that the task was timedout
-		if t.State == task.Claimed {
-			if t.Timeout <= reqTime {
-				model = model.Copy()
-				new_t := *t
-				new_t.State = task.Timedout
-				new_t.Counter = 0
-				model.tasks.set(dropTaskReq.Id, &new_t)
-				return model, nil
-			}
-			if t.ExpiresAt <= reqTime {
-				model = model.Copy()
-				new_t := *t
-				new_t.State = task.Init
-				model.tasks.set(dropTaskReq.Id, &new_t)
-				return model, nil
-			}
-			return model, fmt.Errorf("task '%s' was claimed", dropTaskReq.Id)
+		// TODO: provide description
+		if !t.State.In(task.Init|task.Enqueued|task.Completed|task.Timedout) && p != nil && p.State == promise.Pending && t.ExpiresAt >= resTime && resTime >= p.Timeout {
+			return model, fmt.Errorf("nah")
 		}
+
+		model = model.Copy()
+		model.tasks.set(dropTaskReq.Id, dropTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskInvalidCounter:
 		if t == nil {
 			return model, fmt.Errorf("task '%s' does not exist", dropTaskReq.Id)
 		}
+		if dropTaskReq.Counter == t.Counter && t.ExpiresAt >= resTime {
+			return model, fmt.Errorf("task '%s' counter match (%d == %d)", dropTaskReq.Id, dropTaskReq.Counter, t.Counter)
+		}
+
+		model = model.Copy()
+		model.tasks.set(dropTaskReq.Id, dropTaskRes.Task)
 		return model, nil
 	case t_api.StatusTaskNotFound:
 		if t != nil {
@@ -778,29 +738,5 @@ func (v *Validator) ValidateHeartbeatTasks(model *Model, reqTime int64, resTime 
 		return model, nil
 	default:
 		return model, fmt.Errorf("unexpected response status '%d'", res.Status)
-	}
-}
-
-// This function modifies the model in place, make sure you have called
-// model.copy() before calling this function
-func completeRelatedTasks(model *Model, promiseId string, _ int64) {
-	new_tasks := []task.Task{}
-	rp := model.promises.get(promiseId)
-	rpCompletedOn := util.SafeDeref(rp.CompletedOn)
-	for _, t := range *model.tasks {
-		if t.value.State.In(task.Completed | task.Timedout) {
-			continue
-		}
-		// A task created after the promise was completed (resumes) must not be completed
-		if t.value.RootPromiseId == promiseId && *t.value.CreatedOn < rpCompletedOn {
-			new_t := *t.value // Make a copy to avoid modifing the model
-			new_t.State = task.Completed
-			new_t.CompletedOn = &rpCompletedOn
-			new_tasks = append(new_tasks, new_t)
-		}
-	}
-
-	for _, new_t := range new_tasks {
-		model.tasks.set(new_t.Id, &new_t)
 	}
 }


### PR DESCRIPTION
Fixes:
- metadata copy by reference
- dst run command in issue
- skip validation for scheduled tasks/promises received via the backchannel
- do not "assume" state of tasks

When an unexpected task response is received we check the root promise and, if the promise is completed, updates the model task to completed. I have a hunch this could lead to issues so this PR takes a "lazy" approach and only updates the task when the task info is included in the response.

Changes:
- refactor drop task to align with complete task
- return task information for droptask request
- rename `bc_validator.go` to `validator_bc.go` (just so they show up together in the file browser 😄)

Fixes #741, #740, #738, #737, #736, #735, #734, #733, #731, #730, #729, #728, #727, #726, #723, #722, #717, #716, #714, #713, #710, #709, #708, #707, #704, #703, #697, #696, #694, #693, #690, #689, #680, #679