### PR TITLE
Clean up flag shorthands

### DIFF
--- a/cmd/invoke/invoke.go
+++ b/cmd/invoke/invoke.go
@@ -54,7 +54,6 @@ func NewCmd() *cobra.Command {
 			if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
-
 			if token != "" {
 				c.SetBearerToken(token)
 			}
@@ -137,17 +136,18 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&funcName, "func", "", "function to invoke")
-	cmd.Flags().StringArrayVarP(&args, "arg", "a", []string{}, "function argument, can be provided multiple times")
-	cmd.Flags().StringVar(&jsonArgs, "json-args", "", "function arguments as json array")
-	cmd.Flags().IntVar(&version, "version", 1, "function version")
-	cmd.Flags().DurationVar(&timeout, "timeout", time.Hour, "promise timeout")
-	cmd.Flags().StringVar(&target, "target", "poll://any@default", "invoke target")
-	cmd.Flags().DurationVar(&delay, "delay", 0, "promise delay")
-	cmd.Flags().StringVar(&server, "server", "http://localhost:8001", "resonate server url")
+	cmd.Flags().StringVarP(&server, "server", "S", "http://localhost:8001", "resonate server url")
+	cmd.Flags().StringVarP(&token, "token", "T", "", "JWT bearer token")
 	cmd.Flags().StringVarP(&username, "username", "U", "", "basic auth username")
 	cmd.Flags().StringVarP(&password, "password", "P", "", "basic auth password")
-	cmd.Flags().StringVarP(&token, "token", "J", "", "JWT bearer token")
+
+	cmd.Flags().StringVarP(&funcName, "func", "f", "", "function to invoke")
+	cmd.Flags().StringArrayVar(&args, "arg", []string{}, "function argument, can be provided multiple times")
+	cmd.Flags().StringVar(&jsonArgs, "json-args", "", "function arguments as json array")
+	cmd.Flags().IntVar(&version, "version", 1, "function version")
+	cmd.Flags().DurationVarP(&timeout, "timeout", "t", time.Hour, "promise timeout")
+	cmd.Flags().StringVar(&target, "target", "poll://any@default", "invoke target")
+	cmd.Flags().DurationVar(&delay, "delay", 0, "promise delay")
 
 	cmd.Flags().SortFlags = false
 	_ = cmd.MarkFlagRequired("func")

--- a/cmd/projects/list.go
+++ b/cmd/projects/list.go
@@ -1,7 +1,6 @@
 package projects
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -31,7 +30,7 @@ func ListProjectCmd() *cobra.Command {
 				templates = filterByLang(templates, lang)
 			}
 
-			display(templates)
+			display(cmd, templates)
 			return nil
 		},
 	}
@@ -43,12 +42,12 @@ func ListProjectCmd() *cobra.Command {
 	return cmd
 }
 
-func display(templates Projects) {
-	fmt.Printf("\n✨ Available templates ✨\n\n")
+func display(cmd *cobra.Command, templates Projects) {
+	cmd.Printf("\n✨ Available templates ✨\n\n")
 	for name, t := range templates {
-		fmt.Printf("✨ %s\n\n\t%s\n\n", name, t.Desc)
-		fmt.Printf("\tTo use this template, run:\n\n")
-		fmt.Printf("\tresonate project create --name your-project --template %s\n\n", name)
+		cmd.Printf("✨ %s\n\n\t%s\n\n", name, t.Desc)
+		cmd.Printf("\tTo use this template, run:\n\n")
+		cmd.Printf("\tresonate project create --name your-project --template %s\n\n", name)
 	}
 }
 

--- a/cmd/promises/callback.go
+++ b/cmd/promises/callback.go
@@ -85,9 +85,9 @@ func CreatePromiseCallbackCmd(c client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&rootPromiseId, "root-promise-id", "", "root promise id")
+	cmd.Flags().StringVarP(&rootPromiseId, "root-promise-id", "p", "", "root promise id")
+	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "task timeout")
 	cmd.Flags().StringVar(&recvStr, "recv", "default", "task receiver")
-	cmd.Flags().DurationVar(&timeout, "timeout", 0, "task timeout")
 
 	_ = cmd.MarkFlagRequired("root-promise-id")
 	_ = cmd.MarkFlagRequired("timeout")

--- a/cmd/promises/complete.go
+++ b/cmd/promises/complete.go
@@ -90,13 +90,10 @@ func CompletePromiseCmds(c client.Client) []*cobra.Command {
 			},
 		}
 
