### PR TITLE
feat: add pluggable auth system

### DIFF
--- a/cmd/invoke/invoke.go
+++ b/cmd/invoke/invoke.go
@@ -43,6 +43,7 @@ func NewCmd() *cobra.Command {
 		server   string
 		username string
 		password string
+		token    string
 	)
 
 	cmd := &cobra.Command{
@@ -50,7 +51,9 @@ func NewCmd() *cobra.Command {
 		Short:   "Invoke a function",
 		Example: invokeExample,
 		PreRunE: func(cmd *cobra.Command, cmdArgs []string) error {
-			if username != "" || password != "" {
+			if token != "" {
+				c.SetBearerToken(token)
+			} else if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
 
@@ -142,6 +145,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVar(&server, "server", "http://localhost:8001", "resonate server url")
 	cmd.Flags().StringVarP(&username, "username", "U", "", "basic auth username")
 	cmd.Flags().StringVarP(&password, "password", "P", "", "basic auth password")
+	cmd.Flags().StringVar(&token, "token", "", "bearer token for authentication")
 
 	cmd.Flags().SortFlags = false
 	_ = cmd.MarkFlagRequired("func")

--- a/cmd/promises/promises.go
+++ b/cmd/promises/promises.go
@@ -17,6 +17,7 @@ func NewCmd() *cobra.Command {
 		server   string
 		username string
 		password string
+		token    string
 	)
 
 	cmd := &cobra.Command{
@@ -27,7 +28,9 @@ func NewCmd() *cobra.Command {
 			_ = cmd.Help()
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if username != "" || password != "" {
+			if token != "" {
+				c.SetBearerToken(token)
+			} else if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
 
@@ -47,6 +50,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "resonate url")
 	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "basic auth username")
 	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "basic auth password")
+	cmd.PersistentFlags().StringVar(&token, "token", "", "bearer token for authentication")
 
 	return cmd
 }

--- a/cmd/schedules/schedules.go
+++ b/cmd/schedules/schedules.go
@@ -17,6 +17,7 @@ func NewCmd() *cobra.Command {
 		server   string
 		username string
 		password string
+		token    string
 	)
 
 	cmd := &cobra.Command{
@@ -27,7 +28,9 @@ func NewCmd() *cobra.Command {
 			_ = cmd.Help()
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if username != "" || password != "" {
+			if token != "" {
+				c.SetBearerToken(token)
+			} else if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
 
@@ -45,6 +48,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "resonate url")
 	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "basic auth username")
 	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "basic auth password")
+	cmd.PersistentFlags().StringVar(&token, "token", "", "bearer token for authentication")
 
 	return cmd
 }

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -12,6 +12,7 @@ func NewCmd() *cobra.Command {
 		server   string
 		username string
 		password string
+		token    string
 	)
 
 	cmd := &cobra.Command{
@@ -22,7 +23,9 @@ func NewCmd() *cobra.Command {
 			_ = cmd.Help()
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if username != "" || password != "" {
+			if token != "" {
+				c.SetBearerToken(token)
+			} else if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
 			return c.Setup(server)
@@ -38,6 +41,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "Resonate server URL")
 	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "Basic auth username")
 	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "Basic auth password")
+	cmd.PersistentFlags().StringVar(&token, "token", "", "bearer token for authentication")
 
 	return cmd
 }

--- a/internal/app/auth/auth.go
+++ b/internal/app/auth/auth.go
@@ -1,0 +1,294 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ContextIdentityKey is used to store authentication details in request contexts.
+const ContextIdentityKey = "auth.identity"
+
+// Identity represents an authenticated caller.
+type Identity struct {
+	Subject string
+	Claims  jwt.MapClaims
+	Token   *jwt.Token
+}
+
+// Error represents an authentication failure response.
+type Error struct {
+	Status  int
+	Message string
+	Headers map[string]string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("authentication failed with status %d", e.Status)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// Write renders the error as an HTTP response.
+func (e *Error) Write(w http.ResponseWriter) {
+	if e == nil {
+		return
+	}
+	for key, value := range e.Headers {
+		w.Header().Set(key, value)
+	}
+	http.Error(w, e.Error(), e.Status)
+}
+
+// Authenticator validates inbound requests.
+type Authenticator interface {
+	Enabled() bool
+	Authenticate(r *http.Request) (*Identity, *Error)
+}
+
+// New creates an Authenticator from configuration. It returns nil when
+// authentication is disabled.
+func New(cfg *Config) (Authenticator, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+
+	provider := strings.TrimSpace(strings.ToLower(cfg.Provider))
+	if provider == "" && len(cfg.Basic) > 0 {
+		provider = "basic"
+	}
+
+	switch provider {
+	case "":
+		return nil, nil
+	case "basic":
+		if len(cfg.Basic) == 0 {
+			return nil, errors.New("basic auth provider requires credentials")
+		}
+		return newBasicAuthenticator(cfg.Basic), nil
+	case "jwt":
+		return newJWTAuthenticator(&cfg.JWT)
+	default:
+		return nil, fmt.Errorf("unsupported auth provider %q", cfg.Provider)
+	}
+}
+
+// GinMiddleware creates a gin middleware that enforces authentication.
+func GinMiddleware(a Authenticator) gin.HandlerFunc {
+	if a == nil || !a.Enabled() {
+		return nil
+	}
+
+	return func(c *gin.Context) {
+		identity, err := a.Authenticate(c.Request)
+		if err != nil {
+			err.Write(c.Writer)
+			c.Abort()
+			return
+		}
+		if identity != nil {
+			c.Set(ContextIdentityKey, identity)
+		}
+		c.Next()
+	}
+}
+
+// RequireHTTP enforces authentication for a standard net/http handler. It returns
+// the authenticated identity (when available) and a boolean indicating whether
+// the request should proceed.
+func RequireHTTP(a Authenticator, w http.ResponseWriter, r *http.Request) (*Identity, bool) {
+	if a == nil || !a.Enabled() {
+		return nil, true
+	}
+
+	identity, err := a.Authenticate(r)
+	if err != nil {
+		err.Write(w)
+		return nil, false
+	}
+
+	return identity, true
+}
+
+func loadKeyMaterial(cfg *JWTConfig) ([]byte, error) {
+	if cfg.KeyFile != "" {
+		data, err := os.ReadFile(cfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("read jwt key file: %w", err)
+		}
+		return data, nil
+	}
+	if cfg.Key != "" {
+		return []byte(cfg.Key), nil
+	}
+	return nil, errors.New("jwt key or key-file must be provided")
+}
+
+func signingKey(algorithm string, material []byte) (any, error) {
+	switch algorithm {
+	case jwt.SigningMethodHS256.Alg(), jwt.SigningMethodHS384.Alg(), jwt.SigningMethodHS512.Alg():
+		return material, nil
+	case jwt.SigningMethodRS256.Alg(), jwt.SigningMethodRS384.Alg(), jwt.SigningMethodRS512.Alg():
+		return jwt.ParseRSAPublicKeyFromPEM(material)
+	case jwt.SigningMethodES256.Alg(), jwt.SigningMethodES384.Alg(), jwt.SigningMethodES512.Alg():
+		return jwt.ParseECPublicKeyFromPEM(material)
+	case jwt.SigningMethodEdDSA.Alg():
+		return jwt.ParseEdPublicKeyFromPEM(material)
+	default:
+		return nil, fmt.Errorf("unsupported jwt algorithm %q", algorithm)
+	}
+}
+
+func parserOptions(cfg *JWTConfig) []jwt.ParserOption {
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{cfg.Algorithm}),
+	}
+	if cfg.ClockSkew > 0 {
+		opts = append(opts, jwt.WithLeeway(cfg.ClockSkew))
+	}
+	if cfg.Issuer != "" {
+		opts = append(opts, jwt.WithIssuer(cfg.Issuer))
+	}
+	if len(cfg.Audience) > 0 {
+		opts = append(opts, jwt.WithAudience(cfg.Audience...))
+	}
+	return opts
+}
+
+func bearerUnauthorized(message string, cause error) *Error {
+	return &Error{
+		Status:  http.StatusUnauthorized,
+		Message: message,
+		Headers: map[string]string{"WWW-Authenticate": "Bearer"},
+		Err:     cause,
+	}
+}
+
+func basicUnauthorized(cause error) *Error {
+	return &Error{
+		Status:  http.StatusUnauthorized,
+		Message: "unauthorized",
+		Headers: map[string]string{"WWW-Authenticate": `Basic realm="Restricted"`},
+		Err:     cause,
+	}
+}
+
+func newBasicAuthenticator(credentials map[string]string) Authenticator {
+	sanitized := map[string]string{}
+	for user, pass := range credentials {
+		trimmed := strings.TrimSpace(user)
+		if trimmed == "" {
+			continue
+		}
+		sanitized[trimmed] = pass
+	}
+	return &basicAuthenticator{credentials: sanitized}
+}
+
+func newJWTAuthenticator(cfg *JWTConfig) (Authenticator, error) {
+	algorithm := cfg.Algorithm
+	if algorithm == "" {
+		algorithm = jwt.SigningMethodHS256.Name
+	}
+	method := jwt.GetSigningMethod(algorithm)
+	if method == nil {
+		return nil, fmt.Errorf("unknown jwt signing algorithm %q", algorithm)
+	}
+	cfg.Algorithm = method.Alg()
+
+	material, err := loadKeyMaterial(cfg)
+	if err != nil {
+		return nil, err
+	}
+	key, err := signingKey(cfg.Algorithm, material)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := jwt.NewParser(parserOptions(cfg)...)
+
+	return &jwtAuthenticator{
+		key:    key,
+		parser: parser,
+	}, nil
+}
+
+type basicAuthenticator struct {
+	credentials map[string]string
+}
+
+func (a *basicAuthenticator) Enabled() bool {
+	return len(a.credentials) > 0
+}
+
+func (a *basicAuthenticator) Authenticate(r *http.Request) (*Identity, *Error) {
+	username, password, ok := r.BasicAuth()
+	if !ok {
+		return nil, basicUnauthorized(errors.New("missing basic auth header"))
+	}
+
+	expected, exists := a.credentials[username]
+	if !exists || expected != password {
+		return nil, basicUnauthorized(errors.New("invalid credentials"))
+	}
+
+	return &Identity{Subject: username}, nil
+}
+
+type jwtAuthenticator struct {
+	key    any
+	parser *jwt.Parser
+}
+
+func (a *jwtAuthenticator) Enabled() bool { return true }
+
+func (a *jwtAuthenticator) Authenticate(r *http.Request) (*Identity, *Error) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return nil, bearerUnauthorized("missing authorization header", errors.New("missing authorization header"))
+	}
+
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return nil, bearerUnauthorized("invalid authorization header", errors.New("expected bearer token"))
+	}
+
+	token, err := a.parser.ParseWithClaims(parts[1], jwt.MapClaims{}, func(*jwt.Token) (any, error) {
+		return a.key, nil
+	})
+	if err != nil {
+		return nil, bearerUnauthorized("invalid token", err)
+	}
+	if !token.Valid {
+		return nil, bearerUnauthorized("invalid token", errors.New("token validation failed"))
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, bearerUnauthorized("invalid token", errors.New("token claims unexpected"))
+	}
+
+	subject, _ := claims["sub"].(string)
+
+	return &Identity{Subject: subject, Claims: claims, Token: token}, nil
+}

