### PR TITLE
Fix error URLs and disambiguate error code 40300

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -56,7 +56,7 @@ func (a *JwtAuthenticator) Process(req *t_api.Request) *t_api.Error {
 
 	err = a.authorize(claims, req)
 	if err != nil {
-		return t_api.NewError(t_api.StatusForbidden, err)
+		return t_api.NewError(t_api.StatusForbiddenPrefix, err)
 	}
 
 	return nil

--- a/internal/app/subsystems/api/error.go
+++ b/internal/app/subsystems/api/error.go
@@ -56,7 +56,7 @@ func ServerError(err error) *Error {
 			Message: message,
 			Domain:  "server",
 			Metadata: map[string]string{
-				"url": fmt.Sprintf("https://docs.resonatehq.io/operate/errors#%d", error.Code()),
+				"url": fmt.Sprintf("https://docs.resonatehq.io/debug/errors#%d", error.Code()),
 			},
 		}},
 	}
@@ -71,7 +71,7 @@ func RequestError(status t_api.StatusCode) *Error {
 			Message: "Request errors are not retryable since they are caused by invalid client requests",
 			Domain:  "request",
 			Metadata: map[string]string{
-				"url": fmt.Sprintf("https://docs.resonatehq.io/operate/errors#%d", status),
+				"url": fmt.Sprintf("https://docs.resonatehq.io/debug/errors#%d", status),
 			},
 		}},
 	}
@@ -87,7 +87,7 @@ func RequestValidationError(err error) *Error {
 			Message: err,
 			Domain:  "request",
 			Metadata: map[string]string{
-				"url": fmt.Sprintf("https://docs.resonatehq.io/operate/errors#%d", code),
+				"url": fmt.Sprintf("https://docs.resonatehq.io/debug/errors#%d", code),
 			},
 		})
 	}

--- a/internal/kernel/t_api/status.go
+++ b/internal/kernel/t_api/status.go
@@ -17,6 +17,7 @@ const (
 	StatusFieldValidationError   StatusCode = 40000
 	StatusUnauthorized           StatusCode = 40100
 	StatusForbidden              StatusCode = 40300
+	StatusForbiddenPrefix        StatusCode = 40310
 	StatusTaskAlreadyClaimed     StatusCode = 40306
 	StatusTaskAlreadyCompleted   StatusCode = 40307
 	StatusTaskInvalidCounter     StatusCode = 40308
@@ -54,6 +55,8 @@ func (s StatusCode) String() string {
 		return "The request is unauthorized"
 	case StatusForbidden:
 		return "The request is forbidden"
+	case StatusForbiddenPrefix:
+		return "The request prefix is not authorized"
 	case StatusTaskAlreadyClaimed:
 		return "The task is already claimed"
 	case StatusTaskAlreadyCompleted:


### PR DESCRIPTION
## Summary
- Update error documentation URLs from `/operate/errors` to `/debug/errors` (3 occurrences in `error.go`)
- Add new `StatusForbiddenPrefix` (40310) for JWT auth "unauthorized prefix" errors, so 40300 is no longer overloaded for both auth and promise immutability
- `StatusForbidden` (40300) is now reserved for "promise already resolved" per the [error docs](https://docs.resonatehq.io/debug/errors#40300)

This is part of the composite debugging/developer UX improvement tracked in resonatehq/resonatehq-workq#6.

Resolves resonatehq/resonate-temp#87

## Related PRs
- Docs: resonatehq/docs.resonatehq.io (fix/error-codes-docs)
- Python SDK: resonatehq/resonate-sdk-py (fix/registry-error-codes)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/kernel/t_api/... ./internal/api/... ./internal/app/subsystems/api/...` passes
- [ ] Verify JWT auth errors now return code 40310 instead of 40300

🤖 Generated with [Claude Code](https://claude.com/claude-code)