-		cmd.Flags().StringToStringVarP(&headers, "header", "H", map[string]string{}, "promise value header")
-		cmd.Flags().StringVarP(&data, "data", "D", "", "promise value data")
-		cmd.Flags().StringVarP(&idempotencyKey, "idempotency-key", "i", "", "idempotency key")
-		cmd.Flags().BoolVarP(&strict, "strict", "s", true, "strict mode")
-
-		_ = cmd.MarkFlagRequired("id")
-		_ = cmd.MarkFlagRequired("state")
+		cmd.Flags().StringToStringVar(&headers, "header", map[string]string{}, "promise value header")
+		cmd.Flags().StringVar(&data, "data", "", "promise value data")
+		cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "idempotency key")
+		cmd.Flags().BoolVar(&strict, "strict", true, "strict mode")
 
 		cmds[i] = cmd
 	}

--- a/cmd/promises/create.go
+++ b/cmd/promises/create.go
@@ -84,11 +84,11 @@ func CreatePromiseCmd(c client.Client) *cobra.Command {
 	}
 
 	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "promise timeout")
-	cmd.Flags().StringToStringVarP(&headers, "header", "H", map[string]string{}, "promise param header")
-	cmd.Flags().StringVarP(&data, "data", "D", "", "promise param data")
-	cmd.Flags().StringToStringVarP(&tags, "tag", "T", map[string]string{}, "promise tags")
-	cmd.Flags().StringVarP(&idempotencyKey, "idempotency-key", "i", "", "idempotency key")
-	cmd.Flags().BoolVarP(&strict, "strict", "s", true, "strict mode")
+	cmd.Flags().StringToStringVar(&headers, "header", map[string]string{}, "promise param header")
+	cmd.Flags().StringVar(&data, "data", "", "promise param data")
+	cmd.Flags().StringToStringVar(&tags, "tag", map[string]string{}, "promise tags")
+	cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "idempotency key")
+	cmd.Flags().BoolVar(&strict, "strict", true, "strict mode")
 
 	_ = cmd.MarkFlagRequired("timeout")
 

--- a/cmd/promises/promises.go
+++ b/cmd/promises/promises.go
@@ -28,7 +28,6 @@ func NewCmd() *cobra.Command {
 			if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
-
 			if token != "" {
 				c.SetBearerToken(token)
 			}
@@ -49,10 +48,10 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(CreateSubscriptionCmd(c))
 
 	// Flags
-	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "resonate url")
+	cmd.PersistentFlags().StringVarP(&server, "server", "S", "http://localhost:8001", "resonate url")
+	cmd.PersistentFlags().StringVarP(&token, "token", "T", "", "JWT bearer token")
 	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "basic auth username")
 	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "basic auth password")
-	cmd.PersistentFlags().StringVarP(&token, "token", "J", "", "JWT bearer token")
 
 	return cmd
 }

--- a/cmd/promises/search.go
+++ b/cmd/promises/search.go
@@ -92,10 +92,10 @@ func SearchPromisesCmd(c client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&state, "state", "s", "", "promise state, can be one of: pending, resolved, rejected")
-	cmd.Flags().StringToStringVarP(&tags, "tag", "T", map[string]string{}, "promise tags")
-	cmd.Flags().IntVarP(&limit, "limit", "l", 100, "results per page")
-	cmd.Flags().StringVarP(&cursor, "cursor", "c", "", "pagination cursor")
+	cmd.Flags().StringVar(&state, "state", "", "promise state, can be one of: pending, resolved, rejected")
+	cmd.Flags().StringToStringVar(&tags, "tag", map[string]string{}, "promise tags")
+	cmd.Flags().IntVar(&limit, "limit", 100, "results per page")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor")
 	cmd.Flags().StringVarP(&output, "output", "o", "", "output format, can be one of: json")
 
 	return cmd

--- a/cmd/promises/subscribe.go
+++ b/cmd/promises/subscribe.go
@@ -85,9 +85,9 @@ func CreateSubscriptionCmd(c client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&id, "id", "", "subscription id")
+	cmd.Flags().StringVarP(&id, "id", "i", "", "subscription id")
+	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "task timeout")
 	cmd.Flags().StringVar(&recvStr, "recv", "default", "task receiver")
