### PR TITLE
Fix/flags

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -49,11 +49,15 @@ type config[T t_api, U t_aio] struct {
 }
 
 func (c *Config) Bind(cmd *cobra.Command) error {
-	return bind(cmd, c, false, "", "")
+	return bind(cmd, c, "default", "", "")
+}
+
+func (c *Config) BindDev(cmd *cobra.Command) error {
+	return bind(cmd, c, "dev", "", "dev")
 }
 
 func (c *ConfigDST) BindDST(cmd *cobra.Command) error {
-	return bind(cmd, c, true, "", "dst")
+	return bind(cmd, c, "dst", "", "dst")
 }
 
 func (c *Config) Parse() error {
@@ -64,6 +68,21 @@ func (c *Config) Parse() error {
 	)
 
 	if err := viper.Unmarshal(&c, viper.DecodeHook(hooks)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Config) ParseDev() error {
+	hooks := mapstructure.ComposeDecodeHookFunc(
+		util.MapToBytes(),
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+	)
+
+	config := struct{ Dev *Config }{Dev: c}
+	if err := viper.Unmarshal(&config, viper.DecodeHook(hooks)); err != nil {
 		return err
 	}
 
@@ -304,7 +323,7 @@ func (c *ConfigDST) store(a aio.AIO, metrics *metrics.Metrics) (aio.SubsystemDST
 
 // Helper functions
 
-func bind(cmd *cobra.Command, cfg any, dst bool, fPrefix string, kPrefix string) error {
+func bind(cmd *cobra.Command, cfg any, tag string, fPrefix string, kPrefix string) error {
 	v := reflect.ValueOf(cfg).Elem()
 	t := v.Type()
 
@@ -314,8 +333,8 @@ func bind(cmd *cobra.Command, cfg any, dst bool, fPrefix string, kPrefix string)
 		desc := field.Tag.Get("desc")
 
 		var value string
-		if dst && field.Tag.Get("dst") != "" {
-			value = field.Tag.Get("dst")
+		if v := field.Tag.Get(tag); v != "" {
+			value = v
 		} else {
 			value = field.Tag.Get("default")
 		}
@@ -429,7 +448,7 @@ func bind(cmd *cobra.Command, cfg any, dst bool, fPrefix string, kPrefix string)
 			cmd.Flags().StringToString(n, v, desc)
 			_ = viper.BindPFlag(k, cmd.Flags().Lookup(n))
 		case reflect.Struct:
-			if err := bind(cmd, v.Field(i).Addr().Interface(), dst, n, k); err != nil {
+			if err := bind(cmd, v.Field(i).Addr().Interface(), tag, n, k); err != nil {
 				return err
 			}
 		default:

--- a/cmd/dev/dev.go
+++ b/cmd/dev/dev.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd(serveCmd *cobra.Command) *cobra.Command {
+func NewCmd() *cobra.Command {
 	var (
 		config = &config.Config{}
 	)

--- a/cmd/dev/dev.go
+++ b/cmd/dev/dev.go
@@ -1,31 +1,31 @@
 package dev
 
 import (
+	"github.com/resonatehq/resonate/cmd/config"
+	"github.com/resonatehq/resonate/cmd/serve"
 	"github.com/spf13/cobra"
 )
 
 func NewCmd(serveCmd *cobra.Command) *cobra.Command {
+	var (
+		config = &config.Config{}
+	)
+
 	cmd := &cobra.Command{
 		Use:   "dev",
 		Short: "Start Resonate server in development mode",
 		Long:  "Start Resonate server with development-friendly defaults (in-memory SQLite store).\n\nThis command is an alias for: resonate serve --aio-store-sqlite-path ':memory:' --aio-store-postgres-query 'sslmode=disable'\n",
-		RunE:  serveCmd.RunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.ParseDev(); err != nil {
+				return err
+			}
+
+			return serve.Serve(config)
+		},
 	}
 
+	_ = config.BindDev(cmd)
 	cmd.Flags().SortFlags = false
-	cmd.Flags().AddFlagSet(serveCmd.Flags())
-
-	f := cmd.Flags().Lookup("aio-store-sqlite-path")
-	if f != nil {
-		f.DefValue = ":memory:"
-		_ = cmd.Flags().Set("aio-store-sqlite-path", ":memory:")
-	}
-
-	f = cmd.Flags().Lookup("aio-store-postgres-query")
-	if f != nil {
-		f.DefValue = "sslmode=disable"
-		_ = cmd.Flags().Set("aio-store-postgres-query", "sslmode=disable")
-	}
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,16 +36,14 @@ func init() {
 	rootCmd.PersistentFlags().StringP("log-level", "", "info", "can be one of: debug, info, warn, error")
 
 	// Add Subcommands
+	rootCmd.AddCommand(dev.NewCmd())
 	rootCmd.AddCommand(dst.NewCmd())
 	rootCmd.AddCommand(invoke.NewCmd())
 	rootCmd.AddCommand(projects.NewCmd())
 	rootCmd.AddCommand(promises.NewCmd())
 	rootCmd.AddCommand(schedules.NewCmd())
+	rootCmd.AddCommand(serve.NewCmd())
 	rootCmd.AddCommand(tasks.NewCmd())
-
-	serveCmd := serve.NewCmd()
-	rootCmd.AddCommand(serveCmd)
-	rootCmd.AddCommand(dev.NewCmd(serveCmd))
 
 	// Set default output
 	rootCmd.SetOut(os.Stdout)

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -36,150 +36,7 @@ func NewCmd() *cobra.Command {
 				return err
 			}
 
-			// logger
-			logLevel, err := log.ParseLevel(config.LogLevel)
-			if err != nil {
-				slog.Error("failed to parse log level", "error", err)
-				return err
-			}
-			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
-			slog.SetDefault(logger)
-
-			// metrics
-			reg := prometheus.NewRegistry()
-			metrics := metrics.New(reg)
-
-			// api/aio
-			api := api.New(config.API.Size, metrics)
-			aio := aio.New(config.AIO.Size, metrics)
-
-			// plugins
-			aioPlugins, pollAddr, err := config.AIOPlugins(aio, metrics)
-			if err != nil {
-				return err
-			}
-
-			// api subsystems
-			apiSubsystems, err := config.APISubsystems(api, pollAddr)
-			if err != nil {
-				return err
-			}
-			for _, subsystem := range apiSubsystems {
-				api.AddSubsystem(subsystem)
-			}
-
-			// aio subsystems
-			aioSubsystems, err := config.AIOSubsystems(aio, metrics, aioPlugins)
-			if err != nil {
-				return err
-			}
-			for _, subsystem := range aioSubsystems {
-				aio.AddSubsystem(subsystem)
-			}
-
-			// start api/aio
-			if err := api.Start(); err != nil {
-				slog.Error("failed to start api", "error", err)
-				return err
-			}
-			if err := aio.Start(); err != nil {
-				slog.Error("failed to start aio", "error", err)
-				return err
-			}
-
-			// set default url
-			if config.System.Url == "" {
-				config.System.Url = fmt.Sprintf("http://%s", api.Addr())
-			}
-
-			// instantiate system
-			system := system.New(api, aio, &config.System, metrics)
-
-			// request coroutines
-			system.AddOnRequest(t_api.ReadPromise, coroutines.ReadPromise)
-			system.AddOnRequest(t_api.SearchPromises, coroutines.SearchPromises)
-			system.AddOnRequest(t_api.CreatePromise, coroutines.CreatePromise)
-			system.AddOnRequest(t_api.CreatePromiseAndTask, coroutines.CreatePromiseAndTask)
-			system.AddOnRequest(t_api.CreateCallback, coroutines.CreateCallback)
-			system.AddOnRequest(t_api.CompletePromise, coroutines.CompletePromise)
-			system.AddOnRequest(t_api.ReadSchedule, coroutines.ReadSchedule)
-			system.AddOnRequest(t_api.SearchSchedules, coroutines.SearchSchedules)
-			system.AddOnRequest(t_api.CreateSchedule, coroutines.CreateSchedule)
-			system.AddOnRequest(t_api.DeleteSchedule, coroutines.DeleteSchedule)
-			system.AddOnRequest(t_api.AcquireLock, coroutines.AcquireLock)
-			system.AddOnRequest(t_api.HeartbeatLocks, coroutines.HeartbeatLocks)
-			system.AddOnRequest(t_api.ReleaseLock, coroutines.ReleaseLock)
-			system.AddOnRequest(t_api.ClaimTask, coroutines.ClaimTask)
-			system.AddOnRequest(t_api.CompleteTask, coroutines.CompleteTask)
-			system.AddOnRequest(t_api.DropTask, coroutines.DropTask)
-			system.AddOnRequest(t_api.HeartbeatTasks, coroutines.HeartbeatTasks)
-
-			// background coroutines
-			system.AddBackground("TimeoutPromises", coroutines.TimeoutPromises)
-			system.AddBackground("SchedulePromises", coroutines.SchedulePromises)
-			system.AddBackground("TimeoutLocks", coroutines.TimeoutLocks)
-			system.AddBackground("EnqueueTasks", coroutines.EnqueueTasks)
-			system.AddBackground("TimeoutTasks", coroutines.TimeoutTasks)
-
-			// metrics server
-			mux := http.NewServeMux()
-			mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-			metricsServer := &http.Server{Addr: config.MetricsAddr, Handler: mux}
-
-			go func() {
-				for {
-					slog.Info("starting metrics server", "addr", metricsServer.Addr)
-					if err := metricsServer.ListenAndServe(); err != nil && err == http.ErrServerClosed {
-						return
-					}
-
-					slog.Error("restarting metrics server...", "error", err)
-					time.Sleep(5 * time.Second)
-				}
-			}()
-
-			// listen for shutdown signal
-			go func() {
-				sig := make(chan os.Signal, 1)
-				signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-
-				// halt until we get a shutdown signal or an error
-				// occurs, whichever happens first
-				select {
-				case s := <-sig:
-					slog.Info("shutdown signal received, shutting down", "signal", s)
-				case err := <-api.Errors():
-					slog.Error("api error received, shutting down", "error", err)
-				case err := <-aio.Errors():
-					slog.Error("aio error received, shutting down", "error", err)
-				}
-
-				// shutdown system
-				<-system.Shutdown()
-
-				// shutdown metrics server
-				if err := metricsServer.Close(); err != nil {
-					slog.Warn("error stopping metrics server", "error", err)
-				}
-			}()
-
-			// control loop
-			if err := system.Loop(); err != nil {
-				slog.Error("control loop failed", "error", err)
-				return err
-			}
-
-			// stop api/aio
-			if err := api.Stop(); err != nil {
-				slog.Error("failed to stop api", "error", err)
-				return err
-			}
-			if err := aio.Stop(); err != nil {
-				slog.Error("failed to stop aio", "error", err)
-				return err
-			}
-
-			return nil
+			return Serve(config)
 		},
 	}
 
@@ -194,4 +51,151 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().SortFlags = false
 
 	return cmd
+}
+
+func Serve(config *config.Config) error {
+	// logger
+	logLevel, err := log.ParseLevel(config.LogLevel)
+	if err != nil {
+		slog.Error("failed to parse log level", "error", err)
+		return err
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
+	slog.SetDefault(logger)
+
+	// metrics
+	reg := prometheus.NewRegistry()
+	metrics := metrics.New(reg)
+
+	// api/aio
+	api := api.New(config.API.Size, metrics)
+	aio := aio.New(config.AIO.Size, metrics)
+
+	// plugins
+	aioPlugins, pollAddr, err := config.AIOPlugins(aio, metrics)
+	if err != nil {
+		return err
+	}
+
+	// api subsystems
+	apiSubsystems, err := config.APISubsystems(api, pollAddr)
+	if err != nil {
+		return err
+	}
+	for _, subsystem := range apiSubsystems {
+		api.AddSubsystem(subsystem)
+	}
+
+	// aio subsystems
+	aioSubsystems, err := config.AIOSubsystems(aio, metrics, aioPlugins)
+	if err != nil {
+		return err
+	}
+	for _, subsystem := range aioSubsystems {
+		aio.AddSubsystem(subsystem)
+	}
+
+	// start api/aio
+	if err := api.Start(); err != nil {
+		slog.Error("failed to start api", "error", err)
+		return err
+	}
+	if err := aio.Start(); err != nil {
+		slog.Error("failed to start aio", "error", err)
+		return err
+	}
+
+	// set default url
+	if config.System.Url == "" {
+		config.System.Url = fmt.Sprintf("http://%s", api.Addr())
+	}
+
+	// instantiate system
+	system := system.New(api, aio, &config.System, metrics)
+
+	// request coroutines
+	system.AddOnRequest(t_api.ReadPromise, coroutines.ReadPromise)
+	system.AddOnRequest(t_api.SearchPromises, coroutines.SearchPromises)
+	system.AddOnRequest(t_api.CreatePromise, coroutines.CreatePromise)
+	system.AddOnRequest(t_api.CreatePromiseAndTask, coroutines.CreatePromiseAndTask)
+	system.AddOnRequest(t_api.CreateCallback, coroutines.CreateCallback)
+	system.AddOnRequest(t_api.CompletePromise, coroutines.CompletePromise)
+	system.AddOnRequest(t_api.ReadSchedule, coroutines.ReadSchedule)
+	system.AddOnRequest(t_api.SearchSchedules, coroutines.SearchSchedules)
+	system.AddOnRequest(t_api.CreateSchedule, coroutines.CreateSchedule)
+	system.AddOnRequest(t_api.DeleteSchedule, coroutines.DeleteSchedule)
+	system.AddOnRequest(t_api.AcquireLock, coroutines.AcquireLock)
+	system.AddOnRequest(t_api.HeartbeatLocks, coroutines.HeartbeatLocks)
+	system.AddOnRequest(t_api.ReleaseLock, coroutines.ReleaseLock)
+	system.AddOnRequest(t_api.ClaimTask, coroutines.ClaimTask)
+	system.AddOnRequest(t_api.CompleteTask, coroutines.CompleteTask)
+	system.AddOnRequest(t_api.DropTask, coroutines.DropTask)
+	system.AddOnRequest(t_api.HeartbeatTasks, coroutines.HeartbeatTasks)
+
+	// background coroutines
+	system.AddBackground("TimeoutPromises", coroutines.TimeoutPromises)
+	system.AddBackground("SchedulePromises", coroutines.SchedulePromises)
+	system.AddBackground("TimeoutLocks", coroutines.TimeoutLocks)
+	system.AddBackground("EnqueueTasks", coroutines.EnqueueTasks)
+	system.AddBackground("TimeoutTasks", coroutines.TimeoutTasks)
+
+	// metrics server
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	metricsServer := &http.Server{Addr: config.MetricsAddr, Handler: mux}
+
+	go func() {
+		for {
+			slog.Info("starting metrics server", "addr", metricsServer.Addr)
+			if err := metricsServer.ListenAndServe(); err != nil && err == http.ErrServerClosed {
+				return
+			}
+
+			slog.Error("restarting metrics server...", "error", err)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	// listen for shutdown signal
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+		// halt until we get a shutdown signal or an error
+		// occurs, whichever happens first
+		select {
+		case s := <-sig:
+			slog.Info("shutdown signal received, shutting down", "signal", s)
+		case err := <-api.Errors():
+			slog.Error("api error received, shutting down", "error", err)
+		case err := <-aio.Errors():
+			slog.Error("aio error received, shutting down", "error", err)
+		}
+
+		// shutdown system
+		<-system.Shutdown()
+
+		// shutdown metrics server
+		if err := metricsServer.Close(); err != nil {
+			slog.Warn("error stopping metrics server", "error", err)
+		}
+	}()
+
+	// control loop
+	if err := system.Loop(); err != nil {
+		slog.Error("control loop failed", "error", err)
+		return err
+	}
+
+	// stop api/aio
+	if err := api.Stop(); err != nil {
+		slog.Error("failed to stop api", "error", err)
+		return err
+	}
+	if err := aio.Stop(); err != nil {
+		slog.Error("failed to stop aio", "error", err)
+		return err
+	}
+
+	return nil
 }

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -392,7 +392,7 @@ type Config struct {
 	Username  string            `flag:"username" desc:"postgres username"`
 	Password  string            `flag:"password" desc:"postgres password"`
 	Database  string            `flag:"database" desc:"postgres database" default:"resonate" dst:"resonate_dst"`
-	Query     map[string]string `flag:"query" desc:"postgres query options" dst:"{\"sslmode\":\"disable\"}"`
+	Query     map[string]string `flag:"query" desc:"postgres query options" dst:"{\"sslmode\":\"disable\"}" dev:"{\"sslmode\":\"disable\"}"`
 	TxTimeout time.Duration     `flag:"tx-timeout" desc:"postgres transaction timeout" default:"10s"`
 	Reset     bool              `flag:"reset" desc:"reset postgres db on shutdown" default:"false" dst:"true"`
 }

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -375,7 +375,7 @@ const (
 type Config struct {
 	Size      int           `flag:"size" desc:"submission buffered channel size" default:"1000"`
 	BatchSize int           `flag:"batch-size" desc:"max submissions processed per iteration" default:"1000"`
-	Path      string        `flag:"path" desc:"sqlite database path" default:"resonate.db" dst:":memory:"`
+	Path      string        `flag:"path" desc:"sqlite database path" default:"resonate.db" dst:":memory:" dev:":memory:"`
 	TxTimeout time.Duration `flag:"tx-timeout" desc:"sqlite transaction timeout" default:"10s"`
 	Reset     bool          `flag:"reset" desc:"reset sqlite db on shutdown" default:"false" dst:"true"`
 }


### PR DESCRIPTION
Viper flags are global, so the `serve` and `dev` commands were clobbering each other, causing the last defined command to "win", in this case dev.

This means that the following two commands would default to using `:memory:`:
- resonate dev
- resonate serve

This PR fixes this issue by using the approach we already use for the dst command
1. look up the "dev" struct tag for the default value, if not present fallback to "default"
2. unmarshal the dev config from the dev key, this gives each flag a unique viper identity fixing the conflict