### PR TITLE
feat: add NATS transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-nats"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +573,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +734,28 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
 
 [[package]]
 name = "either"
@@ -740,6 +830,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "figment"
@@ -1814,12 +1910,27 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.5",
+ "signatory",
 ]
 
 [[package]]
@@ -1839,6 +1950,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1940,6 +2060,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -2141,6 +2267,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2577,6 +2709,7 @@ dependencies = [
 name = "resonate"
 version = "0.9.3"
 dependencies = [
+ "async-nats",
  "async-stream",
  "async-trait",
  "axum",
@@ -2701,6 +2834,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.10",
  "subtle",
@@ -2709,14 +2843,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2726,6 +2873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2750,10 +2906,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.37",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.10",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2772,6 +2928,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2859,6 +3026,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
@@ -2930,6 +3110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +3127,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3037,6 +3237,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -3156,7 +3368,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "sha2",
@@ -3596,6 +3808,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3652,7 +3885,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3817,6 +4050,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,5 @@ validator = { version = "0.18", features = ["derive"] }
 url = "2"
 base64 = "0.22"
 google-cloud-pubsub = "0.33.1"
+async-nats = "0.38"
 tower-http = { version = "0.6", features = ["trace"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -119,6 +119,11 @@ pub struct CommonArgs {
     #[arg(long = "transports-gcps-project", value_name = "PROJECT")]
     pub transports_gcps_project: Option<String>,
 
+    // --- NATS ---
+    /// NATS server URL (enables NATS transport, e.g. nats://localhost:4222)
+    #[arg(long = "transports-nats-url", value_name = "URL")]
+    pub transports_nats_url: Option<String>,
+
     // --- Observability ---
     /// Prometheus metrics port (0 = disabled) [default: 9090]
     #[arg(long = "observability-metrics-port", value_name = "PORT")]
@@ -228,6 +233,10 @@ impl CommonArgs {
                 .gcps
                 .get_or_insert(crate::config::GcpsConfig { project: None });
             gcps.project = Some(project);
+        }
+
+        if let Some(url) = self.transports_nats_url {
+            config.transports.nats = Some(crate::config::NatsConfig { url });
         }
 
         if let Some(v) = self.observability_metrics_port {

--- a/src/config.rs
+++ b/src/config.rs
@@ -287,6 +287,10 @@ pub struct TransportsConfig {
     /// Google Cloud Pub/Sub transport configuration
     #[serde(default)]
     pub gcps: Option<GcpsConfig>,
+
+    /// NATS transport configuration
+    #[serde(default)]
+    pub nats: Option<NatsConfig>,
 }
 
 /// Google Cloud Pub/Sub transport configuration.
@@ -298,6 +302,15 @@ pub struct GcpsConfig {
     /// Default GCP project ID. Used when the address doesn't specify a project.
     #[serde(default)]
     pub project: Option<String>,
+}
+
+/// NATS transport configuration.
+///
+/// When present, enables the nats:// address scheme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NatsConfig {
+    /// NATS server URL (e.g. "nats://localhost:4222")
+    pub url: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,10 +227,24 @@ async fn run_server(config: Config) -> Result<(), String> {
         }
         None => None,
     };
+    let nats = match &state.config.transports.nats {
+        Some(nats_config) => {
+            tracing::info!(url = %nats_config.url, "NATS transport enabled");
+            match transport::transport_nats::NatsTransport::connect(&nats_config.url).await {
+                Ok(t) => Some(Arc::new(t)),
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to connect to NATS, transport disabled");
+                    None
+                }
+            }
+        }
+        None => None,
+    };
     let dispatcher = Arc::new(transport::TransportDispatcher::new(
         http_push,
         poll_registry.clone(),
         gcps,
+        nats,
     ));
 
     // Spawn background loops

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,19 +1,22 @@
 pub mod transport_gcps;
 pub mod transport_http_poll;
 pub mod transport_http_push;
+pub mod transport_nats;
 
 use transport_gcps::GcpsPubSubTransport;
 use transport_http_poll::PollRegistry;
 use transport_http_push::HttpPushTransport;
+use transport_nats::NatsTransport;
 
 use std::sync::Arc;
 
 /// Dispatches messages to the appropriate transport by parsing the address once.
-/// Routes by URL scheme: http/https → push, poll → SSE, gcps → GCP Pub/Sub.
+/// Routes by URL scheme: http/https → push, poll → SSE, gcps → GCP Pub/Sub, nats → NATS.
 pub struct TransportDispatcher {
     http: Arc<HttpPushTransport>,
     poll: Arc<PollRegistry>,
     gcps: Option<Arc<GcpsPubSubTransport>>,
+    nats: Option<Arc<NatsTransport>>,
 }
 
 impl TransportDispatcher {
@@ -21,8 +24,9 @@ impl TransportDispatcher {
         http: Arc<HttpPushTransport>,
         poll: Arc<PollRegistry>,
         gcps: Option<Arc<GcpsPubSubTransport>>,
+        nats: Option<Arc<NatsTransport>>,
     ) -> Self {
-        Self { http, poll, gcps }
+        Self { http, poll, gcps, nats }
     }
 
     /// Parse the address, route to the correct transport, deliver.
@@ -50,6 +54,15 @@ impl TransportDispatcher {
                     tracing::warn!(address = %address, "GCP Pub/Sub transport not configured, message dropped")
                 }
             },
+            Some(Address::Nats(addr)) => match &self.nats {
+                Some(nats) => {
+                    tracing::debug!(transport = "nats", subject = %addr.subject, kind = kind, "Dispatching message via NATS");
+                    nats.send(&addr, payload).await;
+                }
+                None => {
+                    tracing::warn!(address = %address, "NATS transport not configured, message dropped")
+                }
+            },
             None => {
                 tracing::warn!(address = %address, "Invalid address, message cannot be routed");
             }
@@ -66,6 +79,8 @@ pub enum Address {
     Poll(PollAddress),
     /// Google Cloud Pub/Sub delivery
     Gcps(GcpsAddress),
+    /// NATS subject delivery
+    Nats(NatsAddress),
 }
 
 #[derive(Debug, Clone)]
@@ -92,6 +107,11 @@ pub struct GcpsAddress {
     pub topic: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct NatsAddress {
+    pub subject: String,
+}
+
 /// Returns true if the address is a valid, routable URL.
 pub fn is_valid_address(address: &str) -> bool {
     parse_address(address).is_some()
@@ -103,6 +123,7 @@ pub fn is_valid_address(address: &str) -> bool {
 /// - `http://...` / `https://...` — HTTP webhook delivery
 /// - `poll://cast@group[/id]` — Poll SSE delivery
 /// - `gcps://project/topic` — Google Cloud Pub/Sub delivery
+/// - `nats://subject` — NATS subject delivery
 pub fn parse_address(address: &str) -> Option<Address> {
     let parsed = url::Url::parse(address).ok()?;
 
@@ -136,6 +157,13 @@ pub fn parse_address(address: &str) -> Option<Address> {
                 return None;
             }
             Some(Address::Gcps(GcpsAddress { project, topic }))
+        }
+        "nats" => {
+            let subject = parsed.host_str()?.to_string();
+            if subject.is_empty() {
+                return None;
+            }
+            Some(Address::Nats(NatsAddress { subject }))
         }
         _ => None,
     }

--- a/src/transport/transport_nats.rs
+++ b/src/transport/transport_nats.rs
@@ -1,0 +1,44 @@
+//! NATS transport — publish messages to NATS subjects.
+//!
+//! Address format: nats://subject
+
+use async_nats::Client;
+
+use super::NatsAddress;
+use crate::metrics;
+
+/// NATS transport — publishes messages to subjects.
+pub struct NatsTransport {
+    client: Client,
+}
+
+impl NatsTransport {
+    pub async fn connect(url: &str) -> Result<Self, String> {
+        let client = async_nats::connect(url)
+            .await
+            .map_err(|e| format!("Failed to connect to NATS at {}: {}", url, e))?;
+        Ok(Self { client })
+    }
+
+    pub async fn send(&self, address: &NatsAddress, payload: &serde_json::Value) {
+        let data = serde_json::to_vec(payload).unwrap_or_default();
+        match self
+            .client
+            .publish(address.subject.clone(), data.into())
+            .await
+        {
+            Ok(()) => {
+                tracing::debug!(subject = %address.subject, "NATS delivery succeeded");
+                metrics::DELIVERIES_TOTAL
+                    .with_label_values(&["success"])
+                    .inc();
+            }
+            Err(e) => {
+                tracing::warn!(subject = %address.subject, error = %e, "NATS delivery failed");
+                metrics::DELIVERIES_TOTAL
+                    .with_label_values(&["error"])
+                    .inc();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds nats:// as a supported address scheme. Configure with --transports-nats-url (e.g. nats://localhost:4222); the subject is encoded in the address (nats://my-subject).