-	cmd.Flags().DurationVar(&timeout, "timeout", 0, "task timeout")
 
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("timeout")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,6 @@ var rootCmd = &cobra.Command{
 func init() {
 	// Create config
 	cfg := &config.Config{}
-	vip := viper.New()
 
 	// Add Subsystems
 	cfg.API.Subsystems.Add("http", true, &http.Config{})
@@ -57,14 +56,14 @@ func init() {
 	cfg.AIO.Plugins.Add("kafka", false, &kafkaPlugin.Config{})
 
 	// Add Subcommands
-	rootCmd.AddCommand(dev.NewCmd(cfg, vip))
+	rootCmd.AddCommand(dev.NewCmd(cfg, viper.New()))
 	rootCmd.AddCommand(dst.NewCmd())
 	rootCmd.AddCommand(invoke.NewCmd())
-	rootCmd.AddCommand(migrate.NewCmd(cfg, vip))
+	rootCmd.AddCommand(migrate.NewCmd(cfg, viper.New()))
 	rootCmd.AddCommand(projects.NewCmd())
 	rootCmd.AddCommand(promises.NewCmd())
 	rootCmd.AddCommand(schedules.NewCmd())
-	rootCmd.AddCommand(serve.NewCmd(cfg, vip))
+	rootCmd.AddCommand(serve.NewCmd(cfg, viper.New()))
 	rootCmd.AddCommand(tasks.NewCmd())
 	rootCmd.AddCommand(tree.NewCmd())
 

--- a/cmd/schedules/create.go
+++ b/cmd/schedules/create.go
@@ -88,11 +88,11 @@ func CreateScheduleCmd(c client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&description, "description", "d", "", "schedule description")
 	cmd.Flags().StringVarP(&cron, "cron", "c", "", "schedule cron expression")
-	cmd.Flags().StringToStringVarP(&tags, "tag", "T", map[string]string{}, "schedule tags")
-	cmd.Flags().StringVar(&promiseId, "promise-id", "", "templated schedule id, can include {{.timestamp}}")
-	cmd.Flags().DurationVar(&promiseTimeout, "promise-timeout", 0, "promise timeout")
+	cmd.Flags().StringVarP(&promiseId, "promise-id", "i", "", "templated schedule id, can include {{.timestamp}}")
+	cmd.Flags().DurationVarP(&promiseTimeout, "promise-timeout", "t", 0, "promise timeout")
+	cmd.Flags().StringVar(&description, "description", "", "schedule description")
+	cmd.Flags().StringToStringVar(&tags, "tag", map[string]string{}, "schedule tags")
 	cmd.Flags().StringToStringVar(&promiseHeaders, "promise-header", map[string]string{}, "promise param header")
 	cmd.Flags().StringVar(&promiseData, "promise-data", "", "promise param data")
 	cmd.Flags().StringToStringVar(&promiseTags, "promise-tag", map[string]string{}, "promise tags")

--- a/cmd/schedules/schedules.go
+++ b/cmd/schedules/schedules.go
@@ -28,7 +28,6 @@ func NewCmd() *cobra.Command {
 			if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
-
 			if token != "" {
 				c.SetBearerToken(token)
 			}
@@ -47,10 +46,10 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(DeleteScheduleCmd(c))
 
 	// Flags
-	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "resonate url")
+	cmd.PersistentFlags().StringVarP(&server, "server", "S", "http://localhost:8001", "resonate url")
+	cmd.PersistentFlags().StringVarP(&token, "token", "T", "", "JWT bearer token")
 	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "basic auth username")
 	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "basic auth password")
-	cmd.PersistentFlags().StringVarP(&token, "token", "J", "", "JWT bearer token")
 
 	return cmd
 }

--- a/cmd/schedules/search.go
+++ b/cmd/schedules/search.go
@@ -77,9 +77,9 @@ func SearchSchedulesCmd(c client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringToStringVarP(&tags, "tag", "T", map[string]string{}, "schedule tags")
-	cmd.Flags().IntVarP(&limit, "limit", "l", 100, "results per page")
-	cmd.Flags().StringVarP(&cursor, "cursor", "c", "", "pagination cursor")
+	cmd.Flags().StringToStringVar(&tags, "tag", map[string]string{}, "schedule tags")
+	cmd.Flags().IntVar(&limit, "limit", 100, "results per page")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor")
 	cmd.Flags().StringVarP(&output, "output", "o", "", "output format, can be one of: json")
 
 	return cmd

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -49,16 +49,6 @@ func NewCmd(cfg *config.Config, vip *viper.Viper) *cobra.Command {
 				}
 			}
 
