### PR TITLE
Use template IDs for project templates

### DIFF
--- a/cmd/projects/create.go
+++ b/cmd/projects/create.go
@@ -39,7 +39,7 @@ resonate projects create --template basic-workflow-py --name my-app`
 		},
 	}
 
-	cmd.Flags().StringVarP(&template, "template", "t", "", "name of the template, run 'resonate project list' to view available templates")
+	cmd.Flags().StringVarP(&template, "template", "t", "", "id of the template, run 'resonate project list' to view available templates")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "name of the project")
 
 	_ = cmd.MarkFlagRequired("template")

--- a/cmd/projects/list.go
+++ b/cmd/projects/list.go
@@ -45,20 +45,18 @@ func ListProjectCmd() *cobra.Command {
 
 func display(templates Projects) {
 	fmt.Printf("\n✨ Available templates ✨\n\n")
-	for name, t := range templates {
-		fmt.Printf("✨ %s\n\n\t%s\n\n", name, t.Desc)
+	for id, t := range templates {
+		fmt.Printf("✨ %s\n\n\t%s\n\n", t.Name, t.Desc)
 		fmt.Printf("\tTo use this template, run:\n\n")
-		fmt.Printf("\tresonate project create --name your-project --template %s\n\n", name)
+		fmt.Printf("\tresonate project create --name your-project --template %s\n\n", id)
 	}
 }
 
-
-
 func filterByLang(projects Projects, lang string) Projects {
 	filtered := Projects{}
-	for name, p := range projects {
+	for id, p := range projects {
 		if strings.EqualFold(p.Lang, lang) {
-			filtered[name] = p
+			filtered[id] = p
 		}
 	}
 	return filtered

--- a/cmd/projects/projects.go
+++ b/cmd/projects/projects.go
@@ -11,9 +11,11 @@ import (
 
 type (
 	Project struct {
-		Href string `json:"href"`
-		Desc string `json:"desc"`
-		Lang string `json:"lang"`
+		TemplateID string `json:"template_id"`
+		Name       string `json:"name"`
+		Href       string `json:"href"`
+		Desc       string `json:"desc"`
+		Lang       string `json:"lang"`
 	}
 
 	Projects map[string]Project
@@ -63,9 +65,14 @@ func GetProjects() (Projects, error) {
 }
 
 func parse(body []byte) (Projects, error) {
-	projects := Projects{}
-	if err := json.Unmarshal(body, &projects); err != nil {
+	var list []Project
+	if err := json.Unmarshal(body, &list); err != nil {
 		return nil, err
+	}
+
+	projects := Projects{}
+	for _, p := range list {
+		projects[p.TemplateID] = p
 	}
 
 	return projects, nil
@@ -74,8 +81,8 @@ func parse(body []byte) (Projects, error) {
 func GetProjectKeys(projects Projects) []string {
 	keys := make([]string, 0)
 
-	for name := range projects {
-		keys = append(keys, name)
+	for id := range projects {
+		keys = append(keys, id)
 	}
 
 	return keys

--- a/cmd/projects/scaffold.go
+++ b/cmd/projects/scaffold.go
@@ -13,13 +13,13 @@ import (
 )
 
 // scaffold orchestrates the setup of the project from source to destination.
-func scaffold(tmpl, name string) error {
+func scaffold(tmpl string, name string) error {
 	projects, err := GetProjects()
 	if err != nil {
 		return err
 	}
 
-	// find the project based on project (key)
+	// find the project based on template ID
 	project, exists := projects[tmpl]
 	if !exists {
 		return fmt.Errorf("unknown project '%s', available projects are: %v", tmpl, GetProjectKeys(projects))


### PR DESCRIPTION
## Summary
- parse `template_id` and `name` from `templates.json`
- list projects using human-friendly name but reference template IDs in `--template` commands
- lookup templates by ID when scaffolding projects

## Testing
- `go test ./...` *(fails: TestPollPlugin, TestGrpc, TestHttp)*

------
https://chatgpt.com/codex/tasks/task_b_68b7911bb814832ba5f6ff18e8f51c03