### PR TITLE
new tree command

### DIFF
--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -49,11 +49,11 @@ func NewCmd() *cobra.Command {
 
 			var rootPromise *v1.Promise
 			promises := map[string][]*v1.Promise{}
-			usingNewFormat := false
 
 			// Try new tag format first (resonate:origin)
+			id := "*"
 			res, err := c.V1().SearchPromisesWithResponse(context.TODO(), &v1.SearchPromisesParams{
-				Id:   &[]string{"*"}[0],
+				Id:   &id,
 				Tags: &map[string]string{"resonate:origin": args[0]},
 			})
 			if err != nil {
@@ -66,8 +66,6 @@ func NewCmd() *cobra.Command {
 
 			// If we got results with resonate:origin, we have the entire call graph
 			if len(*res.JSON200.Promises) > 0 {
-				usingNewFormat = true
-
 				// Collect all promises with pagination
 				for {
 					for _, p := range *res.JSON200.Promises {
@@ -85,7 +83,7 @@ func NewCmd() *cobra.Command {
 					}
 
 					res, err = c.V1().SearchPromisesWithResponse(context.TODO(), &v1.SearchPromisesParams{
-						Id:     &[]string{"*"}[0],
+						Id:     &id,
 						Tags:   &map[string]string{"resonate:origin": args[0]},
 						Cursor: res.JSON200.Cursor,
 					})
@@ -97,10 +95,7 @@ func NewCmd() *cobra.Command {
 						return nil
 					}
 				}
-			}
-
-			// Fallback to old format if new format returned no results
-			if !usingNewFormat {
+			} else {
 				searches := []*searchParams{{id: "*", origin: args[0]}}
 
 				for len(searches) > 0 {


### PR DESCRIPTION
New format (with resonate:origin):

1 initial search + pagination calls (if the result set is large)
Gets the entire call graph in one query
Number of API calls = 1 + (number of pagination rounds)

Old format (with resonate:root):

1 search per branch in the call graph
If you have a call graph with N branches (global scope promises), you need N separate searches
Each search may also require pagination
Number of API calls = N branches × (1 + pagination rounds per branch)

Example:
If you have a call graph with 5 branches and each branch requires 2 pagination rounds:

New format: 1 + 2 = 3 API calls total
Old format: 5 × (1 + 2) = 15 API calls total

The new format is more efficient because resonate:origin represents the entire call graph ID, so all promises in that graph share the same origin tag. The old format required traversing the tree structure and making separate API calls for each branch because resonate:root only represented individual branch roots, not the entire graph.