### PR TITLE
Add duration metrics for api, aio, coroutines, and http api subsystem

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -98,10 +98,10 @@ type DisabledSubsystem[T any] struct {
 	Config  T    `flag:"-"`
 }
 
-func (c *Config) APISubsystems(a api.API, pollAddr string) ([]api.Subsystem, error) {
+func (c *Config) APISubsystems(a api.API, metrics *metrics.Metrics, pollAddr string) ([]api.Subsystem, error) {
 	subsystems := []api.Subsystem{}
 	if c.API.Subsystems.Http.Enabled {
-		subsystem, err := http.New(a, &c.API.Subsystems.Http.Config, pollAddr)
+		subsystem, err := http.New(a, metrics, &c.API.Subsystems.Http.Config, pollAddr)
 		if err != nil {
 			return nil, err
 		}
@@ -211,10 +211,10 @@ type AIODSTSubsystems struct {
 	StoreSqlite   EnabledSubsystem[sqlite.Config]    `flag:"store-sqlite"`
 }
 
-func (c *ConfigDST) APISubsystems(a api.API, pollAddr string) ([]api.Subsystem, error) {
+func (c *ConfigDST) APISubsystems(a api.API, metrics *metrics.Metrics, pollAddr string) ([]api.Subsystem, error) {
 	subsystems := []api.Subsystem{}
 	if c.API.Subsystems.Http.Enabled {
-		subsystem, err := http.New(a, &c.API.Subsystems.Http.Config, pollAddr)
+		subsystem, err := http.New(a, metrics, &c.API.Subsystems.Http.Config, pollAddr)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/dst/run.go
+++ b/cmd/dst/run.go
@@ -140,7 +140,7 @@ func RunDSTCmd() *cobra.Command {
 			aio := aio.NewDST(r, p, metrics)
 
 			// api subsystems
-			apiSubsystems, err := config.APISubsystems(api, "")
+			apiSubsystems, err := config.APISubsystems(api, metrics, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -112,7 +112,7 @@ func Serve(config *config.Config) error {
 	}
 
 	// api subsystems
-	apiSubsystems, err := config.APISubsystems(api, pollAddr)
+	apiSubsystems, err := config.APISubsystems(api, metrics, pollAddr)
 	if err != nil {
 		return err
 	}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -56,10 +56,10 @@ Resonate emits the following Prometheus metrics.
 
 ---
 
-## aio_connection
+## aio_plugin_connections
 
 **Type:** Gauge
-**Help:** Number of AIO subsystem connections.
+**Help:** Number of AIO plugin connections.
 
 **Dimensions:**
 - `type`
@@ -127,6 +127,29 @@ Resonate emits the following Prometheus metrics.
 
 **Dimensions:**
 - `type`
+
+---
+
+## http_requests_total
+
+**Type:** Counter
+**Help:** Count of HTTP requests.
+
+**Dimensions:**
+- `method`
+- `path`
+- `status`
+
+---
+
+## http_requests_duration_seconds
+
+**Type:** Histogram
+**Help:** Duration of HTTP requests in seconds.
+
+**Dimensions:**
+- `method`
+- `path`
 
 ---
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,46 +2,158 @@
 
 Resonate emits the following Prometheus metrics.
 
-## aio_total_submissions
+---
 
-The total number of AIO submissions.
+## aio_submissions_total
 
-Dimensions:
-- type
-- status (success/failure)
+**Type:** Counter
+**Help:** Total number of AIO submissions.
 
-## aio_in_flight_submissions
+**Dimensions:**
+- `type`
+- `status` (success/failure)
 
-The current number of in flight AIO submissions.
+---
 
-Dimensions:
-- type
+## aio_submissions_in_flight
 
-## api_total_requests
+**Type:** Gauge
+**Help:** Number of in-flight AIO submissions.
 
-The total number of API requests.
+**Dimensions:**
+- `type`
 
-Dimensions:
-- type
-- status (analagous to http status code)
+---
 
-## api_in_flight_requests
+## aio_duration_seconds
 
-The current number of in flight API requests.
+**Type:** Histogram
+**Help:** Duration of AIO submissions in seconds.
 
-Dimensions:
-- type
+**Dimensions:**
+- `type`
+
+---
+
+## aio_worker_count
+
+**Type:** Gauge
+**Help:** Number of AIO subsystem workers.
+
+**Dimensions:**
+- `type`
+
+---
+
+## aio_worker_submissions_in_flight
+
+**Type:** Gauge
+**Help:** Number of in-flight AIO submissions per worker.
+
+**Dimensions:**
+- `type`
+- `worker`
+
+---
+
+## aio_connection
+
+**Type:** Gauge
+**Help:** Number of AIO subsystem connections.
+
+**Dimensions:**
+- `type`
+
+---
+
+## api_requests_total
+
+**Type:** Counter
+**Help:** Total number of API requests.
+
+**Dimensions:**
+- `type`
+- `protocol`
+- `status` (analogous to HTTP status code)
+
+---
+
+## api_requests_in_flight
+
+**Type:** Gauge
+**Help:** Number of in-flight API requests.
+
+**Dimensions:**
+- `type`
+- `protocol`
+
+---
+
+## api_duration_seconds
+
+**Type:** Histogram
+**Help:** Duration of API requests in seconds.
+
+**Dimensions:**
+- `type`
+- `protocol`
+
+---
 
 ## coroutines_total
 
-The total number of coroutines.
+**Type:** Counter
+**Help:** Total number of coroutines.
 
-Dimensions
-- type
+**Dimensions:**
+- `type`
+
+---
 
 ## coroutines_in_flight
 
-The current number of in flight coroutines.
+**Type:** Gauge
+**Help:** Number of in-flight coroutines.
 
-Dimensions
-- type
+**Dimensions:**
+- `type`
+
+---
+
+## coroutines_seconds
+
+**Type:** Histogram
+**Help:** Duration of coroutines in seconds.
+
+**Dimensions:**
+- `type`
+
+---
+
+## promises_total
+
+**Type:** Counter
+**Help:** Count of promises.
+
+**Dimensions:**
+- `state`
+
+---
+
+## schedules_total
+
+**Type:** Counter
+**Help:** Count of schedules.
+
+**Dimensions:**
+- `state`
+
+---
+
+## tasks_total
+
+**Type:** Counter
+**Help:** Count of tasks.
+
+**Dimensions:**
+- `state`

--- a/internal/aio/aio.go
+++ b/internal/aio/aio.go
@@ -162,7 +162,7 @@ func (a *aio) EnqueueSQE(sqe *bus.SQE[t_aio.Submission, t_aio.Completion]) {
 
 		timer.ObserveDuration()
 		count.Dec()
-		a.metrics.AioTotal.WithLabelValues(sqe.Submission.Kind.String(), status).Inc()
+		a.metrics.AioTotal.WithLabelValues(kind, status).Inc()
 
 		callback(completion, err)
 	}

--- a/internal/app/coroutines/completePromise.go
+++ b/internal/app/coroutines/completePromise.go
@@ -206,11 +206,11 @@ func completePromise(tags map[string]string, fence *task.FencingToken, updatePro
 		util.Assert(createTasksResult.RowsAffected == deleteCallbacksResult.RowsAffected, "created rows must equal deleted rows")
 
 		// count promises
-		metrics.Promises.WithLabelValues(strings.ToLower(updatePromiseCmd.State.String())).Add(float64(updatePromiseResult.RowsAffected))
+		metrics.PromisesTotal.WithLabelValues(strings.ToLower(updatePromiseCmd.State.String())).Add(float64(updatePromiseResult.RowsAffected))
 
 		// count tasks
-		metrics.Tasks.WithLabelValues("created").Add(float64(createTasksResult.RowsAffected))
-		metrics.Tasks.WithLabelValues("completed").Add(float64(completeTasksResult.RowsAffected))
+		metrics.TasksTotal.WithLabelValues("created").Add(float64(createTasksResult.RowsAffected))
+		metrics.TasksTotal.WithLabelValues("completed").Add(float64(completeTasksResult.RowsAffected))
 
 		return updatePromiseResult.RowsAffected == 1, nil
 	}

--- a/internal/app/coroutines/completeTask.go
+++ b/internal/app/coroutines/completeTask.go
@@ -99,7 +99,7 @@ func CompleteTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any],
 				t.CompletedOn = &completedOn
 
 				// count tasks
-				metrics.Tasks.WithLabelValues("completed").Inc()
+				metrics.TasksTotal.WithLabelValues("completed").Inc()
 			} else {
 				// It's possible that the task was modified by another coroutine
 				// while we were trying to complete. In that case, we should just retry.

--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -274,11 +274,11 @@ func createPromise(tags map[string]string, fence *task.FencingToken, promiseCmd 
 			}
 
 			// count promise
-			metrics.Promises.WithLabelValues("created").Inc()
+			metrics.PromisesTotal.WithLabelValues("created").Inc()
 
 			// count task (if applicable)
 			if t != nil {
-				metrics.Tasks.WithLabelValues("created").Inc()
+				metrics.TasksTotal.WithLabelValues("created").Inc()
 			}
 
 			return &promiseAndTask{created: true, promise: p, task: t}, nil

--- a/internal/app/coroutines/createSchedule.go
+++ b/internal/app/coroutines/createSchedule.go
@@ -115,7 +115,7 @@ func CreateSchedule(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any
 			}
 
 			// count schedules
-			metrics.Schedules.WithLabelValues("created").Inc()
+			metrics.SchedulesTotal.WithLabelValues("created").Inc()
 		} else {
 			// It's possible that the schedule was completed by another coroutine
 			// while we were creating. In that case, we should just retry.

--- a/internal/app/coroutines/deleteSchedule.go
+++ b/internal/app/coroutines/deleteSchedule.go
@@ -41,7 +41,7 @@ func DeleteSchedule(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any
 		status = t_api.StatusNoContent
 
 		// count schedules
-		metrics.Schedules.WithLabelValues("deleted").Inc()
+		metrics.SchedulesTotal.WithLabelValues("deleted").Inc()
 	} else {
 		status = t_api.StatusScheduleNotFound
 	}

--- a/internal/app/coroutines/dropTask.go
+++ b/internal/app/coroutines/dropTask.go
@@ -99,7 +99,7 @@ func DropTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any], r *
 				t.ExpiresAt = 0
 
 				// count tasks
-				metrics.Tasks.WithLabelValues("dropped").Inc()
+				metrics.TasksTotal.WithLabelValues("dropped").Inc()
 			} else {
 				// It's possible that the task was modified by another coroutine
 				// while we were trying to complete. In that case, we should just retry.

--- a/internal/app/coroutines/enqueueTasks.go
+++ b/internal/app/coroutines/enqueueTasks.go
@@ -250,10 +250,10 @@ func EnqueueTasks(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any],
 			util.Assert(result.RowsAffected == 0 || result.RowsAffected == 1, "result must return 0 or 1 rows")
 
 			if command.State == task.Completed && result.RowsAffected == 1 {
-				metrics.Tasks.WithLabelValues("completed").Inc()
+				metrics.TasksTotal.WithLabelValues("completed").Inc()
 			}
 			if command.State == task.Timedout && result.RowsAffected == 1 {
-				metrics.Tasks.WithLabelValues("timedout").Inc()
+				metrics.TasksTotal.WithLabelValues("timedout").Inc()
 			}
 		}
 	}

--- a/internal/app/coroutines/timeoutTasks.go
+++ b/internal/app/coroutines/timeoutTasks.go
@@ -101,7 +101,7 @@ func TimeoutTasks(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any],
 			util.Assert(result.RowsAffected == 0 || result.RowsAffected == 1, "result must return 0 or 1 rows")
 
 			if command.State == task.Timedout && result.RowsAffected == 1 {
-				metrics.Tasks.WithLabelValues("timedout").Inc()
+				metrics.TasksTotal.WithLabelValues("timedout").Inc()
 			}
 		}
 	}

--- a/internal/app/plugins/poll/poll.go
+++ b/internal/app/plugins/poll/poll.go
@@ -162,7 +162,7 @@ func New(a aio.AIO, metrics *metrics.Metrics, config *Config) (*Poll, error) {
 		server: &http.Server{Handler: handler},
 	}
 
-	counter := metrics.AioConnection.WithLabelValues((&Poll{}).String())
+	counter := metrics.AioPluginConnections.WithLabelValues((&Poll{}).String())
 
 	worker := &PollWorker{
 		sq:         sq,

--- a/internal/app/subsystems/api/http/http_test.go
+++ b/internal/app/subsystems/api/http/http_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/resonatehq/resonate/internal/api"
 	"github.com/resonatehq/resonate/internal/app/subsystems/api/test"
+	"github.com/resonatehq/resonate/internal/metrics"
 	"github.com/resonatehq/resonate/internal/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,8 +25,9 @@ type httpTest struct {
 
 func setup(auth map[string]string) (*httpTest, error) {
 	api := &test.API{}
+	metrics := metrics.New(prometheus.NewRegistry())
 	errors := make(chan error)
-	subsystem, err := New(api, &Config{
+	subsystem, err := New(api, metrics, &Config{
 		Addr:          ":0",
 		Auth:          auth,
 		Timeout:       1 * time.Second,

--- a/internal/kernel/system/system.go
+++ b/internal/kernel/system/system.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/resonatehq/gocoro"
 	"github.com/resonatehq/gocoro/pkg/promise"
 	"github.com/resonatehq/resonate/internal/aio"
@@ -197,6 +198,9 @@ func (s *System) AddOnRequest(kind t_api.Kind, constructor func(gocoro.Coroutine
 			// set metrics
 			c.Set("metrics", s.metrics)
 
+			timer := prometheus.NewTimer(s.metrics.CoroutinesDuration.WithLabelValues(kind.String()))
+			defer timer.ObserveDuration()
+
 			// run coroutine
 			res, err := constructor(c, req)
 
@@ -222,6 +226,9 @@ func (s *System) AddBackground(name string, constructor func(gocoro.Coroutine[*t
 
 				// set metrics
 				c.Set("metrics", s.metrics)
+
+				timer := prometheus.NewTimer(s.metrics.CoroutinesDuration.WithLabelValues(name))
+				defer timer.ObserveDuration()
 
 				// run coroutine
 				return constructor(c, m)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -15,9 +15,9 @@ type Metrics struct {
 	CoroutinesTotal    *prometheus.CounterVec
 	CoroutinesInFlight *prometheus.GaugeVec
 	CoroutinesDuration *prometheus.HistogramVec
-	Promises           *prometheus.CounterVec
-	Schedules          *prometheus.CounterVec
-	Tasks              *prometheus.CounterVec
+	PromisesTotal      *prometheus.CounterVec
+	SchedulesTotal     *prometheus.CounterVec
+	TasksTotal         *prometheus.CounterVec
 }
 
 func New(reg prometheus.Registerer) *Metrics {
@@ -73,17 +73,17 @@ func New(reg prometheus.Registerer) *Metrics {
 			Help:    "duration of coroutines in seconds",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"type"}),
-		Promises: prometheus.NewCounterVec(prometheus.CounterOpts{
+		PromisesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "promises_total",
 			Help: "count of promises",
 		}, []string{"state"}),
-		Schedules: prometheus.NewCounterVec(prometheus.CounterOpts{
+		SchedulesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "schedules_total",
-			Help: "number of schedules",
+			Help: "count of schedules",
 		}, []string{"state"}),
-		Tasks: prometheus.NewCounterVec(prometheus.CounterOpts{
+		TasksTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "tasks_total",
-			Help: "number of tasks",
+			Help: "count of tasks",
 		}, []string{"state"}),
 	}
 
@@ -104,9 +104,9 @@ func (m *Metrics) Enable(reg prometheus.Registerer) {
 	reg.MustRegister(m.CoroutinesTotal)
 	reg.MustRegister(m.CoroutinesInFlight)
 	reg.MustRegister(m.CoroutinesDuration)
-	reg.MustRegister(m.Promises)
-	reg.MustRegister(m.Schedules)
-	reg.MustRegister(m.Tasks)
+	reg.MustRegister(m.PromisesTotal)
+	reg.MustRegister(m.SchedulesTotal)
+	reg.MustRegister(m.TasksTotal)
 }
 
 func (m *Metrics) Disable(reg prometheus.Registerer) {
@@ -122,7 +122,7 @@ func (m *Metrics) Disable(reg prometheus.Registerer) {
 	reg.Unregister(m.CoroutinesTotal)
 	reg.Unregister(m.CoroutinesInFlight)
 	reg.Unregister(m.CoroutinesDuration)
-	reg.Unregister(m.Promises)
-	reg.Unregister(m.Schedules)
-	reg.Unregister(m.Tasks)
+	reg.Unregister(m.PromisesTotal)
+	reg.Unregister(m.SchedulesTotal)
+	reg.Unregister(m.TasksTotal)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,13 +5,16 @@ import "github.com/prometheus/client_golang/prometheus"
 type Metrics struct {
 	AioTotal           *prometheus.CounterVec
 	AioInFlight        *prometheus.GaugeVec
+	AioDuration        *prometheus.HistogramVec
 	AioWorker          *prometheus.GaugeVec
 	AioWorkerInFlight  *prometheus.GaugeVec
 	AioConnection      *prometheus.GaugeVec
 	ApiTotal           *prometheus.CounterVec
 	ApiInFlight        *prometheus.GaugeVec
+	ApiDuration        *prometheus.HistogramVec
 	CoroutinesTotal    *prometheus.CounterVec
 	CoroutinesInFlight *prometheus.GaugeVec
+	CoroutinesDuration *prometheus.HistogramVec
 	Promises           *prometheus.CounterVec
 	Schedules          *prometheus.CounterVec
 	Tasks              *prometheus.CounterVec
@@ -20,19 +23,24 @@ type Metrics struct {
 func New(reg prometheus.Registerer) *Metrics {
 	metrics := &Metrics{
 		AioTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "aio_total_submissions",
+			Name: "aio_submissions_total",
 			Help: "total number of aio submissions",
 		}, []string{"type", "status"}),
 		AioInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "aio_in_flight_submissions",
+			Name: "aio_submissions_in_flight",
 			Help: "number of in flight aio submissions",
+		}, []string{"type"}),
+		AioDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "aio_duration_seconds",
+			Help:    "duration of aio submissions in seconds",
+			Buckets: prometheus.DefBuckets,
 		}, []string{"type"}),
 		AioWorker: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "aio_worker_count",
 			Help: "number of aio subsystem workers",
 		}, []string{"type"}),
 		AioWorkerInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "aio_worker_in_flight_submissions",
+			Name: "aio_worker_submissions_in_flight",
 			Help: "number of in flight aio submissions",
 		}, []string{"type", "worker"}),
 		AioConnection: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -40,12 +48,17 @@ func New(reg prometheus.Registerer) *Metrics {
 			Help: "number of aio subsystem connections",
 		}, []string{"type"}),
 		ApiTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "api_total_requests",
+			Name: "api_requests_total",
 			Help: "total number of api requests",
 		}, []string{"type", "protocol", "status"}),
 		ApiInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "api_in_flight_requests",
+			Name: "api_requests_in_flight",
 			Help: "number of in flight api requests",
+		}, []string{"type", "protocol"}),
+		ApiDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "api_duration_seconds",
+			Help:    "duration of api requests in seconds",
+			Buckets: prometheus.DefBuckets,
 		}, []string{"type", "protocol"}),
 		CoroutinesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "coroutines_total",
@@ -55,16 +68,21 @@ func New(reg prometheus.Registerer) *Metrics {
 			Name: "coroutines_in_flight",
 			Help: "number of in flight coroutines",
 		}, []string{"type"}),