--- a/internal/app/auth/auth_test.go
+++ b/internal/app/auth/auth_test.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBasicAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(&Config{Provider: "basic", Basic: map[string]string{"user": "pass"}})
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.SetBasicAuth("user", "pass")
+	identity, authErr := a.Authenticate(req)
+	require.Nil(t, authErr)
+	require.NotNil(t, identity)
+	require.Equal(t, "user", identity.Subject)
+
+	badReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	badReq.SetBasicAuth("user", "wrong")
+	_, authErr = a.Authenticate(badReq)
+	require.NotNil(t, authErr)
+	require.Equal(t, http.StatusUnauthorized, authErr.Status)
+}
+
+func TestNewBasicAuthenticatorRequiresCredentials(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(&Config{Provider: "basic"})
+	require.Error(t, err)
+	require.Nil(t, a)
+}
+
+func TestJWTAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{Provider: "jwt", JWT: JWTConfig{Algorithm: "HS256", Issuer: "resonate", Audience: []string{"resonate"}, Key: "secret", ClockSkew: time.Second}}
+	a, err := New(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	token := issueTestToken(t, cfg.JWT, "user")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	identity, authErr := a.Authenticate(req)
+	require.Nil(t, authErr)
+	require.NotNil(t, identity)
+	require.Equal(t, "user", identity.Subject)
+
+	missing := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, authErr = a.Authenticate(missing)
+	require.NotNil(t, authErr)
+	require.Equal(t, http.StatusUnauthorized, authErr.Status)
+}
+
+func TestGinMiddlewareAndRequireHTTP(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(&Config{Provider: "basic", Basic: map[string]string{"user": "pass"}})
+	require.NoError(t, err)
+
+	// Gin middleware should block unauthorized requests
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	middleware := GinMiddleware(a)
+	require.NotNil(t, middleware)
+
+	router.Use(middleware)
+	router.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// RequireHTTP helper should permit authorized requests
+	resp := httptest.NewRecorder()
+	authedReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	authedReq.SetBasicAuth("user", "pass")
+	_, ok := RequireHTTP(a, resp, authedReq)
+	require.True(t, ok)
+	require.Equal(t, http.StatusOK, resp.Code)
+}
+
+func issueTestToken(t *testing.T, cfg JWTConfig, subject string) string {
+	t.Helper()
+
+	claims := jwt.RegisteredClaims{
+		Subject:   subject,
+		Issuer:    cfg.Issuer,
+		Audience:  jwt.ClaimStrings(cfg.Audience),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
+	}
+
+	method := jwt.SigningMethodHS256
+	token := jwt.NewWithClaims(method, claims)
+	signed, err := token.SignedString([]byte(cfg.Key))
+	require.NoError(t, err)
+
+	return signed
+}

