### PR TITLE
fix(http): close connected channel on keep-alive connection reuse

### DIFF
--- a/internal/app/plugins/http/http.go
+++ b/internal/app/plugins/http/http.go
@@ -142,9 +142,11 @@ func (p *processor) Process(data []byte, head map[string]string, body []byte) (b
 			_ = res.Body.Close()
 		}
 
-		// when request fails and the connection was not established, close
-		// the channel and return false
-		if err != nil && !succeeded {
+		// when the request completes without ConnectDone firing (e.g. keep-alive
+		// connection reuse), close the channel; succeeded reflects whether the
+		// request itself succeeded
+		if !succeeded {
+			succeeded = (err == nil)
 			close(connected)
 		}
 	}()


### PR DESCRIPTION
## Problem

Closes resonatehq/resonate-temp#80.

The HTTP plugin's `processor.Process()` uses `httptrace.ConnectDone` to detect a successful TCP connection and close the `connected` channel. However, `ConnectDone` is **only called when a new TCP connection is dialed**. When `http.Transport` reuses an existing keep-alive connection, `ConnectDone` never fires.

Before this fix, the goroutine only handled the failure case:

```go
if err != nil && !succeeded {
    close(connected)
}
```

This left the `err == nil && !succeeded` case (request succeeded on a reused connection) completely unhandled. `<-connected` in `Process()` would block **forever**.

## Failure chain

1. Startup batch: each `__invoke` task dials a fresh TCP connection → `ConnectDone` fires → `succeeded = true` → `Process()` returns normally
2. Post-startup task: keep-alive reuses the connection → `ConnectDone` never fires → `err == nil` but the goroutine does nothing → `<-connected` hangs permanently
3. The HTTP plugin worker goroutine is stuck → `Done()` is never called → the Sender AIO SQE has no CQE → the `gocoro.Await` in `EnqueueTasks` never unblocks
4. `bg.promise.Pending() == true` forever → no new `EnqueueTasks` coroutines are scheduled → all subsequent `__invoke` tasks sit in the DB undelivered (`state=1, expires_at=0`)

## Fix

Close `connected` whenever `ConnectDone` hasn't already closed it, and set `succeeded` based on whether the HTTP request itself succeeded:

```go
if !succeeded {
    succeeded = (err == nil)
    close(connected)
}
```

**Safety:** `ConnectDone` and the goroutine run sequentially on the same goroutine (`ConnectDone` is called from within `client.Do()`). If `ConnectDone` has already set `succeeded = true` and closed `connected`, the `!succeeded` guard prevents a double-close.

## Test needed

A new test case should send two consecutive requests to the same server using a single plugin instance (forcing keep-alive reuse) and assert `Done` is called with `success = true` for both. The second call hangs indefinitely on v0.8.2 and passes after this fix.

## Workaround (for users on v0.8.2)

Reduce `--aio-http-timeout` (e.g. `--aio-http-timeout 30s`). The default 3-minute timeout is the only mechanism that eventually unblocks `<-connected` on the error path. Shorter timeouts reduce the stuck window but don't eliminate the problem.