### PR TITLE
Add resonate tree command

### DIFF
--- a/cmd/promises/promises.go
+++ b/cmd/promises/promises.go
@@ -23,15 +23,15 @@ func NewCmd() *cobra.Command {
 		Use:     "promises",
 		Aliases: []string{"promise"},
 		Short:   "Resonate promises",
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = cmd.Help()
-		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
 
 			return c.Setup(server)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/resonatehq/resonate/cmd/schedules"
 	"github.com/resonatehq/resonate/cmd/serve"
 	"github.com/resonatehq/resonate/cmd/tasks"
+	"github.com/resonatehq/resonate/cmd/tree"
 	"github.com/resonatehq/resonate/internal"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,7 @@ func init() {
 	rootCmd.AddCommand(schedules.NewCmd())
 	rootCmd.AddCommand(serve.NewCmd())
 	rootCmd.AddCommand(tasks.NewCmd())
+	rootCmd.AddCommand(tree.NewCmd())
 
 	// Set default output
 	rootCmd.SetOut(os.Stdout)

--- a/cmd/schedules/schedules.go
+++ b/cmd/schedules/schedules.go
@@ -23,15 +23,15 @@ func NewCmd() *cobra.Command {
 		Use:     "schedules",
 		Aliases: []string{"schedule"},
 		Short:   "Resonate schedules",
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = cmd.Help()
-		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
 
 			return c.Setup(server)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
 		},
 	}
 

--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -84,7 +84,7 @@ func NewCmd() *cobra.Command {
 				}
 			}
 
-			for _, children := range promises {
+			for _, children := range promises { // nosemgrep: range-over-map
 				sort.Slice(children, func(i, j int) bool { return *children[i].CreatedOn < *children[j].CreatedOn })
 			}
 

--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -157,7 +157,7 @@ func details(p *v1.Promise) string {
 	}
 
 	var f string
-	var postfix string
+	var details string
 
 	if p.Param.Data != nil {
 		if b, err := base64.StdEncoding.DecodeString(*p.Param.Data); err == nil {
@@ -173,12 +173,12 @@ func details(p *v1.Promise) string {
 	}
 
 	if p.Tags["resonate:timeout"] != "" {
-		postfix = "(sleep)"
+		details = "(sleep)"
 	} else if p.Tags["resonate:scope"] == "global" {
-		postfix = fmt.Sprintf("(rpc%s)", f)
+		details = fmt.Sprintf("(rpc%s)", f)
 	} else if p.Tags["resonate:scope"] == "local" {
-		postfix = fmt.Sprintf("(run%s)", f)
+		details = fmt.Sprintf("(run%s)", f)
 	}
 
-	return postfix
+	return details
 }

--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -1,0 +1,149 @@
+package tree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/resonatehq/resonate/pkg/client"
+	v1 "github.com/resonatehq/resonate/pkg/client/v1"
+	"github.com/spf13/cobra"
+)
+
+type searchParams struct {
+	id     string
+	root   string
+	cursor *string
+}
+
+func NewCmd() *cobra.Command {
+	var (
+		c        = client.New()
+		server   string
+		username string
+		password string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "tree <id>",
+		Aliases: []string{"tree"},
+		Short:   "Resonate call graph tree",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if username != "" || password != "" {
+				c.SetBasicAuth(username, password)
+			}
+
+			return c.Setup(server)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("must specify an id")
+			}
+
+			searches := []*searchParams{{id: "*", root: args[0]}}
+			promises := map[string][]v1.Promise{}
+
+			for len(searches) > 0 {
+				params := searches[0]
+				searches = searches[1:]
+
+				res, err := c.V1().SearchPromisesWithResponse(context.TODO(), &v1.SearchPromisesParams{
+					Id:     &params.id,
+					Tags:   &map[string]string{"resonate:root": params.root},
+					Cursor: params.cursor,
+				})
+				if err != nil {
+					return err
+				}
+				if res.StatusCode() != 200 {
+					cmd.PrintErrln(res.Status(), string(res.Body))
+					return nil
+				}
+
+				for _, p := range *res.JSON200.Promises {
+					if parent, ok := p.Tags["resonate:parent"]; ok && parent != p.Id {
+						promises[parent] = append(promises[parent], p)
+					}
+
+					if p.Tags["resonate:scope"] == "global" && p.Id != params.root {
+						searches = append(searches, &searchParams{
+							id:     "*",
+							root:   p.Id,
+							cursor: nil,
+						})
+					}
+				}
+
+				if res.JSON200.Cursor != nil {
+					searches = append(searches, &searchParams{
+						id:     params.id,
+						root:   params.root,
+						cursor: res.JSON200.Cursor,
+					})
+				}
+			}
+
+			for _, children := range promises {
+				sort.Slice(children, func(i, j int) bool { return *children[i].CreatedOn < *children[j].CreatedOn })
+			}
+
+			var printTree func(id string, prefix string, postfix string, isLast bool, isRoot bool)
+			printTree = func(id string, prefix string, postfix string, isLast bool, isRoot bool) {
+				var connector string
+
+				if isRoot {
+					connector = ""
+				} else if !isLast {
+					connector = "├── "
+				} else {
+					connector = "└── "
+				}
+
+				// Print the current node
+				cmd.Printf("%s%s%s %s\n", prefix, connector, id, postfix)
+
+				// Recurse into children
+				children := promises[id]
+				for i, child := range children {
+					var newPrefix string
+					var newPostfix string
+
+					if isRoot {
+						newPrefix = prefix
+					} else if !isLast {
+						newPrefix = prefix + "│   "
+					} else {
+						newPrefix = prefix + "    "
+					}
+
+					var f string
+					if child.Tags["resonate:func"] != "" {
+						f = " " + child.Tags["resonate:func"]
+					}
+					if child.Tags["resonate:timeout"] != "" {
+						f = " sleep"
+					}
+
+					if child.Tags["resonate:scope"] == "global" {
+						newPostfix = fmt.Sprintf("(rpc%s)", f)
+					} else {
+						newPostfix = fmt.Sprintf("(run%s)", f)
+					}
+
+					printTree(child.Id, newPrefix, newPostfix, i == len(children)-1, false)
+				}
+			}
+
+			printTree(args[0], "", "", true, true)
+			return nil
+		},
+	}
+
+	// Flags
+	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "resonate url")
+	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "basic auth username")
+	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "basic auth password")
+
+	return cmd
+}


### PR DESCRIPTION
Example usage:
```
❯ resonate tree f1
f1
├── f1.0 (run bar)
│   ├── f1.0.0 (run baz)
│   │   └── f1.0.0.0 (rpc sleep)
│   ├── f1.0.1 (run baz)
│   │   └── f1.0.1.0 (rpc sleep)
│   └── f1.0.2 (run baz)
│       └── f1.0.2.0 (rpc sleep)
├── f1.1 (run bar)
│   ├── f1.1.0 (run baz)
│   │   └── f1.1.0.0 (rpc sleep)
│   ├── f1.1.1 (run baz)
│   │   └── f1.1.1.0 (rpc sleep)
│   └── f1.1.2 (run baz)
│       └── f1.1.2.0 (rpc sleep)
└── f1.2 (run bar)
    ├── f1.2.0 (run baz)
    │   └── f1.2.0.0 (rpc sleep)
    ├── f1.2.1 (run baz)
    │   └── f1.2.1.0 (rpc sleep)
    └── f1.2.2 (run baz)
        └── f1.2.2.0 (rpc sleep)
```