--- a/internal/app/auth/config.go
+++ b/internal/app/auth/config.go
@@ -1,0 +1,27 @@
+package auth
+
+import "time"
+
+// Config defines pluggable authentication settings.
+type Config struct {
+	// Provider selects which authentication strategy to enable. Supported values
+	// are "basic" and "jwt". When empty authentication is disabled unless basic
+	// credentials are provided via the Basic field.
+	Provider string `flag:"provider" desc:"auth provider to use (basic,jwt)"`
+	// Basic maintains backwards compatibility with the legacy map based basic
+	// authentication configuration. When populated the provider defaults to
+	// "basic".
+	Basic map[string]string `flag:"-" desc:"http basic auth username password pairs"`
+	// JWT holds JSON web token validation options.
+	JWT JWTConfig `flag:"jwt" desc:"jwt auth settings"`
+}
+
+// JWTConfig represents the configuration required to validate JWT bearer tokens.
+type JWTConfig struct {
+	Algorithm string        `flag:"algorithm" desc:"jwt signing algorithm" default:"HS256"`
+	Audience  []string      `flag:"audience" desc:"expected jwt audiences"`
+	Issuer    string        `flag:"issuer" desc:"expected jwt issuer"`
+	Key       string        `flag:"key" desc:"jwt verification key or shared secret"`
+	KeyFile   string        `flag:"key-file" desc:"path to jwt verification key or shared secret"`
+	ClockSkew time.Duration `flag:"clock-skew" desc:"clock skew tolerance when validating tokens" default:"30s"`
+}

