### PR TITLE
Add Redpanda sender plugin

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/resonatehq/resonate/internal/api"
 	httpPlugin "github.com/resonatehq/resonate/internal/app/plugins/http"
 	"github.com/resonatehq/resonate/internal/app/plugins/poll"
+	redpandaPlugin "github.com/resonatehq/resonate/internal/app/plugins/redpanda"
 	"github.com/resonatehq/resonate/internal/app/plugins/sqs"
 	"github.com/resonatehq/resonate/internal/app/subsystems/aio/echo"
 	"github.com/resonatehq/resonate/internal/app/subsystems/aio/router"
@@ -202,6 +203,14 @@ func (c *Config) AIOPlugins(a aio.AIO, metrics *metrics.Metrics) ([]aio.Plugin, 
 	}
 	if c.AIO.Subsystems.Sender.Config.Plugins.Http.Enabled {
 		plugin, err := httpPlugin.New(a, metrics, &c.AIO.Subsystems.Sender.Config.Plugins.Http.Config)
+		if err != nil {
+			return nil, "", err
+		}
+
+		plugins = append(plugins, plugin)
+	}
+	if c.AIO.Subsystems.Sender.Config.Plugins.Redpanda.Enabled {
+		plugin, err := redpandaPlugin.New(a, metrics, &c.AIO.Subsystems.Sender.Config.Plugins.Redpanda.Config)
 		if err != nil {
 			return nil, "", err
 		}

--- a/internal/app/plugins/redpanda/redpanda.go
+++ b/internal/app/plugins/redpanda/redpanda.go
@@ -1,0 +1,228 @@
+package redpanda
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/resonatehq/resonate/internal/aio"
+	"github.com/resonatehq/resonate/internal/kernel/t_aio"
+	"github.com/resonatehq/resonate/internal/metrics"
+)
+
+type Config struct {
+	Size        int           `flag:"size" desc:"submission buffered channel size" default:"100"`
+	Workers     int           `flag:"workers" desc:"number of workers" default:"1"`
+	Timeout     time.Duration `flag:"timeout" desc:"http request timeout" default:"5s"`
+	TimeToRetry time.Duration `flag:"ttr" desc:"time to wait before resending" default:"15s"`
+	TimeToClaim time.Duration `flag:"ttc" desc:"time to wait for claim before resending" default:"1m"`
+	Endpoints   []string      `flag:"endpoints" desc:"default Redpanda proxy endpoints" default:"http://localhost:8082"`
+	Topic       string        `flag:"topic" desc:"default topic" default:""`
+}
+
+type Addr struct {
+	Endpoint string            `json:"endpoint,omitempty"`
+	Topic    string            `json:"topic,omitempty"`
+	Key      *string           `json:"key,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+}
+
+type clientFactory func(timeout time.Duration) *http.Client
+
+type Redpanda struct {
+	sq      chan *aio.Message
+	workers []*Worker
+}
+
+type Worker struct {
+	i        int
+	sq       <-chan *aio.Message
+	config   *Config
+	metrics  *metrics.Metrics
+	client   *http.Client
+	endpoint string
+	timeout  time.Duration
+}
+
+func New(a aio.AIO, metrics *metrics.Metrics, config *Config) (*Redpanda, error) {
+	return newWithFactory(a, metrics, config, func(timeout time.Duration) *http.Client {
+		return &http.Client{Timeout: timeout}
+	})
+}
+
+func newWithFactory(a aio.AIO, metrics *metrics.Metrics, config *Config, factory clientFactory) (*Redpanda, error) {
+	if len(config.Endpoints) == 0 {
+		return nil, fmt.Errorf("redpanda: at least one endpoint must be configured")
+	}
+
+	sq := make(chan *aio.Message, config.Size)
+	workers := make([]*Worker, config.Workers)
+	timeout := config.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+
+	for i := 0; i < config.Workers; i++ {
+		workers[i] = &Worker{
+			i:        i,
+			sq:       sq,
+			config:   config,
+			metrics:  metrics,
+			client:   factory(timeout),
+			endpoint: config.Endpoints[i%len(config.Endpoints)],
+			timeout:  timeout,
+		}
+	}
+
+	return &Redpanda{
+		sq:      sq,
+		workers: workers,
+	}, nil
+}
+
+func (r *Redpanda) String() string {
+	return fmt.Sprintf("%s:redpanda", t_aio.Sender.String())
+}
+
+func (r *Redpanda) Type() string {
+	return "redpanda"
+}
+
+func (r *Redpanda) Start(chan<- error) error {
+	for _, worker := range r.workers {
+		go worker.Start()
+	}
+
+	return nil
+}
+
+func (r *Redpanda) Stop() error {
+	close(r.sq)
+	return nil
+}
+
+func (r *Redpanda) Enqueue(msg *aio.Message) bool {
+	select {
+	case r.sq <- msg:
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *Worker) String() string {
+	return fmt.Sprintf("%s:redpanda", t_aio.Sender.String())
+}
+
+func (w *Worker) Start() {
+	counter := w.metrics.AioWorkerInFlight.WithLabelValues(w.String(), strconv.Itoa(w.i))
+	w.metrics.AioWorker.WithLabelValues(w.String()).Inc()
+	defer w.metrics.AioWorker.WithLabelValues(w.String()).Dec()
+
+	for {
+		msg, ok := <-w.sq
+		if !ok {
+			return
+		}
+
+		counter.Inc()
+		success, err := w.Process(msg.Addr, msg.Body)
+		if err != nil {
+			slog.Warn("failed to send task", "err", err)
+		}
+
+		msg.Done(&t_aio.SenderCompletion{
+			Success:     success,
+			TimeToRetry: w.config.TimeToRetry.Milliseconds(),
+			TimeToClaim: w.config.TimeToClaim.Milliseconds(),
+		})
+		counter.Dec()
+	}
+}
+
+func (w *Worker) Process(data []byte, body []byte) (bool, error) {
+	addr := &Addr{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, addr); err != nil {
+			return false, err
+		}
+	}
+
+	endpoint := w.endpoint
+	if addr.Endpoint != "" {
+		endpoint = addr.Endpoint
+	}
+	endpoint = strings.TrimRight(endpoint, "/")
+	if endpoint == "" {
+		return false, fmt.Errorf("redpanda: endpoint must be provided")
+	}
+
+	topic := addr.Topic
+	if topic == "" {
+		topic = w.configTopic()
+	}
+	if topic == "" {
+		return false, fmt.Errorf("redpanda: topic must be provided")
+	}
+
+	record := map[string]any{
+		"value": base64.StdEncoding.EncodeToString(body),
+	}
+	if addr.Key != nil {
+		record["key"] = base64.StdEncoding.EncodeToString([]byte(*addr.Key))
+	}
+	if len(addr.Headers) > 0 {
+		headers := make([]map[string]string, 0, len(addr.Headers))
+		for k, v := range addr.Headers { // nosemgrep: range-over-map
+			headers = append(headers, map[string]string{
+				"key":   k,
+				"value": base64.StdEncoding.EncodeToString([]byte(v)),
+			})
+		}
+		record["headers"] = headers
+	}
+
+	payload := map[string]any{"records": []map[string]any{record}}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return false, err
+	}
+
+	reqURL, err := url.JoinPath(endpoint, "topics", topic)
+	if err != nil {
+		return false, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(buf))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/vnd.kafka.binary.v2+json")
+
+	res, err := w.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return false, fmt.Errorf("redpanda: unexpected status %d", res.StatusCode)
+	}
+
+	return true, nil
+}
+
+func (w *Worker) configTopic() string {
+	return w.config.Topic
+}

--- a/internal/app/plugins/redpanda/redpanda_test.go
+++ b/internal/app/plugins/redpanda/redpanda_test.go
@@ -1,0 +1,117 @@
+package redpanda
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/resonatehq/resonate/internal/aio"
+	"github.com/resonatehq/resonate/internal/kernel/t_aio"
+	"github.com/resonatehq/resonate/internal/metrics"
+)
+
+type produceRequest struct {
+	Records []struct {
+		Key     string `json:"key,omitempty"`
+		Value   string `json:"value"`
+		Headers []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		} `json:"headers,omitempty"`
+	} `json:"records"`
+}
+
+func TestRedpandaPlugin(t *testing.T) {
+	metrics := metrics.New(prometheus.NewRegistry())
+
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/vnd.kafka.binary.v2+json", r.Header.Get("Content-Type"))
+
+		var req produceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+
+		assert.Len(t, req.Records, 1)
+		record := req.Records[0]
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("payload")), record.Value)
+		if strings.Contains(r.URL.Path, "override") {
+			assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("key")), record.Key)
+			assert.Len(t, record.Headers, 1)
+			assert.Equal(t, "h1", record.Headers[0].Key)
+			assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("v1")), record.Headers[0].Value)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer successServer.Close()
+
+	failureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failureServer.Close()
+
+	for _, tc := range []struct {
+		name     string
+		addr     []byte
+		config   *Config
+		expected bool
+	}{
+		{
+			name:     "SuccessDefault",
+			addr:     []byte(`{}`),
+			config:   &Config{Size: 1, Workers: 1, Endpoints: []string{successServer.URL}, Topic: "default"},
+			expected: true,
+		},
+		{
+			name:     "SuccessOverride",
+			addr:     []byte(`{"endpoint":"` + successServer.URL + `","topic":"override","key":"key","headers":{"h1":"v1"}}`),
+			config:   &Config{Size: 1, Workers: 1, Endpoints: []string{failureServer.URL}, Topic: "default"},
+			expected: true,
+		},
+		{
+			name:     "FailureJSON",
+			addr:     []byte(`{"endpoint":"` + successServer.URL + `","topic":`),
+			config:   &Config{Size: 1, Workers: 1, Endpoints: []string{successServer.URL}, Topic: "default"},
+			expected: false,
+		},
+		{
+			name:     "FailureHTTP",
+			addr:     []byte(`{"endpoint":"` + failureServer.URL + `","topic":"default"}`),
+			config:   &Config{Size: 1, Workers: 1, Endpoints: []string{successServer.URL}, Topic: "default"},
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin, err := newWithFactory(nil, metrics, tc.config, func(timeout time.Duration) *http.Client {
+				client := &http.Client{Timeout: timeout}
+				return client
+			})
+			assert.NoError(t, err)
+
+			assert.NoError(t, plugin.Start(nil))
+
+			done := make(chan *t_aio.SenderCompletion, 1)
+			ok := plugin.Enqueue(&aio.Message{
+				Addr: tc.addr,
+				Body: []byte("payload"),
+				Done: func(completion *t_aio.SenderCompletion) {
+					done <- completion
+				},
+			})
+			assert.True(t, ok)
+
+			completion := <-done
+			assert.Equal(t, tc.expected, completion.Success)
+
+			assert.NoError(t, plugin.Stop())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add an HTTP-based Redpanda sender plugin with configurable endpoints, timeouts, and topic defaults
- register the Redpanda transport in sender configuration and URL scheme parsing
- add unit coverage for success and failure scenarios when producing via the Redpanda plugin

## Testing
- go test ./internal/app/plugins/redpanda -run TestRedpandaPlugin -v


------
https://chatgpt.com/codex/tasks/task_b_68eeaaa44448832b89cf83ca4dfaa732