### PR TITLE
Use aggregate function to get deterministic group by in sqlite

### DIFF
--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -279,18 +279,18 @@ const (
 	TASK_SELECT_ALL_STATEMENT = `
 	SELECT
 		id,
-	    process_id,
+		process_id,
 		state,
-	    root_promise_id,
-	    recv,
-	    mesg,
-	    timeout,
-	    counter,
-	    attempt,
-	    ttl,
-	    expires_at,
-	    created_on,
-	    completed_on
+		root_promise_id,
+		recv,
+		mesg,
+		timeout,
+		counter,
+		attempt,
+		ttl,
+		expires_at,
+		created_on,
+		completed_on
 	FROM tasks
 	WHERE
 		state & ? != 0 AND ((expires_at != 0 AND expires_at <= ?) OR timeout <= ?)
@@ -300,18 +300,19 @@ const (
 	TASK_SELECT_ENQUEUEABLE_STATEMENT = `
 	SELECT
 		id,
-	    process_id,
+		process_id,
 		state,
-	    root_promise_id,
-	    recv,
-	    mesg,
-	    timeout,
-	    counter,
-	    attempt,
-	    ttl,
-	    expires_at,
-	    created_on,
-	    completed_on
+		root_promise_id,
+		recv,
+		mesg,
+		timeout,
+		counter,
+		attempt,
+		ttl,
+		expires_at,
+		created_on,
+		completed_on,
+		min(sort_id)
 	FROM tasks t1
 	WHERE
 		state = 1 AND expires_at <= ? -- State = 1 -> Init
@@ -1477,6 +1478,7 @@ func (w *SqliteStoreWorker) readEnqueueableTasks(tx *sql.Tx, cmd *t_aio.ReadEnqu
 
 	rowsReturned := int64(0)
 	var records []*task.TaskRecord
+	var ignored string
 
 	for rows.Next() {
 		record := &task.TaskRecord{}
@@ -1494,6 +1496,7 @@ func (w *SqliteStoreWorker) readEnqueueableTasks(tx *sql.Tx, cmd *t_aio.ReadEnqu
 			&record.ExpiresAt,
 			&record.CreatedOn,
 			&record.CompletedOn,
+			&ignored,
 		); err != nil {
 			return nil, store.StoreErr(err)
 		}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -7,14 +7,11 @@ import (
 )
 
 const (
-	// DebugLevel defines debug log level.
 	DebugLevel = slog.LevelDebug
-	// InfoLevel defines info log level.
-	InfoLevel = slog.LevelInfo
-	// WarnLevel defines warn log level.
-	WarnLevel = slog.LevelWarn
-	// ErrorLevel defines error log level.
+	InfoLevel  = slog.LevelInfo
+	WarnLevel  = slog.LevelWarn
 	ErrorLevel = slog.LevelError
+	OffLevel   = slog.Level(1000)
 )
 
 // ParseLevel takes a string level and returns the slog log level constant.
@@ -28,6 +25,8 @@ func ParseLevel(lvl string) (slog.Level, error) {
 		return WarnLevel, nil
 	case "error":
 		return ErrorLevel, nil
+	case "off":
+		return OffLevel, nil
 	default:
 		return 0, fmt.Errorf("unrecognized level: %s", lvl)
 	}


### PR DESCRIPTION
```sql
SELECT
  root_promise_id,
  min(sort_id)
FROM tasks
GROUP BY root_promise_id
ORDER BY root_promise_id, sort_id ASC
```

This PR adds the aggregate function `min` which ensures sqlite selects the row with the minimum sort_id, effectively forcing the query to respect the ORDER BY clause. Since we only want to grab a single task for each root_promise_id, the row with the minimum sort_id is the correct row. Previously the row selected by sqlite was undefined, but appeared to be the latest inserted row.

Our postgres query already returns the correct row because SELECT DISTINCT ON respects the ORDER BY clause.

See [this stackoverflow](https://stackoverflow.com/a/71924314/2230252) answer for more details.