### PR TITLE
chore: remove unsupported nix artifact

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake


### PR DESCRIPTION
As communicated in the community Discord server, there is no intention to support Nix within this repository. However, there is a leftover file from when Nix was supported.

This PR deletes `.envrc`, which is only used to use a Nix flake which does not exist anymore.