--- a/internal/app/subsystems/api/grpc/grpc.go
+++ b/internal/app/subsystems/api/grpc/grpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 
 	i_api "github.com/resonatehq/resonate/internal/api"
 	"github.com/resonatehq/resonate/internal/app/subsystems/api"
@@ -55,7 +56,7 @@ func (g *Grpc) Kind() string {
 }
 
 func (g *Grpc) Addr() string {
-	return g.listen.Addr().String()
+	return listenAddr(g.listen.Addr())
 }
 
 func (g *Grpc) Start(errors chan<- error) {
@@ -134,4 +135,18 @@ func (s *server) log(ctx context.Context, req interface{}, info *grpc.UnaryServe
 
 	slog.Debug("grpc", "method", info.FullMethod, "error", err)
 	return res, err
+}
+
+func listenAddr(addr net.Addr) string {
+	host, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return addr.String()
+	}
+
+	host = strings.Trim(host, "[]")
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+
+	return net.JoinHostPort(host, port)
 }


### PR DESCRIPTION
## Summary
- add a pluggable authentication package with basic/JWT support plus helpers and tests
- integrate the new authenticator across HTTP and poll subsystems and expose listener helpers
- wire bearer token support through the CLI clients and API tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68f7b95f9458832bb26392f5bd205d19