### PR TITLE
feat(api): add ping health endpoints

### DIFF
--- a/internal/app/subsystems/api/grpc/grpc.go
+++ b/internal/app/subsystems/api/grpc/grpc.go
@@ -18,6 +18,8 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Config struct {
@@ -70,6 +72,10 @@ func New(a i_api.API, config *Config) (i_api.Subsystem, error) {
 	pb.RegisterSchedulesServer(server, s)
 	pb.RegisterLocksServer(server, s)
 	pb.RegisterTasksServer(server, s)
+
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, healthServer)
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 
 	return &Grpc{
 		config: config,

--- a/internal/app/subsystems/api/grpc/grpc_test.go
+++ b/internal/app/subsystems/api/grpc/grpc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -27,6 +28,7 @@ type grpcTest struct {
 	schedules pb.SchedulesClient
 	locks     pb.LocksClient
 	tasks     pb.TasksClient
+	health    grpc_health_v1.HealthClient
 }
 
 func setup() (*grpcTest, error) {
@@ -55,6 +57,7 @@ func setup() (*grpcTest, error) {
 		schedules: pb.NewSchedulesClient(conn),
 		locks:     pb.NewLocksClient(conn),
 		tasks:     pb.NewTasksClient(conn),
+		health:    grpc_health_v1.NewHealthClient(conn),
 	}, nil
 }
 
@@ -135,6 +138,8 @@ func TestGrpc(t *testing.T) {
 				_, err = grpcTest.tasks.DropTask(ctx, req)
 			case *pb.HeartbeatTasksRequest:
 				_, err = grpcTest.tasks.HeartbeatTasks(ctx, req)
+			case *grpc_health_v1.HealthCheckRequest:
+				res, err = grpcTest.health.Check(ctx, req)
 			default:
 				t.Fatalf("unexpected type %T", req)
 			}

--- a/internal/app/subsystems/api/http/http.go
+++ b/internal/app/subsystems/api/http/http.go
@@ -120,7 +120,11 @@ func New(a i_api.API, metrics *metrics.Metrics, config *Config) (i_api.Subsystem
 	}
 
 	// Ping endpoint, no auth required
-	handler.GET("/ping", server.ping)
+	handler.GET("/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status": "ok",
+		})
+	})
 
 	// Authentication
 	authorized := handler.Group("/")
@@ -281,12 +285,6 @@ type server struct {
 
 func (s *server) code(status t_api.StatusCode) int {
 	return int(status) / 100
-}
-
-func (s *server) ping(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
-		"status": "ok",
-	})
 }
 
 // Helper functions

--- a/internal/app/subsystems/api/http/http.go
+++ b/internal/app/subsystems/api/http/http.go
@@ -119,6 +119,9 @@ func New(a i_api.API, metrics *metrics.Metrics, config *Config) (i_api.Subsystem
 		}))
 	}
 
+	// Ping endpoint, no auth required
+	handler.GET("/ping", server.ping)
+
 	// Authentication
 	authorized := handler.Group("/")
 	if len(config.Auth) > 0 {
@@ -278,6 +281,12 @@ type server struct {
 
 func (s *server) code(status t_api.StatusCode) int {
 	return int(status) / 100
+}
+
+func (s *server) ping(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status": "ok",
+	})
 }
 
 // Helper functions

--- a/internal/app/subsystems/api/http/http_test.go
+++ b/internal/app/subsystems/api/http/http_test.go
@@ -141,7 +141,7 @@ func TestHttp(t *testing.T) {
 
 					// apply override code if applicable
 					code := tc.Http.Res.Code
-					if ts.codeOverride != 0 {
+					if ts.codeOverride != 0 && !tc.NoAuth {
 						code = ts.codeOverride
 					}
 

--- a/internal/app/subsystems/api/test/cases.go
+++ b/internal/app/subsystems/api/test/cases.go
@@ -16,11 +16,12 @@ import (
 )
 
 type testCase struct {
-	Name string
-	Req  *t_api.Request
-	Res  *t_api.Response
-	Http *httpTestCase
-	Grpc *grpcTestCase
+	Name   string
+	Req    *t_api.Request
+	Res    *t_api.Response
+	Http   *httpTestCase
+	Grpc   *grpcTestCase
+	NoAuth bool
 }
 
 type httpTestCase struct {
@@ -47,6 +48,23 @@ type grpcTestCase struct {
 }
 
 var TestCases = []*testCase{
+	// Ping
+	{
+		Name:   "Ping",
+		NoAuth: true,
+		Req:    nil,
+		Res:    nil,
+		Http: &httpTestCase{
+			Req: &httpTestCaseRequest{
+				Method: "GET",
+				Path:   "ping",
+			},
+			Res: &httpTestCaseResponse{
+				Code: 200,
+				Body: []byte(`{"status":"ok"}`),
+			},
+		},
+	},
 	// Promises
 	{
 		Name: "ReadPromise",

--- a/internal/app/subsystems/api/test/cases.go
+++ b/internal/app/subsystems/api/test/cases.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/resonatehq/resonate/internal/app/subsystems/api/grpc/pb"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type testCase struct {
@@ -62,6 +63,12 @@ var TestCases = []*testCase{
 			Res: &httpTestCaseResponse{
 				Code: 200,
 				Body: []byte(`{"status":"ok"}`),
+			},
+		},
+		Grpc: &grpcTestCase{
+			Req: &grpc_health_v1.HealthCheckRequest{},
+			Res: &grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_SERVING,
 			},
 		},
 	},


### PR DESCRIPTION
This PR adds a `/ping` endpoint for HTTP and the `grpc_health_v1` proto from `google.golang.org/grpc/health/grpc_health_v1` for gRPC as mentioned in #837.

For manual tophatting:
- `/ping` (HTTP): `curl http://localhost:8001/ping`
- Health proto cannot be manually tested without enabling reflection, but I have done it locally and it works using `grpcurl`

Necessary tests included in their respective commits.