### PR TITLE
Use isolated viper instances per command

### DIFF
--- a/cmd/dev/dev.go
+++ b/cmd/dev/dev.go
@@ -1,13 +1,19 @@
 package dev
 
 import (
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/resonatehq/resonate/cmd/config"
 	"github.com/resonatehq/resonate/cmd/serve"
+	"github.com/resonatehq/resonate/cmd/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewCmd() *cobra.Command {
 	var (
+		v      = viper.New()
 		config = &config.Config{}
 	)
 
@@ -15,8 +21,34 @@ func NewCmd() *cobra.Command {
 		Use:   "dev",
 		Short: "Start Resonate server in development mode",
 		Long:  "Start Resonate server with development-friendly defaults (in-memory SQLite store).\n\nThis command is an alias for: resonate serve --aio-store-sqlite-path ':memory:' --aio-store-postgres-query 'sslmode=disable'\n",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if file, _ := cmd.Flags().GetString("config"); file != "" {
+				v.SetConfigFile(file)
+			} else {
+				v.SetConfigName("resonate-dev")
+				v.AddConfigPath(".")
+				v.AddConfigPath("$HOME")
+			}
+
+			v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+			v.AutomaticEnv()
+
+			if err := v.ReadInConfig(); err != nil {
+				if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+					return err
+				}
+			}
+
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := config.ParseDev(); err != nil {
+			hooks := mapstructure.ComposeDecodeHookFunc(
+				util.MapToBytes(),
+				mapstructure.StringToTimeDurationHookFunc(),
+				mapstructure.StringToSliceHookFunc(","),
+			)
+
+			if err := v.Unmarshal(&config, viper.DecodeHook(hooks)); err != nil {
 				return err
 			}
 
@@ -24,7 +56,11 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	_ = config.BindDev(cmd)
+	// bind config file flag
+	cmd.Flags().StringP("config", "c", "", "config file (default resonate-dev.yaml)")
+
+	// bind config
+	_ = config.Bind(cmd, v, "dev")
 	cmd.Flags().SortFlags = false
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/resonatehq/resonate/cmd/dev"
 	"github.com/resonatehq/resonate/cmd/dst"
@@ -15,11 +13,6 @@ import (
 	"github.com/resonatehq/resonate/cmd/tasks"
 	"github.com/resonatehq/resonate/internal"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-)
-
-var (
-	cfgFile string
 )
 
 var rootCmd = &cobra.Command{
@@ -29,12 +22,6 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
-
-	// Flags
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "", "", "config file (default \"resonate.yml\")")
-	rootCmd.PersistentFlags().StringP("log-level", "", "info", "can be one of: debug, info, warn, error")
-
 	// Add Subcommands
 	rootCmd.AddCommand(dev.NewCmd())
 	rootCmd.AddCommand(dst.NewCmd())
@@ -48,26 +35,6 @@ func init() {
 	// Set default output
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.SetErr(os.Stderr)
-}
-
-func initConfig() {
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		viper.SetConfigName("resonate")
-		viper.AddConfigPath(".")
-		viper.AddConfigPath("$HOME")
-	}
-
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.AutomaticEnv()
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			slog.Error("error reading config file", "error", err)
-			os.Exit(1)
-		}
-	}
 }
 
 func Execute() {


### PR DESCRIPTION
- Create isolated viper instance per command
- Use independent config files for the three commands that support config files
  - serve (resonate.yaml)
  - dev (resonate-dev.yaml)
  - dst (resonate-dst.yaml)

This prevents the commands from clobbering each other, letting us use flags with the same name and different default values across different commands.