### PR TITLE
Change flag to pid and use defaults for pid/ttl

### DIFF
--- a/cmd/tasks/claim.go
+++ b/cmd/tasks/claim.go
@@ -13,14 +13,14 @@ import (
 // Example command usage for claiming a task
 var claimTasksExample = `
 # Claim a task
-resonate tasks claim foo --counter 1 --process-id bar --ttl 1m`
+resonate tasks claim foo --counter 1 --pid bar --ttl 1m`
 
 // ClaimTaskCmd returns a cobra command for claiming a task.
 func ClaimTaskCmd(c client.Client) *cobra.Command {
 	var (
-		counter   int           // Counter for the task claim
-		processId string        // Unique process ID identifying the claimer
-		ttl       time.Duration // Time to live for the task claim
+		counter int
+		pid     string
+		ttl     time.Duration
 	)
 
 	// Define the cobra command
@@ -39,8 +39,8 @@ func ClaimTaskCmd(c client.Client) *cobra.Command {
 			if counter <= 0 {
 				return errors.New("counter is required")
 			}
-			if processId == "" {
-				return errors.New("process-id is required")
+			if pid == "" {
+				return errors.New("pid is required")
 			}
 
 			// Create parameters for the claim task request
@@ -50,7 +50,7 @@ func ClaimTaskCmd(c client.Client) *cobra.Command {
 			body := v1.ClaimTaskJSONRequestBody{
 				Id:        id,
 				Counter:   counter,
-				ProcessId: processId,
+				ProcessId: pid,
 				Ttl:       ttl.Milliseconds(), // Convert duration to milliseconds
 			}
 
@@ -75,14 +75,12 @@ func ClaimTaskCmd(c client.Client) *cobra.Command {
 
 	// Define command flags
 	cmd.Flags().IntVarP(&counter, "counter", "c", 0, "task counter")
-	cmd.Flags().StringVarP(&processId, "process-id", "p", "", "unique id that identifies the claimer")
-	cmd.Flags().DurationVarP(&ttl, "ttl", "t", 0, "task time to live")
+	cmd.Flags().StringVarP(&pid, "pid", "p", "default", "claimant pid")
+	cmd.Flags().DurationVarP(&ttl, "ttl", "t", time.Minute, "task ttl, time before which a heartbeat must be sent")
 
 	// Mark flags as required
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("counter")
-	_ = cmd.MarkFlagRequired("process-id")
-	_ = cmd.MarkFlagRequired("ttl")
 
-	return cmd // Return the constructed command
+	return cmd
 }

--- a/cmd/tasks/complete.go
+++ b/cmd/tasks/complete.go
@@ -17,7 +17,7 @@ resonate tasks complete foo --counter 1`
 // CompleteTaskCmd returns a cobra command for completing a task.
 func CompleteTaskCmd(c client.Client) *cobra.Command {
 	var (
-		counter int // Counter for the task completion
+		counter int
 	)
 
 	// Define the cobra command
@@ -69,5 +69,5 @@ func CompleteTaskCmd(c client.Client) *cobra.Command {
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("counter")
 
-	return cmd // Return the constructed command
+	return cmd
 }

--- a/cmd/tasks/heartbeat.go
+++ b/cmd/tasks/heartbeat.go
@@ -11,12 +11,12 @@ import (
 // Example command usage for sending a heartbeat to a task
 var heartbeatTasksExample = `
 # Heartbeat a task
-resonate tasks heartbeat --process-id foo`
+resonate tasks heartbeat --pid bar`
 
 // HeartbeatTaskCmd returns a cobra command for sending a heartbeat to a task.
 func HeartbeatTaskCmd(c client.Client) *cobra.Command {
 	var (
-		processId string // Unique process ID to heartbeat tasks
+		pid string
 	)
 
 	// Define the cobra command
@@ -30,7 +30,7 @@ func HeartbeatTaskCmd(c client.Client) *cobra.Command {
 
 			// Create the body for heartbeat tasks request
 			body := v1.HeartbeatTasksJSONRequestBody{
-				ProcessId: processId,
+				ProcessId: pid,
 			}
 
 			// Call the client method to send the heartbeat (GET request with path params)
@@ -53,10 +53,7 @@ func HeartbeatTaskCmd(c client.Client) *cobra.Command {
 	}
 
 	// Define command flags
-	cmd.Flags().StringVarP(&processId, "process-id", "p", "", "unique id that identifies the claimer")
+	cmd.Flags().StringVarP(&pid, "pid", "p", "default", "claimant pid")
 
-	// Mark flags as required
-	_ = cmd.MarkFlagRequired("process-id")
-
-	return cmd // Return the constructed command
+	return cmd
 }


### PR DESCRIPTION
This PR simplifies the task cli experience.

```
# at minimum
resonate tasks claim --counter 1
resonate tasks heartbeat
resonate tasks complete --counter 1

# optionally
resonate tasks claim --counter 1 --pid foo --ttl 1m
resonate tasks heartbeat --pid foo
resonate tasks complete --counter 1
```