+		CoroutinesDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "coroutines_seconds",
+			Help:    "duration of coroutines in seconds",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"type"}),
 		Promises: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "promises",
+			Name: "promises_total",
 			Help: "count of promises",
 		}, []string{"state"}),
 		Schedules: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "schedules",
+			Name: "schedules_total",
 			Help: "number of schedules",
 		}, []string{"state"}),
 		Tasks: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "tasks",
+			Name: "tasks_total",
 			Help: "number of tasks",
 		}, []string{"state"}),
 	}
@@ -76,13 +94,16 @@ func New(reg prometheus.Registerer) *Metrics {
 func (m *Metrics) Enable(reg prometheus.Registerer) {
 	reg.MustRegister(m.AioTotal)
 	reg.MustRegister(m.AioInFlight)
+	reg.MustRegister(m.AioDuration)
 	reg.MustRegister(m.AioWorker)
 	reg.MustRegister(m.AioWorkerInFlight)
 	reg.MustRegister(m.AioConnection)
 	reg.MustRegister(m.ApiTotal)
 	reg.MustRegister(m.ApiInFlight)
+	reg.MustRegister(m.ApiDuration)
 	reg.MustRegister(m.CoroutinesTotal)
 	reg.MustRegister(m.CoroutinesInFlight)
+	reg.MustRegister(m.CoroutinesDuration)
 	reg.MustRegister(m.Promises)
 	reg.MustRegister(m.Schedules)
 	reg.MustRegister(m.Tasks)
@@ -91,13 +112,16 @@ func (m *Metrics) Enable(reg prometheus.Registerer) {
 func (m *Metrics) Disable(reg prometheus.Registerer) {
 	reg.Unregister(m.AioTotal)
 	reg.Unregister(m.AioInFlight)
+	reg.Unregister(m.AioDuration)
 	reg.Unregister(m.AioWorker)
 	reg.Unregister(m.AioWorkerInFlight)
 	reg.Unregister(m.AioConnection)
 	reg.Unregister(m.ApiTotal)
 	reg.Unregister(m.ApiInFlight)
+	reg.Unregister(m.ApiDuration)
 	reg.Unregister(m.CoroutinesTotal)
 	reg.Unregister(m.CoroutinesInFlight)
+	reg.Unregister(m.CoroutinesDuration)
 	reg.Unregister(m.Promises)
 	reg.Unregister(m.Schedules)
 	reg.Unregister(m.Tasks)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -3,21 +3,23 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 type Metrics struct {
-	AioTotal           *prometheus.CounterVec
-	AioInFlight        *prometheus.GaugeVec
-	AioDuration        *prometheus.HistogramVec
-	AioWorker          *prometheus.GaugeVec
-	AioWorkerInFlight  *prometheus.GaugeVec
-	AioConnection      *prometheus.GaugeVec
-	ApiTotal           *prometheus.CounterVec
-	ApiInFlight        *prometheus.GaugeVec
-	ApiDuration        *prometheus.HistogramVec
-	CoroutinesTotal    *prometheus.CounterVec
-	CoroutinesInFlight *prometheus.GaugeVec
-	CoroutinesDuration *prometheus.HistogramVec
-	PromisesTotal      *prometheus.CounterVec
-	SchedulesTotal     *prometheus.CounterVec
-	TasksTotal         *prometheus.CounterVec
+	AioTotal             *prometheus.CounterVec
+	AioInFlight          *prometheus.GaugeVec
+	AioDuration          *prometheus.HistogramVec
+	AioWorker            *prometheus.GaugeVec
+	AioWorkerInFlight    *prometheus.GaugeVec
+	AioPluginConnections *prometheus.GaugeVec
+	ApiTotal             *prometheus.CounterVec
+	ApiInFlight          *prometheus.GaugeVec
+	ApiDuration          *prometheus.HistogramVec
+	CoroutinesTotal      *prometheus.CounterVec
+	CoroutinesInFlight   *prometheus.GaugeVec
+	CoroutinesDuration   *prometheus.HistogramVec
+	HttpRequestsTotal    *prometheus.CounterVec
+	HttpRequestsDuration *prometheus.HistogramVec
+	PromisesTotal        *prometheus.CounterVec
+	SchedulesTotal       *prometheus.CounterVec
+	TasksTotal           *prometheus.CounterVec
 }
 
 func New(reg prometheus.Registerer) *Metrics {
@@ -43,9 +45,9 @@ func New(reg prometheus.Registerer) *Metrics {
 			Name: "aio_worker_submissions_in_flight",
 			Help: "number of in flight aio submissions",
 		}, []string{"type", "worker"}),
-		AioConnection: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "aio_connection",
-			Help: "number of aio subsystem connections",
+		AioPluginConnections: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "aio_plugin_connections",
+			Help: "number of aio plugin connections",
 		}, []string{"type"}),
 		ApiTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "api_requests_total",
@@ -73,6 +75,15 @@ func New(reg prometheus.Registerer) *Metrics {
 			Help:    "duration of coroutines in seconds",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"type"}),
+		HttpRequestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "http_requests_total",
+			Help: "count of http requests",
+		}, []string{"method", "path", "status"}),
+		HttpRequestsDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_requests_duration_seconds",
+			Help:    "duration of http requests in seconds",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"method", "path"}),
 		PromisesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "promises_total",
 			Help: "count of promises",
