### PR TITLE
Clamp int64 additions

### DIFF
--- a/cmd/util/flags.go
+++ b/cmd/util/flags.go
@@ -124,30 +124,6 @@ func (f *rangeFlag[T]) Resolve(r *rand.Rand) T {
 	return f.resolve(f, r)
 }
 
-func RangeIntn(r *rand.Rand, min int, max int) int {
-	return r.Intn(max-min) + min
-}
-
-func RangeInt63n(r *rand.Rand, min int64, max int64) int64 {
-	return r.Int63n(max-min) + min
-}
-
-func RangeFloat63n(r *rand.Rand, min float64, max float64) float64 {
-	return r.Float64()*(max-min) + min
-}
-
-func RangeMap[K comparable, V any](r *rand.Rand, m map[K]V) K {
-	i := r.Intn(len(m))
-	for k := range m { // nosemgrep: range-over-map
-		if i == 0 {
-			return k
-		}
-		i--
-	}
-	var zero K
-	return zero
-}
-
 // Helper functions
 
 func StringToRange(r *rand.Rand) mapstructure.DecodeHookFunc {

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand" // nosemgrep
 	"reflect"
 	"strconv"
 	"strings"

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
@@ -58,6 +59,39 @@ func MapToBytes() mapstructure.DecodeHookFunc {
 
 		return json.Marshal(data)
 	}
+}
+
+// Random value generators
+func RangeIntn(r *rand.Rand, min int, max int) int {
+	return r.Intn(max-min) + min
+}
+
+func RangeInt63n(r *rand.Rand, min int64, max int64) int64 {
+	return r.Int63n(max-min) + min
+}
+
+func RangeFloat63n(r *rand.Rand, min float64, max float64) float64 {
+	return r.Float64()*(max-min) + min
+}
+
+func RangeMap[K comparable, V any](r *rand.Rand, m map[K]V) K {
+	i := r.Intn(len(m))
+	for k := range m { // nosemgrep: range-over-map
+		if i == 0 {
+			return k
+		}
+		i--
+	}
+	var zero K
+	return zero
+}
+
+func Choose[T any](r *rand.Rand, v ...T) T {
+	if len(v) == 0 {
+		panic("must provide at least one value")
+	}
+
+	return v[r.Intn(len(v))]
 }
 
 // Bind configuration struct fields to cobra flags and viper config