-			// TODO: find a more flexible solution
-			// if multiple stores are enabled, postgres takes precedence, we
-			// need a different strategy if more than two stores are supported
-			// sFlag := cmd.PersistentFlags().Lookup("aio-store-sqlite-enable")
-			// pFlag := cmd.PersistentFlags().Lookup("aio-store-postgres-enable")
-			// if sFlag != nil && pFlag != nil && sFlag.Value.String() == "true" && pFlag.Value.String() == "true" {
-			// 	// postgres takes precedence
-			// 	_ = sFlag.Value.Set("false")
-			// }
-
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/tasks/claim.go
+++ b/cmd/tasks/claim.go
@@ -75,11 +75,10 @@ func ClaimTaskCmd(c client.Client) *cobra.Command {
 
 	// Define command flags
 	cmd.Flags().IntVarP(&counter, "counter", "c", 0, "task counter")
-	cmd.Flags().StringVarP(&pid, "pid", "p", "default", "claimant pid")
-	cmd.Flags().DurationVarP(&ttl, "ttl", "t", time.Minute, "task ttl, time before which a heartbeat must be sent")
+	cmd.Flags().StringVar(&pid, "pid", "default", "claimant pid")
+	cmd.Flags().DurationVar(&ttl, "ttl", time.Minute, "task ttl, time before which a heartbeat must be sent")
 
 	// Mark flags as required
-	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("counter")
 
 	return cmd

--- a/cmd/tasks/complete.go
+++ b/cmd/tasks/complete.go
@@ -66,7 +66,6 @@ func CompleteTaskCmd(c client.Client) *cobra.Command {
 	cmd.Flags().IntVarP(&counter, "counter", "c", 0, "task counter")
 
 	// Mark flags as required
-	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("counter")
 
 	return cmd

--- a/cmd/tasks/heartbeat.go
+++ b/cmd/tasks/heartbeat.go
@@ -53,7 +53,7 @@ func HeartbeatTaskCmd(c client.Client) *cobra.Command {
 	}
 
 	// Define command flags
-	cmd.Flags().StringVarP(&pid, "pid", "p", "default", "claimant pid")
+	cmd.Flags().StringVar(&pid, "pid", "default", "claimant pid")
 
 	return cmd
 }

--- a/cmd/tasks/tasks.go
+++ b/cmd/tasks/tasks.go
@@ -29,6 +29,7 @@ func NewCmd() *cobra.Command {
 			if token != "" {
 				c.SetBearerToken(token)
 			}
+
 			return c.Setup(server)
 		},
 	}
@@ -39,10 +40,10 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(HeartbeatTaskCmd(c)) // Heartbeat task subcommand
 
 	// Flags
-	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "Resonate server URL")
-	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "Basic auth username")
-	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "Basic auth password")
-	cmd.PersistentFlags().StringVarP(&token, "token", "J", "", "JWT bearer token")
+	cmd.PersistentFlags().StringVarP(&server, "server", "S", "http://localhost:8001", "resonate url")
+	cmd.PersistentFlags().StringVarP(&token, "token", "T", "", "JWT bearer token")
+	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "basic auth username")
+	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "basic auth password")
 
 	return cmd
 }

--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -36,7 +36,6 @@ func NewCmd() *cobra.Command {
 			if username != "" || password != "" {
 				c.SetBasicAuth(username, password)
 			}
-
 			if token != "" {
 				c.SetBearerToken(token)
 			}
@@ -149,10 +148,10 @@ func NewCmd() *cobra.Command {
 	}
 
 	// Flags
-	cmd.PersistentFlags().StringVarP(&server, "server", "", "http://localhost:8001", "resonate url")
-	cmd.PersistentFlags().StringVarP(&username, "username", "U", "", "basic auth username")
-	cmd.PersistentFlags().StringVarP(&password, "password", "P", "", "basic auth password")
-	cmd.PersistentFlags().StringVarP(&token, "token", "J", "", "JWT bearer token")
+	cmd.Flags().StringVarP(&server, "server", "S", "http://localhost:8001", "resonate server url")
+	cmd.Flags().StringVarP(&token, "token", "T", "", "JWT bearer token")
+	cmd.Flags().StringVarP(&username, "username", "U", "", "basic auth username")
+	cmd.Flags().StringVarP(&password, "password", "P", "", "basic auth password")
 
 	return cmd
 }

--- a/internal/app/subsystems/api/http/http.go
+++ b/internal/app/subsystems/api/http/http.go
@@ -206,7 +206,7 @@ func New(a i_api.API, metrics *metrics.Metrics, config *Config) (i_api.Subsystem
 			if auth := c.GetString("authorization"); auth != "" {
 				metadata["authorization"] = auth
 			}
-			_, err := server.api.Process("", &t_api.Request{
+			_, err := server.api.Process(c.GetHeader("RequestId"), &t_api.Request{
 				Metadata: metadata,
 				Payload:  &t_api.NoopRequest{},
 			})


### PR DESCRIPTION
Consolidate server flags as:
- server (S)
- token (T)
- username (U)
- password (P)

In general required flags get a shorthand and non-required flags do not. This cuts down on conflicts and opens up the `T` shorthand for token (as opposed to tag).