@@ -97,13 +108,15 @@ func (m *Metrics) Enable(reg prometheus.Registerer) {
 	reg.MustRegister(m.AioDuration)
 	reg.MustRegister(m.AioWorker)
 	reg.MustRegister(m.AioWorkerInFlight)
-	reg.MustRegister(m.AioConnection)
+	reg.MustRegister(m.AioPluginConnections)
 	reg.MustRegister(m.ApiTotal)
 	reg.MustRegister(m.ApiInFlight)
 	reg.MustRegister(m.ApiDuration)
 	reg.MustRegister(m.CoroutinesTotal)
 	reg.MustRegister(m.CoroutinesInFlight)
 	reg.MustRegister(m.CoroutinesDuration)
+	reg.MustRegister(m.HttpRequestsTotal)
+	reg.MustRegister(m.HttpRequestsDuration)
 	reg.MustRegister(m.PromisesTotal)
 	reg.MustRegister(m.SchedulesTotal)
 	reg.MustRegister(m.TasksTotal)
@@ -115,13 +128,15 @@ func (m *Metrics) Disable(reg prometheus.Registerer) {
 	reg.Unregister(m.AioDuration)
 	reg.Unregister(m.AioWorker)
 	reg.Unregister(m.AioWorkerInFlight)
-	reg.Unregister(m.AioConnection)
+	reg.Unregister(m.AioPluginConnections)
 	reg.Unregister(m.ApiTotal)
 	reg.Unregister(m.ApiInFlight)
 	reg.Unregister(m.ApiDuration)
 	reg.Unregister(m.CoroutinesTotal)
 	reg.Unregister(m.CoroutinesInFlight)
 	reg.Unregister(m.CoroutinesDuration)
+	reg.Unregister(m.HttpRequestsTotal)
+	reg.Unregister(m.HttpRequestsDuration)
 	reg.Unregister(m.PromisesTotal)
 	reg.Unregister(m.SchedulesTotal)
 	reg.Unregister(m.TasksTotal)


### PR DESCRIPTION
Grafana shows a warning when a counter metric name does not end with `_counter` (or some other suffixes). This PR also renames metrics that don't abide by this rule in order to suppress the warning.