### PR TITLE
fix: drop signal-killed bash tasks for reschedule instead of failing

### DIFF
--- a/src/transport/transport_exec_bash.rs
+++ b/src/transport/transport_exec_bash.rs
@@ -295,6 +295,18 @@ async fn run_task(
             .await;
         }
         Ok(out) => {
+            // A signal kill (e.g. SIGKILL from a shutdown or SIGTERM from the OS)
+            // is not a workflow failure — drop the task and let the lease expire so
+            // the message is rescheduled rather than rejecting the promise.
+            use std::os::unix::process::ExitStatusExt;
+            if let Some(sig) = out.status.signal() {
+                tracing::warn!(
+                    task_id,
+                    signal = sig,
+                    "bash-exec: process killed by signal, dropping task for reschedule"
+                );
+                return;
+            }
             let now = system_time_ms();
             if out.status.success() {
                 let value = String::from_utf8_lossy(&out.stdout).trim().to_string();


### PR DESCRIPTION
## Summary

- A bash subprocess exiting via signal (SIGKILL on host shutdown, SIGTERM from the OS) is not a workflow failure.
- Before this fix, a signal-killed bash task rejected the promise as if it had failed with a non-zero exit code.
- After this fix, signal-killed tasks are dropped (no rejection), and the lease expires so the message is rescheduled.

## Test plan

- [ ] Manual: send SIGTERM to a long-running bash script invoked via the bash transport and verify the promise is not rejected; the task is retried after lease expiry.
- [ ] \`cargo check --all-targets\` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)