### PR TITLE
add resonate mcp subcommand

### DIFF
--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -1,0 +1,12 @@
+FROM rust:1.94-slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+
+RUN cargo build 2>&1
+
+CMD ["cargo", "test", "--", "--test-threads=1"]

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  test-runner:
+    build:
+      context: ..
+      dockerfile: .docker/Dockerfile.test
+    networks:
+      - resonate
+
+networks:
+  resonate:
+    driver: bridge

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,6 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::{Args, Subcommand};
 use serde_json::{json, Value};
-use tracing_subscriber;
 
 // ---- Serve args ----
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::{Args, Subcommand};
 use serde_json::{json, Value};
+use tracing_subscriber;
 
 // ---- Serve args ----
 
@@ -282,6 +283,13 @@ impl DevArgs {
         config.storage.sqlite.path = self.sqlite_path.unwrap_or_else(|| ":memory:".to_string());
         config
     }
+}
+
+/// CLI flags for the `mcp` subcommand.
+#[derive(Args)]
+pub struct McpArgs {
+    #[command(flatten)]
+    pub global: GlobalArgs,
 }
 
 // ---- Duration parsing ----
@@ -1242,6 +1250,18 @@ fn promise_detail(p: &Value) -> String {
     } else {
         String::new()
     }
+}
+
+pub async fn run_mcp(args: Box<McpArgs>) {
+    // Tracing must go to stderr — MCP uses stdout for framing
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(env_filter)
+        .init();
+
+    crate::mcp::run(args.global.server.clone(), args.global.token.clone()).await;
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod auth;
 mod cli;
 mod config;
-
+mod mcp;
 mod metrics;
 mod persistence;
 mod processing;
@@ -50,6 +50,8 @@ enum Commands {
     Invoke(cli::InvokeArgs),
     /// Display the call-graph tree rooted at a promise ID
     Tree(cli::TreeArgs),
+    /// Start the Resonate MCP server (stdio transport)
+    Mcp(Box<cli::McpArgs>),
 }
 
 #[tokio::main]
@@ -70,6 +72,9 @@ async fn main() -> std::process::ExitCode {
         }
         Commands::Tree(args) => {
             cli::run_tree(args).await;
+        }
+        Commands::Mcp(args) => {
+            cli::run_mcp(args).await;
         }
         Commands::Serve(args) => {
             let config = match Config::load() {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -29,7 +29,11 @@ pub async fn run(server: String, token: Option<String>) {
         });
     }
 
-    let ctx = Ctx { server, token, session_id };
+    let ctx = Ctx {
+        server,
+        token,
+        session_id,
+    };
     let stdin = tokio::io::stdin();
     let mut reader = BufReader::new(stdin);
 
@@ -52,17 +56,23 @@ pub async fn run(server: String, token: Option<String>) {
 async fn handle(ctx: &Ctx, req: &Value) -> Option<Value> {
     let id = req.get("id").cloned().unwrap_or(Value::Null);
     let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("");
-    let is_notification = req.as_object().map(|o| !o.contains_key("id")).unwrap_or(true);
+    let is_notification = req
+        .as_object()
+        .map(|o| !o.contains_key("id"))
+        .unwrap_or(true);
 
     match method {
-        "initialize" => Some(json_rpc_result(id, json!({
-            "protocolVersion": "2025-11-25",
-            "capabilities": {
-                "tools": {},
-                "experimental": { "claude/channel": {} }
-            },
-            "serverInfo": { "name": "resonate-mcp", "version": env!("CARGO_PKG_VERSION") }
-        }))),
+        "initialize" => Some(json_rpc_result(
+            id,
+            json!({
+                "protocolVersion": "2025-11-25",
+                "capabilities": {
+                    "tools": {},
+                    "experimental": { "claude/channel": {} }
+                },
+                "serverInfo": { "name": "resonate-mcp", "version": env!("CARGO_PKG_VERSION") }
+            }),
+        )),
 
         "notifications/initialized" => None,
 
@@ -88,7 +98,15 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
             let timeout_at = args["timeout_at"].as_i64().ok_or("missing timeout_at")?;
             let param = args.get("param").cloned();
             let tags = args.get("tags").cloned();
-            tools::promise_create(&ctx.server, ctx.token.as_deref(), id, timeout_at, param, tags).await
+            tools::promise_create(
+                &ctx.server,
+                ctx.token.as_deref(),
+                id,
+                timeout_at,
+                param,
+                tags,
+            )
+            .await
         }
         "promise-get" => {
             let id = args["id"].as_str().ok_or("missing id")?.to_string();
@@ -96,26 +114,52 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
         }
         "promise-settle" => {
             let id = args["id"].as_str().ok_or("missing id")?.to_string();
-            let resolution = args["resolution"].as_str().ok_or("missing resolution")?.to_string();
+            let resolution = args["resolution"]
+                .as_str()
+                .ok_or("missing resolution")?
+                .to_string();
             let value = args.get("value").cloned();
             tools::promise_settle(&ctx.server, ctx.token.as_deref(), id, resolution, value).await
         }
         "promise-search" => {
-            let state_filter = args.get("state").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let state_filter = args
+                .get("state")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             let tags = args.get("tags").cloned();
             let limit = args.get("limit").and_then(|v| v.as_i64());
-            let cursor = args.get("cursor").and_then(|v| v.as_str()).map(|s| s.to_string());
-            tools::promise_search(&ctx.server, ctx.token.as_deref(), state_filter, tags, limit, cursor).await
+            let cursor = args
+                .get("cursor")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            tools::promise_search(
+                &ctx.server,
+                ctx.token.as_deref(),
+                state_filter,
+                tags,
+                limit,
+                cursor,
+            )
+            .await
         }
         "promise-listen" => {
             let id = args["id"].as_str().ok_or("missing id")?.to_string();
             tools::promise_listen(&ctx.server, ctx.token.as_deref(), &ctx.session_id, id).await
         }
         "resonate-bash" => {
-            let id = args.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let id = args
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             let timeout_ms = args.get("timeoutMs").and_then(|v| v.as_u64());
-            let script = args.get("script").and_then(|v| v.as_str()).map(|s| s.to_string());
-            let script_path = args.get("scriptPath").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let script = args
+                .get("script")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let script_path = args
+                .get("scriptPath")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             let bash_args = args.get("args").and_then(|v| v.as_array()).map(|a| {
                 a.iter()
                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -126,8 +170,16 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
                 &ctx.server,
                 ctx.token.as_deref(),
                 &ctx.session_id,
-                tools::BashParams { id, timeout_ms, script, script_path, args: bash_args, tags },
-            ).await
+                tools::BashParams {
+                    id,
+                    timeout_ms,
+                    script,
+                    script_path,
+                    args: bash_args,
+                    tags,
+                },
+            )
+            .await
         }
         other => Err(format!("unknown tool '{other}'")),
     }
@@ -220,9 +272,7 @@ async fn sse_listener(server: String, token: Option<String>, session_id: String,
     let client = reqwest::Client::new();
     loop {
         tracing::info!(url = %url, "Connecting to SSE");
-        let mut req = client
-            .get(&url)
-            .header("Accept", "text/event-stream");
+        let mut req = client.get(&url).header("Accept", "text/event-stream");
         if let Some(t) = &token {
             req = req.bearer_auth(t);
         }
@@ -234,7 +284,7 @@ async fn sse_listener(server: String, token: Option<String>, session_id: String,
                 }
             }
             Ok(resp) => tracing::warn!(status = %resp.status(), "SSE connection rejected"),
-            Err(e)   => tracing::warn!(error = %e, "SSE connection failed"),
+            Err(e) => tracing::warn!(error = %e, "SSE connection failed"),
         }
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     }
@@ -243,7 +293,11 @@ async fn sse_listener(server: String, token: Option<String>, session_id: String,
 async fn drain_sse(mut resp: reqwest::Response, writer: &Writer) -> Result<(), String> {
     let mut buf = String::new();
 
-    while let Some(chunk) = resp.chunk().await.map_err(|e: reqwest::Error| e.to_string())? {
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e: reqwest::Error| e.to_string())?
+    {
         buf.push_str(&String::from_utf8_lossy(&chunk));
 
         while let Some(pos) = buf.find("\n\n") {
@@ -259,11 +313,11 @@ async fn drain_sse(mut resp: reqwest::Response, writer: &Writer) -> Result<(), S
                         }
                         let handle = promise_obj["id"].as_str().unwrap_or("unknown").to_string();
                         let status = match promise_obj["state"].as_str().unwrap_or("") {
-                            "resolved"          => "resolved",
-                            "rejected"          => "rejected",
+                            "resolved" => "resolved",
+                            "rejected" => "rejected",
                             "rejected_timedout" => "timedout",
                             "rejected_canceled" => "canceled",
-                            _                   => "unknown",
+                            _ => "unknown",
                         };
                         let content = serde_json::to_string(promise_obj).unwrap_or_default();
                         let notification = json!({
@@ -286,11 +340,16 @@ async fn drain_sse(mut resp: reqwest::Response, writer: &Writer) -> Result<(), S
 async fn send(writer: &Writer, msg: Value) {
     let mut line = match serde_json::to_string(&msg) {
         Ok(s) => s,
-        Err(e) => { tracing::error!("serialize error: {e}"); return; }
+        Err(e) => {
+            tracing::error!("serialize error: {e}");
+            return;
+        }
     };
     line.push('\n');
     let mut w = writer.lock().await;
-    if w.write_all(line.as_bytes()).await.is_err() { return; }
+    if w.write_all(line.as_bytes()).await.is_err() {
+        return;
+    }
     let _ = w.flush().await;
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2,7 +2,7 @@ mod tools;
 
 use serde_json::{json, Value};
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::Mutex;
 
 type Writer = Arc<Mutex<BufWriter<tokio::io::Stdout>>>;
@@ -126,7 +126,7 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
                 &ctx.server,
                 ctx.token.as_deref(),
                 &ctx.session_id,
-                id, timeout_ms, script, script_path, bash_args, tags,
+                tools::BashParams { id, timeout_ms, script, script_path, args: bash_args, tags },
             ).await
         }
         other => Err(format!("unknown tool '{other}'")),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,342 @@
+mod tools;
+
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::sync::Mutex;
+
+type Writer = Arc<Mutex<BufWriter<tokio::io::Stdout>>>;
+
+struct Ctx {
+    server: String,
+    token: Option<String>,
+    session_id: String,
+}
+
+pub async fn run(server: String, token: Option<String>) {
+    let session_id = gen_session_id();
+    tracing::info!(session_id = %session_id, server = %server, "MCP proxy starting");
+
+    let writer: Writer = Arc::new(Mutex::new(BufWriter::new(tokio::io::stdout())));
+
+    {
+        let sse_server = server.clone();
+        let sse_token = token.clone();
+        let sse_session = session_id.clone();
+        let sse_writer = writer.clone();
+        tokio::spawn(async move {
+            sse_listener(sse_server, sse_token, sse_session, sse_writer).await;
+        });
+    }
+
+    let ctx = Ctx { server, token, session_id };
+    let stdin = tokio::io::stdin();
+    let mut reader = BufReader::new(stdin);
+
+    loop {
+        match read_message(&mut reader).await {
+            Ok(Some(request)) => {
+                if let Some(response) = handle(&ctx, &request).await {
+                    send(&writer, response).await;
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                tracing::error!("stdin error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+async fn handle(ctx: &Ctx, req: &Value) -> Option<Value> {
+    let id = req.get("id").cloned().unwrap_or(Value::Null);
+    let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("");
+    let is_notification = req.as_object().map(|o| !o.contains_key("id")).unwrap_or(true);
+
+    match method {
+        "initialize" => Some(json_rpc_result(id, json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {
+                "tools": {},
+                "experimental": { "claude/channel": {} }
+            },
+            "serverInfo": { "name": "resonate-mcp", "version": env!("CARGO_PKG_VERSION") }
+        }))),
+
+        "notifications/initialized" => None,
+
+        "tools/list" => Some(json_rpc_result(id, json!({ "tools": tools_list() }))),
+
+        "tools/call" => {
+            let name = req["params"]["name"].as_str().unwrap_or("");
+            let args = &req["params"]["arguments"];
+            let result = call_tool(ctx, name, args).await;
+            Some(json_rpc_result(id, tool_response(result)))
+        }
+
+        _ if is_notification => None,
+
+        _ => Some(json_rpc_error(id, -32601, "Method not found")),
+    }
+}
+
+async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String> {
+    match name {
+        "promise-create" => {
+            let id = args["id"].as_str().ok_or("missing id")?.to_string();
+            let timeout_at = args["timeout_at"].as_i64().ok_or("missing timeout_at")?;
+            let param = args.get("param").cloned();
+            let tags = args.get("tags").cloned();
+            tools::promise_create(&ctx.server, ctx.token.as_deref(), id, timeout_at, param, tags).await
+        }
+        "promise-get" => {
+            let id = args["id"].as_str().ok_or("missing id")?.to_string();
+            tools::promise_get(&ctx.server, ctx.token.as_deref(), id).await
+        }
+        "promise-settle" => {
+            let id = args["id"].as_str().ok_or("missing id")?.to_string();
+            let resolution = args["resolution"].as_str().ok_or("missing resolution")?.to_string();
+            let value = args.get("value").cloned();
+            tools::promise_settle(&ctx.server, ctx.token.as_deref(), id, resolution, value).await
+        }
+        "promise-search" => {
+            let state_filter = args.get("state").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let tags = args.get("tags").cloned();
+            let limit = args.get("limit").and_then(|v| v.as_i64());
+            let cursor = args.get("cursor").and_then(|v| v.as_str()).map(|s| s.to_string());
+            tools::promise_search(&ctx.server, ctx.token.as_deref(), state_filter, tags, limit, cursor).await
+        }
+        "promise-listen" => {
+            let id = args["id"].as_str().ok_or("missing id")?.to_string();
+            tools::promise_listen(&ctx.server, ctx.token.as_deref(), &ctx.session_id, id).await
+        }
+        "resonate-bash" => {
+            let id = args.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let timeout_ms = args.get("timeoutMs").and_then(|v| v.as_u64());
+            let script = args.get("script").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let script_path = args.get("scriptPath").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let bash_args = args.get("args").and_then(|v| v.as_array()).map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<_>>()
+            });
+            let tags = args.get("tags").cloned();
+            tools::resonate_bash(
+                &ctx.server,
+                ctx.token.as_deref(),
+                &ctx.session_id,
+                id, timeout_ms, script, script_path, bash_args, tags,
+            ).await
+        }
+        other => Err(format!("unknown tool '{other}'")),
+    }
+}
+
+fn tools_list() -> Value {
+    json!([
+        {
+            "name": "promise-create",
+            "description": "Create a durable promise",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id":         { "type": "string",  "description": "Unique promise identifier" },
+                    "timeout_at": { "type": "integer", "description": "Expiry timestamp (epoch ms)" },
+                    "param":      {                    "description": "Optional input value (PromiseValue with optional headers and data fields)" },
+                    "tags":       { "type": "object",  "description": "Optional key-value string tags" }
+                },
+                "required": ["id", "timeout_at"]
+            }
+        },
+        {
+            "name": "promise-get",
+            "description": "Get a promise by ID",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "Promise identifier" }
+                },
+                "required": ["id"]
+            }
+        },
+        {
+            "name": "promise-settle",
+            "description": "Settle a promise (resolve, reject, or cancel)",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id":         { "type": "string", "description": "Promise identifier" },
+                    "resolution": { "type": "string", "enum": ["resolve", "reject", "cancel"] },
+                    "value":      {                   "description": "Optional result value (PromiseValue)" }
+                },
+                "required": ["id", "resolution"]
+            }
+        },
+        {
+            "name": "promise-search",
+            "description": "Search promises with optional filters",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "state":  { "type": "string",  "description": "Filter by state" },
+                    "tags":   { "type": "object",  "description": "Filter by tags" },
+                    "limit":  { "type": "integer", "description": "Max results" },
+                    "cursor": { "type": "string",  "description": "Pagination cursor" }
+                }
+            }
+        },
+        {
+            "name": "promise-listen",
+            "description": "Subscribe to push notifications when a promise settles. Registers a poll listener; the MCP server emits a notifications/message when the promise resolves, rejects, or times out.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "Promise identifier to watch" }
+                },
+                "required": ["id"]
+            }
+        },
+        {
+            "name": "resonate-bash",
+            "description": "Run a shell command as a durable, asynchronous task. Returns a promise ID immediately and registers a listener; the command executes in the background and a `<channel>` notification carrying `{exit_code, stdout, stderr}` is delivered when it finishes. The script body is stored in the promise and restarted from the top on crash, so scripts must be idempotent on restart — for 'trigger external + poll' patterns use 'check-then-trigger + poll' to avoid double-firing on restart. Ideal for fire-and-watch coordination with external systems that have a status endpoint but no webhook (Airflow runs, GitHub Actions, Terraform applies, dbt jobs, K8s rollouts) or for busy-loop polling like `until row exists in BigQuery; do sleep 30; done`. Polling consumes no LLM tokens because the loop runs in the shell, not in the model context.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id":         { "type": "string",  "description": "Promise ID (auto-generated if omitted)" },
+                    "timeoutMs":  { "type": "integer", "description": "Milliseconds from now before timeout (default 300000 = 5 min)" },
+                    "script":     { "type": "string",  "description": "Inline bash script (mutually exclusive with scriptPath)" },
+                    "scriptPath": { "type": "string",  "description": "Named script path under bash_exec.root_dir (mutually exclusive with script)" },
+                    "args":       { "type": "array",   "items": { "type": "string" }, "description": "Arguments for named script" },
+                    "tags":       { "type": "object",  "description": "Additional tags merged with resonate:target" }
+                }
+            }
+        }
+    ])
+}
+
+async fn sse_listener(server: String, token: Option<String>, session_id: String, writer: Writer) {
+    let url = format!("{}/poll/mcp/{}", server.trim_end_matches('/'), session_id);
+    let client = reqwest::Client::new();
+    loop {
+        tracing::info!(url = %url, "Connecting to SSE");
+        let mut req = client
+            .get(&url)
+            .header("Accept", "text/event-stream");
+        if let Some(t) = &token {
+            req = req.bearer_auth(t);
+        }
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::info!("SSE connection established");
+                if let Err(e) = drain_sse(resp, &writer).await {
+                    tracing::warn!("SSE stream ended: {e}");
+                }
+            }
+            Ok(resp) => tracing::warn!(status = %resp.status(), "SSE connection rejected"),
+            Err(e)   => tracing::warn!(error = %e, "SSE connection failed"),
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    }
+}
+
+async fn drain_sse(mut resp: reqwest::Response, writer: &Writer) -> Result<(), String> {
+    let mut buf = String::new();
+
+    while let Some(chunk) = resp.chunk().await.map_err(|e: reqwest::Error| e.to_string())? {
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(pos) = buf.find("\n\n") {
+            let event_block = buf[..pos].to_string();
+            buf = buf[pos + 2..].to_string();
+
+            for line in event_block.lines() {
+                if let Some(data) = line.strip_prefix("data: ") {
+                    if let Ok(payload) = serde_json::from_str::<Value>(data) {
+                        let promise_obj = &payload["data"]["promise"];
+                        if promise_obj.is_null() {
+                            continue;
+                        }
+                        let handle = promise_obj["id"].as_str().unwrap_or("unknown").to_string();
+                        let status = match promise_obj["state"].as_str().unwrap_or("") {
+                            "resolved"          => "resolved",
+                            "rejected"          => "rejected",
+                            "rejected_timedout" => "timedout",
+                            "rejected_canceled" => "canceled",
+                            _                   => "unknown",
+                        };
+                        let content = serde_json::to_string(promise_obj).unwrap_or_default();
+                        let notification = json!({
+                            "jsonrpc": "2.0",
+                            "method": "notifications/claude/channel",
+                            "params": {
+                                "content": content,
+                                "meta": { "handle": handle, "status": status }
+                            }
+                        });
+                        send(writer, notification).await;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn send(writer: &Writer, msg: Value) {
+    let mut line = match serde_json::to_string(&msg) {
+        Ok(s) => s,
+        Err(e) => { tracing::error!("serialize error: {e}"); return; }
+    };
+    line.push('\n');
+    let mut w = writer.lock().await;
+    if w.write_all(line.as_bytes()).await.is_err() { return; }
+    let _ = w.flush().await;
+}
+
+async fn read_message(reader: &mut BufReader<tokio::io::Stdin>) -> Result<Option<Value>, String> {
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line).await {
+            Ok(0) => return Ok(None),
+            Ok(_) => {}
+            Err(e) => return Err(e.to_string()),
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        return serde_json::from_str(trimmed)
+            .map(Some)
+            .map_err(|e| format!("JSON parse error: {e}"));
+    }
+}
+
+fn tool_response(result: Result<Value, String>) -> Value {
+    match result {
+        Ok(v) => json!({
+            "content": [{ "type": "text", "text": serde_json::to_string_pretty(&v).unwrap_or_default() }],
+            "isError": false
+        }),
+        Err(msg) => json!({
+            "content": [{ "type": "text", "text": msg }],
+            "isError": true
+        }),
+    }
+}
+
+fn json_rpc_result(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn json_rpc_error(id: Value, code: i32, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+fn gen_session_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let d = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("mcp-{}-{}", d.as_millis(), d.subsec_nanos() % 1_000_000)
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -128,17 +128,22 @@ fn now_ms() -> i64 {
         .as_millis() as i64
 }
 
+pub struct BashParams {
+    pub id: Option<String>,
+    pub timeout_ms: Option<u64>,
+    pub script: Option<String>,
+    pub script_path: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub tags: Option<Value>,
+}
+
 pub async fn resonate_bash(
     server: &str,
     token: Option<&str>,
     session_id: &str,
-    id: Option<String>,
-    timeout_ms: Option<u64>,
-    script: Option<String>,
-    script_path: Option<String>,
-    args: Option<Vec<String>>,
-    tags: Option<Value>,
+    p: BashParams,
 ) -> Result<Value, String> {
+    let BashParams { id, timeout_ms, script, script_path, args, tags } = p;
     let has_inline = script.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
     let has_path   = script_path.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
     if has_inline == has_path {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,0 +1,215 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde_json::{json, Value};
+
+fn gen_corr_id() -> String {
+    let d = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("mcp-{}-{}", d.as_millis(), d.subsec_nanos() % 1_000_000)
+}
+
+fn build_envelope(kind: &str, token: Option<&str>, data: Value) -> Value {
+    let mut head = json!({ "corrId": gen_corr_id(), "version": "2026-04-01" });
+    if let Some(t) = token {
+        head["auth"] = json!(t);
+    }
+    json!({ "kind": kind, "head": head, "data": data })
+}
+
+async fn post(server: &str, token: Option<&str>, kind: &str, data: Value) -> Result<Value, String> {
+    let client = reqwest::Client::new();
+    let url = format!("{}/", server.trim_end_matches('/'));
+    let body = build_envelope(kind, token, data);
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Connection error: {}", e))?;
+    let envelope: Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+    let status = envelope["head"]["status"].as_i64().unwrap_or(0);
+    if (200..300).contains(&status) {
+        Ok(envelope["data"].clone())
+    } else {
+        Err(format!("{}", envelope["data"]))
+    }
+}
+
+fn b64_encode_data_field(v: &mut Value) {
+    if let Some(data) = v.get("data") {
+        let raw = match data {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        v["data"] = Value::String(STANDARD.encode(raw));
+    }
+}
+
+pub async fn promise_create(
+    server: &str,
+    token: Option<&str>,
+    id: String,
+    timeout_at: i64,
+    param: Option<Value>,
+    tags: Option<Value>,
+) -> Result<Value, String> {
+    let mut data = json!({ "id": id, "timeoutAt": timeout_at });
+    if let Some(mut p) = param {
+        b64_encode_data_field(&mut p);
+        data["param"] = p;
+    }
+    if let Some(t) = tags {
+        data["tags"] = t;
+    }
+    post(server, token, "promise.create", data).await
+}
+
+pub async fn promise_get(server: &str, token: Option<&str>, id: String) -> Result<Value, String> {
+    post(server, token, "promise.get", json!({ "id": id })).await
+}
+
+pub async fn promise_settle(
+    server: &str,
+    token: Option<&str>,
+    id: String,
+    resolution: String,
+    value: Option<Value>,
+) -> Result<Value, String> {
+    let state_str = match resolution.as_str() {
+        "resolve" => "resolved",
+        "reject"  => "rejected",
+        "cancel"  => "rejected_canceled",
+        other     => return Err(format!("invalid resolution '{}'; must be resolve, reject, or cancel", other)),
+    };
+    let mut data = json!({ "id": id, "state": state_str });
+    if let Some(mut v) = value {
+        b64_encode_data_field(&mut v);
+        data["value"] = v;
+    }
+    post(server, token, "promise.settle", data).await
+}
+
+pub async fn promise_search(
+    server: &str,
+    token: Option<&str>,
+    state_filter: Option<String>,
+    tags: Option<Value>,
+    limit: Option<i64>,
+    cursor: Option<String>,
+) -> Result<Value, String> {
+    let mut data = json!({});
+    if let Some(s) = state_filter { data["state"] = json!(s); }
+    if let Some(t) = tags         { data["tags"]  = t; }
+    if let Some(l) = limit        { data["limit"] = json!(l); }
+    if let Some(c) = cursor       { data["cursor"] = json!(c); }
+    post(server, token, "promise.search", data).await
+}
+
+pub async fn promise_listen(
+    server: &str,
+    token: Option<&str>,
+    session_id: &str,
+    id: String,
+) -> Result<Value, String> {
+    let address = format!("poll://uni@mcp/{}", session_id);
+    post(server, token, "promise.register_listener", json!({
+        "awaited": id,
+        "address": address
+    })).await
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+pub async fn resonate_bash(
+    server: &str,
+    token: Option<&str>,
+    session_id: &str,
+    id: Option<String>,
+    timeout_ms: Option<u64>,
+    script: Option<String>,
+    script_path: Option<String>,
+    args: Option<Vec<String>>,
+    tags: Option<Value>,
+) -> Result<Value, String> {
+    let has_inline = script.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
+    let has_path   = script_path.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
+    if has_inline == has_path {
+        return Err("Provide exactly one of `script` or `scriptPath`".into());
+    }
+
+    let promise_id = id.unwrap_or_else(|| {
+        let d = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default();
+        format!("bash-{}-{}", d.as_millis(), d.subsec_nanos() % 1_000_000)
+    });
+
+    let timeout_at = now_ms() + timeout_ms.unwrap_or(5 * 60 * 1000) as i64;
+
+    let (target_address, param_data) = if has_inline {
+        let s = script.unwrap();
+        ("bash://".to_string(), STANDARD.encode(s.as_bytes()))
+    } else {
+        let normalized = script_path.unwrap().trim_start_matches('/').to_string();
+        if normalized.is_empty() {
+            return Err("`scriptPath` must not be empty".into());
+        }
+        if normalized.contains('\0') {
+            return Err("`scriptPath` must not contain null bytes".into());
+        }
+        let address = format!("bash:///{}", normalized);
+        let args_json = serde_json::to_string(&args.unwrap_or_default())
+            .map_err(|e| format!("failed to encode args: {}", e))?;
+        (address, STANDARD.encode(args_json.as_bytes()))
+    };
+
+    let mut merged_tags = match tags {
+        Some(Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    };
+    merged_tags.insert(
+        "resonate:target".to_string(),
+        Value::String(target_address.clone()),
+    );
+
+    let create_data = json!({
+        "id": promise_id,
+        "timeoutAt": timeout_at,
+        "param": { "data": param_data },
+        "tags": Value::Object(merged_tags),
+    });
+
+    let create_resp = post(server, token, "promise.create", create_data).await?;
+
+    let promise = create_resp
+        .get("promise")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let promise_state = promise["state"].as_str().unwrap_or("").to_string();
+
+    let mut listener_registered = false;
+    if promise_state == "pending" {
+        let address = format!("poll://uni@mcp/{}", session_id);
+        match post(server, token, "promise.register_listener", json!({
+            "awaited": promise_id,
+            "address": address,
+        })).await {
+            Ok(_) => listener_registered = true,
+            Err(e) => tracing::warn!(error = %e, "Failed to register listener for resonate-bash promise"),
+        }
+    }
+
+    Ok(json!({
+        "promise": promise,
+        "listener_registered": listener_registered,
+        "target": target_address,
+    }))
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -80,9 +80,14 @@ pub async fn promise_settle(
 ) -> Result<Value, String> {
     let state_str = match resolution.as_str() {
         "resolve" => "resolved",
-        "reject"  => "rejected",
-        "cancel"  => "rejected_canceled",
-        other     => return Err(format!("invalid resolution '{}'; must be resolve, reject, or cancel", other)),
+        "reject" => "rejected",
+        "cancel" => "rejected_canceled",
+        other => {
+            return Err(format!(
+                "invalid resolution '{}'; must be resolve, reject, or cancel",
+                other
+            ))
+        }
     };
     let mut data = json!({ "id": id, "state": state_str });
     if let Some(mut v) = value {
@@ -101,10 +106,18 @@ pub async fn promise_search(
     cursor: Option<String>,
 ) -> Result<Value, String> {
     let mut data = json!({});
-    if let Some(s) = state_filter { data["state"] = json!(s); }
-    if let Some(t) = tags         { data["tags"]  = t; }
-    if let Some(l) = limit        { data["limit"] = json!(l); }
-    if let Some(c) = cursor       { data["cursor"] = json!(c); }
+    if let Some(s) = state_filter {
+        data["state"] = json!(s);
+    }
+    if let Some(t) = tags {
+        data["tags"] = t;
+    }
+    if let Some(l) = limit {
+        data["limit"] = json!(l);
+    }
+    if let Some(c) = cursor {
+        data["cursor"] = json!(c);
+    }
     post(server, token, "promise.search", data).await
 }
 
@@ -115,10 +128,16 @@ pub async fn promise_listen(
     id: String,
 ) -> Result<Value, String> {
     let address = format!("poll://uni@mcp/{}", session_id);
-    post(server, token, "promise.register_listener", json!({
-        "awaited": id,
-        "address": address
-    })).await
+    post(
+        server,
+        token,
+        "promise.register_listener",
+        json!({
+            "awaited": id,
+            "address": address
+        }),
+    )
+    .await
 }
 
 fn now_ms() -> i64 {
@@ -143,9 +162,16 @@ pub async fn resonate_bash(
     session_id: &str,
     p: BashParams,
 ) -> Result<Value, String> {
-    let BashParams { id, timeout_ms, script, script_path, args, tags } = p;
+    let BashParams {
+        id,
+        timeout_ms,
+        script,
+        script_path,
+        args,
+        tags,
+    } = p;
     let has_inline = script.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
-    let has_path   = script_path.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
+    let has_path = script_path.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
     if has_inline == has_path {
         return Err("Provide exactly one of `script` or `scriptPath`".into());
     }
@@ -194,21 +220,27 @@ pub async fn resonate_bash(
 
     let create_resp = post(server, token, "promise.create", create_data).await?;
 
-    let promise = create_resp
-        .get("promise")
-        .cloned()
-        .unwrap_or(Value::Null);
+    let promise = create_resp.get("promise").cloned().unwrap_or(Value::Null);
     let promise_state = promise["state"].as_str().unwrap_or("").to_string();
 
     let mut listener_registered = false;
     if promise_state == "pending" {
         let address = format!("poll://uni@mcp/{}", session_id);
-        match post(server, token, "promise.register_listener", json!({
-            "awaited": promise_id,
-            "address": address,
-        })).await {
+        match post(
+            server,
+            token,
+            "promise.register_listener",
+            json!({
+                "awaited": promise_id,
+                "address": address,
+            }),
+        )
+        .await
+        {
             Ok(_) => listener_registered = true,
-            Err(e) => tracing::warn!(error = %e, "Failed to register listener for resonate-bash promise"),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to register listener for resonate-bash promise")
+            }
         }
     }
 


### PR DESCRIPTION
Standalone MCP stdio server that proxies promise operations to a running Resonate server over HTTP and pushes channel notifications when listened promises settle.

- promise-create / promise-get / promise-settle / promise-search proxy one-to-one to the equivalent HTTP kinds
- promise-listen registers a poll listener at poll://uni@mcp/<session> and the SSE-fed background task converts unblock events into notifications/claude/channel frames
- resonate-bash creates a durable promise targeted at bash:// (inline) or bash:///<path> (named) and registers a listener; execution happens in a separate bash worker, not in the MCP process
- newline-delimited JSON-RPC framing; logs to stderr, frames to stdout