--- a/internal/app/coroutines/claimTask.go
+++ b/internal/app/coroutines/claimTask.go
@@ -62,7 +62,9 @@ func ClaimTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any], r 
 		} else if t.Counter != req.Counter {
 			status = t_api.StatusTaskInvalidCounter
 		} else {
-			expiresAt := c.Time() + int64(req.Ttl)
+			// guard against overflow
+			expiresAt := util.ClampAddInt64(c.Time(), req.Ttl)
+
 			completion, err := gocoro.YieldAndAwait(c, &t_aio.Submission{
 				Kind: t_aio.Store,
 				Tags: r.Metadata,

--- a/internal/app/coroutines/createPromise.go
+++ b/internal/app/coroutines/createPromise.go
@@ -78,7 +78,7 @@ func CreatePromiseAndTask(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completio
 		ProcessId: &req.Task.ProcessId,
 		State:     task.Claimed,
 		Ttl:       req.Task.Ttl,
-		ExpiresAt: c.Time() + int64(req.Task.Ttl),
+		ExpiresAt: util.ClampAddInt64(c.Time(), req.Task.Ttl),
 		CreatedOn: c.Time(),
 	}))
 

--- a/internal/app/coroutines/enqueueTasks.go
+++ b/internal/app/coroutines/enqueueTasks.go
@@ -186,7 +186,7 @@ func EnqueueTasks(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any],
 			} else if err == nil && completion.Sender.Success {
 				var expiresAt int64
 				if completion.Sender.TimeToClaim > 0 {
-					expiresAt = c.Time() + completion.Sender.TimeToClaim
+					expiresAt = util.ClampAddInt64(c.Time(), completion.Sender.TimeToClaim)
 				} else {
 					expiresAt = 0
 				}
@@ -205,9 +205,9 @@ func EnqueueTasks(c gocoro.Coroutine[*t_aio.Submission, *t_aio.Completion, any],
 			} else {
 				var expiresAt int64
 				if err != nil {
-					expiresAt = c.Time() + 15000 // fallback to 15s
+					expiresAt = util.ClampAddInt64(c.Time(), 15000) // fallback to 15s
 				} else if completion.Sender.TimeToRetry > 0 {
-					expiresAt = c.Time() + completion.Sender.TimeToRetry
+					expiresAt = util.ClampAddInt64(c.Time(), completion.Sender.TimeToRetry)
 				} else {
 					expiresAt = 0
 				}

--- a/internal/app/subsystems/aio/store/postgres/postgres.go
+++ b/internal/app/subsystems/aio/store/postgres/postgres.go
@@ -299,7 +299,11 @@ const (
 	UPDATE
 		tasks
 	SET
-		expires_at = $1 + ttl
+		expires_at =
+			CASE
+				WHEN $1 > 9223372036854775807 - ttl THEN 9223372036854775807 -- max int64
+				ELSE $1 + ttl
+			END
 	WHERE
 		process_id = $2 AND state = 4`
 )

--- a/internal/app/subsystems/aio/store/sqlite/sqlite.go
+++ b/internal/app/subsystems/aio/store/sqlite/sqlite.go
@@ -293,7 +293,7 @@ const (
 	UPDATE
 		tasks
 	SET
-		expires_at = ? + ttl
+		expires_at = MIN(? + ttl, 9223372036854775807) -- max int64
 	WHERE
 		process_id = ? AND state = 4`
 )

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"reflect"
 	"sort"
 	"strings"
@@ -143,4 +144,11 @@ func ResumeId(rootPromiseId, promiseId string) string {
 
 func NotifyId(promiseId, id string) string {
 	return fmt.Sprintf("__notify:%s:%s", promiseId, id)
+}
+
+func ClampAddInt64(a, b int64) int64 {
+	if b > 0 && a > math.MaxInt64-b {
+		return math.MaxInt64
+	}
+	return a + b
 }

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"math/rand"
+	"math/rand" // nosemgrep
 	"sort"
 	"strconv"
 	"strings"

--- a/test/dst/dst.go
+++ b/test/dst/dst.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -129,6 +130,7 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 	// backchannel validators
 	d.bcValidator.AddBcValidator(ValidateTasksWithSameRootPromiseId)
 	d.bcValidator.AddBcValidator(ValidateNotify)
+	d.bcValidator.AddBcValidator(ValidateTaskExpiry)
 
 	// porcupine ops
 	var ops []porcupine.Operation
@@ -159,7 +161,7 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 
 					if d.config.PrintOps {
 						// log
-						slog.Info("DST", "t", fmt.Sprintf("%d|%d", reqTime, resTime), "req", req, "res", res, "err", err)
+						slog.Info("DST", "id", req.Metadata["id"], "t", fmt.Sprintf("%d|%d", reqTime, resTime), "req", req, "res", res, "err", err)
 					}
 
 					// add operation to porcupine
@@ -211,7 +213,7 @@ func (d *DST) Run(r *rand.Rand, api api.API, aio aio.AIO, system *system.System)
 						Id:        obj.Id,
 						Counter:   counter,
 						ProcessId: obj.Id,
-						Ttl:       cmdUtil.RangeInt63n(r, 1000, 5000),
+						Ttl:       cmdUtil.Choose(r, 1000, 2000, 3000, 4000, 5000, int64(math.MaxInt64)),
 					},
 				})
 			case *promise.Promise:

--- a/test/dst/generator.go
+++ b/test/dst/generator.go
@@ -205,7 +205,7 @@ func (g *Generator) GenerateCreatePromiseAndTask(r *rand.Rand, t int64) *t_api.R
 			Task: &t_api.CreateTaskRequest{
 				PromiseId: createPromiseReq.Id,
 				ProcessId: createPromiseReq.Id,
-				Ttl:       cmdUtil.RangeInt63n(r, 1000, 5000),
+				Ttl:       cmdUtil.Choose(r, 1000, 2000, 3000, 4000, 5000, int64(math.MaxInt64)),
 				Timeout:   createPromiseReq.Timeout,
 			},
 		},
@@ -467,7 +467,7 @@ func (g *Generator) nextTasks(r *rand.Rand, id string, pid string, counter int, 
 					Id:        id,
 					ProcessId: pid,
 					Counter:   counter,
-					Ttl:       cmdUtil.RangeInt63n(r, 1000, 5000),
+					Ttl:       cmdUtil.Choose(r, 1000, 2000, 3000, 4000, 5000, int64(math.MaxInt64)),
 				},
 			})
 		case 1:

--- a/test/dst/validator_bc.go
+++ b/test/dst/validator_bc.go
@@ -92,3 +92,11 @@ func ValidateTasksWithSameRootPromiseId(model *Model, reqTime int64, _ int64, re
 
 	return model, nil
 }
+
+func ValidateTaskExpiry(model *Model, reqTime int64, _ int64, req *Req) (*Model, error) {
+	if req.bc.Task != nil && req.bc.Task.ExpiresAt < 0 {
+		return model, fmt.Errorf("invalid task expiry %d", req.bc.Task.ExpiresAt)
+	}
+
+	return model, nil
+}


### PR DESCRIPTION
A ttl value added to the current timestamp (in ms) causes int64 overflow, guard against this.

The python task transition tests use a ttl of `sys.maxsize` which causes integer overflow. This problem was masked likely by the system tick frequency but recent changes exposed this problem and the tests are now failing against the remote store. This bug fix fixes the tests and is a good idea anyways.