### PR TITLE
feat: umbrella bash exec — local + docker + tensorlake backends

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -328,37 +328,18 @@ pub struct TransportsConfig {
 }
 
 /// Bash execution transport configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// When `enabled`, the bash:// scheme is routable via three backends:
+/// - `bash://`                       → local bash
+/// - `bash://docker/<image>`         → docker run --rm <image> bash -c <script>
+/// - `bash://tensorlake/<image>`     → Tensorlake Sandboxes API (needs TENSORLAKE_API_KEY)
+///
+/// Scripts are always inline (carried in `param.data`); named scripts are not supported.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BashExecConfig {
     /// Enable the bash:// address scheme [default: false]
     #[serde(default)]
     pub enabled: bool,
-
-    /// Root directory for named scripts (bash:///relative/path.sh).
-    /// Not required if only inline scripts are used.
-    #[serde(default)]
-    pub root_dir: Option<String>,
-
-    /// Working directory for named script execution.
-    /// "<root>"   — CWD is set to root_dir (default)
-    /// "<script>" — CWD is set to the directory containing the script
-    /// any path   — CWD is set to that literal path
-    #[serde(default = "default_working_dir")]
-    pub working_dir: String,
-}
-
-fn default_working_dir() -> String {
-    "<root>".to_string()
-}
-
-impl Default for BashExecConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            root_dir: None,
-            working_dir: default_working_dir(),
-        }
-    }
 }
 
 /// Google Cloud Pub/Sub transport configuration.

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,21 +288,9 @@ async fn run_server(config: Config) -> Result<(), String> {
         None
     };
     let bash: Option<Arc<dyn BashTransport>> = if state.config.transports.bash_exec.enabled {
-        let bash_cfg = &state.config.transports.bash_exec;
-        match &bash_cfg.root_dir {
-            Some(dir) => {
-                tracing::info!(root_dir = %dir, working_dir = %bash_cfg.working_dir, "Bash exec transport enabled")
-            }
-            None => tracing::info!("Bash exec transport enabled (inline only)"),
-        }
-        let working_dir =
-            transport::transport_exec_bash::WorkingDir::from_config(&bash_cfg.working_dir);
+        tracing::info!("Bash exec transport enabled (local + docker + tensorlake)");
         Some(Arc::new(
-            transport::transport_exec_bash::BashExecTransport::new(
-                Arc::clone(&state),
-                bash_cfg.root_dir.as_deref(),
-                working_dir,
-            ),
+            transport::transport_exec_bash::BashExecTransport::new(Arc::clone(&state)),
         ))
     } else {
         None

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -155,16 +155,12 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
             let script = args
                 .get("script")
                 .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let script_path = args
-                .get("scriptPath")
+                .unwrap_or("")
+                .to_string();
+            let target = args
+                .get("target")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            let bash_args = args.get("args").and_then(|v| v.as_array()).map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect::<Vec<_>>()
-            });
             let tags = args.get("tags").cloned();
             tools::resonate_bash(
                 &ctx.server,
@@ -174,8 +170,7 @@ async fn call_tool(ctx: &Ctx, name: &str, args: &Value) -> Result<Value, String>
                     id,
                     timeout_ms,
                     script,
-                    script_path,
-                    args: bash_args,
+                    target,
                     tags,
                 },
             )
@@ -255,13 +250,13 @@ fn tools_list() -> Value {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "id":         { "type": "string",  "description": "Promise ID (auto-generated if omitted)" },
-                    "timeoutMs":  { "type": "integer", "description": "Milliseconds from now before timeout (default 300000 = 5 min)" },
-                    "script":     { "type": "string",  "description": "Inline bash script (mutually exclusive with scriptPath)" },
-                    "scriptPath": { "type": "string",  "description": "Named script path under bash_exec.root_dir (mutually exclusive with script)" },
-                    "args":       { "type": "array",   "items": { "type": "string" }, "description": "Arguments for named script" },
-                    "tags":       { "type": "object",  "description": "Additional tags merged with resonate:target" }
-                }
+                    "id":        { "type": "string",  "description": "Promise ID (auto-generated if omitted)" },
+                    "timeoutMs": { "type": "integer", "description": "Milliseconds from now before timeout (default 300000 = 5 min)" },
+                    "script":    { "type": "string",  "description": "Inline bash script body" },
+                    "target":    { "type": "string",  "description": "Execution target. Defaults to 'bash://' (local). Examples: 'bash://docker/ubuntu:latest', 'bash://tensorlake/python-3.11'." },
+                    "tags":      { "type": "object",  "description": "Additional tags merged with resonate:target" }
+                },
+                "required": ["script"]
             }
         }
     ])

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -150,9 +150,10 @@ fn now_ms() -> i64 {
 pub struct BashParams {
     pub id: Option<String>,
     pub timeout_ms: Option<u64>,
-    pub script: Option<String>,
-    pub script_path: Option<String>,
-    pub args: Option<Vec<String>>,
+    pub script: String,
+    /// Optional address override. Defaults to "bash://" (local).
+    /// Examples: "bash://docker/ubuntu:latest", "bash://tensorlake/python-3.11".
+    pub target: Option<String>,
     pub tags: Option<Value>,
 }
 
@@ -166,14 +167,11 @@ pub async fn resonate_bash(
         id,
         timeout_ms,
         script,
-        script_path,
-        args,
+        target,
         tags,
     } = p;
-    let has_inline = script.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
-    let has_path = script_path.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
-    if has_inline == has_path {
-        return Err("Provide exactly one of `script` or `scriptPath`".into());
+    if script.is_empty() {
+        return Err("`script` must not be empty".into());
     }
 
     let promise_id = id.unwrap_or_else(|| {
@@ -185,22 +183,8 @@ pub async fn resonate_bash(
 
     let timeout_at = now_ms() + timeout_ms.unwrap_or(5 * 60 * 1000) as i64;
 
-    let (target_address, param_data) = if has_inline {
-        let s = script.unwrap();
-        ("bash://".to_string(), STANDARD.encode(s.as_bytes()))
-    } else {
-        let normalized = script_path.unwrap().trim_start_matches('/').to_string();
-        if normalized.is_empty() {
-            return Err("`scriptPath` must not be empty".into());
-        }
-        if normalized.contains('\0') {
-            return Err("`scriptPath` must not contain null bytes".into());
-        }
-        let address = format!("bash:///{}", normalized);
-        let args_json = serde_json::to_string(&args.unwrap_or_default())
-            .map_err(|e| format!("failed to encode args: {}", e))?;
-        (address, STANDARD.encode(args_json.as_bytes()))
-    };
+    let target_address = target.unwrap_or_else(|| "bash://".to_string());
+    let param_data = STANDARD.encode(script.as_bytes());
 
     let mut merged_tags = match tags {
         Some(Value::Object(map)) => map,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -152,7 +152,9 @@ pub enum Address {
     Poll(PollAddress),
     /// Google Cloud Pub/Sub delivery
     Gcps(GcpsAddress),
-    /// Bash script execution (script is in param.data)
+    /// Bash script execution (script is in param.data).
+    /// The bash transport re-parses the address to pick a backend
+    /// (local / docker / tensorlake), so we only mark it routable here.
     #[allow(dead_code)]
     Bash(BashAddress),
 }
@@ -196,6 +198,7 @@ pub fn is_valid_address(address: &str) -> bool {
 /// - `http://...` / `https://...` — HTTP webhook delivery
 /// - `poll://cast@group[/id]` — Poll SSE delivery
 /// - `gcps://project/topic` — Google Cloud Pub/Sub delivery
+/// - `bash://` (local), `bash://docker/<image>`, `bash://tensorlake/<image>`
 pub fn parse_address(address: &str) -> Option<Address> {
     let parsed = url::Url::parse(address).ok()?;
 
@@ -481,10 +484,17 @@ mod tests {
 
     #[test]
     fn bash_address_parses() {
-        assert!(matches!(parse_address("bash://"), Some(Address::Bash(_))));
-        assert!(matches!(
-            parse_address("bash://inline"),
-            Some(Address::Bash(_))
-        ));
+        for addr in [
+            "bash://",
+            "bash://bash",
+            "bash://docker/alpine",
+            "bash://docker/library/ubuntu:latest",
+            "bash://tensorlake/python-3.11",
+        ] {
+            assert!(
+                matches!(parse_address(addr), Some(Address::Bash(_))),
+                "expected Bash for {addr}"
+            );
+        }
     }
 }

--- a/src/transport/transport_exec_bash.rs
+++ b/src/transport/transport_exec_bash.rs
@@ -1,46 +1,123 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
+use async_trait::async_trait;
+use serde_json::json;
 use tokio::process::Command;
 
 use crate::persistence::{Storage, TaskAcquireParams, TaskFulfillParams};
 use crate::server::Server;
 use crate::util::system_time_ms;
 
-// ─── Transport ────────────────────────────────────────────────────────────────
+// ─── Backend trait ────────────────────────────────────────────────────────────
+//
+// Every backend just runs a script and returns an outcome. Lifecycle plumbing
+// (acquire / heartbeat / fulfill / reject) lives in `run_task` below.
 
-pub enum WorkingDir {
-    Root,
-    Script,
-    Explicit(PathBuf),
+#[async_trait]
+pub trait ExecBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn run(&self, req: ExecRequest) -> ExecOutcome;
 }
 
-impl WorkingDir {
-    pub fn from_config(s: &str) -> Self {
-        match s {
-            "<root>" => Self::Root,
-            "<script>" => Self::Script,
-            path => Self::Explicit(PathBuf::from(path)),
+pub struct ExecRequest {
+    pub task_id: String,
+    pub script: String,
+    /// Backend-specific selector. Local ignores it; Docker/Tensorlake require
+    /// an image name.
+    pub target: Option<String>,
+    /// Promise creation time (ms since epoch). Stable across retries.
+    pub created_at: i64,
+    /// Promise timeout / deadline (ms since epoch). Stable across retries —
+    /// lets scripts loop until the deadline rather than for a fixed duration,
+    /// which makes them idempotent across restart-from-top retries.
+    pub timeout_at: i64,
+}
+
+/// Env vars exposed to every script, regardless of backend.
+fn exec_env(req: &ExecRequest) -> [(&'static str, String); 3] {
+    [
+        ("RESONATE_PROMISE_ID", req.task_id.clone()),
+        ("RESONATE_PROMISE_CREATED_AT", req.created_at.to_string()),
+        ("RESONATE_PROMISE_TIMEOUT_AT", req.timeout_at.to_string()),
+    ]
+}
+
+pub struct ExecOutcome {
+    pub result: Result<ExitStatus, String>,
+}
+
+pub struct ExitStatus {
+    pub code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    /// True if the process was killed by a signal (locally) or by the
+    /// container/sandbox runtime (docker exit 137/143, tensorlake "signaled").
+    /// Killed runs are infrastructure failures, not workflow failures: the
+    /// orchestrator drops the task so the lease expires and the message is
+    /// re-dispatched to a fresh worker.
+    pub killed: bool,
+}
+
+// ─── Address parsing ──────────────────────────────────────────────────────────
+//
+// Umbrella scheme: bash:// is always local execution; bash://<backend>/<image>
+// routes to a remote backend.
+
+enum BackendChoice {
+    Local,
+    Docker { image: String },
+    Tensorlake { image: String },
+}
+
+fn parse_backend(address: &str) -> Result<BackendChoice, String> {
+    let parsed = url::Url::parse(address).map_err(|e| format!("invalid address: {e}"))?;
+    if parsed.scheme() != "bash" {
+        return Err(format!("expected bash:// scheme, got {}://", parsed.scheme()));
+    }
+    let host = parsed.host_str().unwrap_or("");
+    let path = parsed.path().trim_start_matches('/');
+    match host {
+        "" | "bash" => {
+            if !path.is_empty() {
+                return Err("local bash:// does not accept a path".into());
+            }
+            Ok(BackendChoice::Local)
         }
+        "docker" => {
+            if path.is_empty() {
+                return Err("bash://docker/<image> requires an image".into());
+            }
+            Ok(BackendChoice::Docker {
+                image: path.to_string(),
+            })
+        }
+        "tensorlake" => {
+            // Empty image → use Tensorlake's default sandbox environment.
+            Ok(BackendChoice::Tensorlake {
+                image: path.to_string(),
+            })
+        }
+        other => Err(format!("unknown bash backend: {other}")),
     }
 }
 
+// ─── Transport ────────────────────────────────────────────────────────────────
+
 pub struct BashExecTransport {
     server: Arc<Server>,
-    root_dir: Option<PathBuf>,
-    working_dir: WorkingDir,
+    local: Arc<LocalBackend>,
+    docker: Arc<DockerBackend>,
+    tensorlake: Arc<TensorlakeBackend>,
 }
 
 impl BashExecTransport {
-    pub fn new(
-        server: Arc<Server>,
-        root_dir: Option<impl Into<PathBuf>>,
-        working_dir: WorkingDir,
-    ) -> Self {
+    pub fn new(server: Arc<Server>) -> Self {
         Self {
             server,
-            root_dir: root_dir.map(|d| d.into()),
-            working_dir,
+            local: Arc::new(LocalBackend),
+            docker: Arc::new(DockerBackend),
+            tensorlake: Arc::new(TensorlakeBackend::from_env()),
         }
     }
 
@@ -57,60 +134,32 @@ impl BashExecTransport {
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
-        let mode = match resolve_mode(address, self.root_dir.as_deref()) {
-            Ok(m) => m,
+        let (backend, target): (Arc<dyn ExecBackend>, Option<String>) = match parse_backend(address)
+        {
+            Ok(BackendChoice::Local) => (self.local.clone(), None),
+            Ok(BackendChoice::Docker { image }) => (self.docker.clone(), Some(image)),
+            Ok(BackendChoice::Tensorlake { image }) => (self.tensorlake.clone(), Some(image)),
             Err(e) => {
-                tracing::warn!(address, error = %e, "bash-exec: cannot resolve script mode");
+                tracing::warn!(address, error = %e, "bash-exec: cannot parse address");
                 return;
             }
         };
 
-        let working_dir = match &self.working_dir {
-            WorkingDir::Root => self.root_dir.clone().map(WorkingDirResolved::Fixed),
-            WorkingDir::Script => Some(WorkingDirResolved::ScriptDir),
-            WorkingDir::Explicit(path) => Some(WorkingDirResolved::Fixed(path.clone())),
-        };
-
         let server = Arc::clone(&self.server);
-
         tokio::spawn(async move {
-            run_task(server, task_id, task_version, mode, working_dir).await;
+            run_task(server, task_id, task_version, backend, target).await;
         });
     }
 }
 
-// ─── Script and working directory modes ──────────────────────────────────────
-
-enum WorkingDirResolved {
-    Fixed(PathBuf), // root_dir or an explicit path
-    ScriptDir,      // resolved at run time from the script path
-}
-
-enum ScriptMode {
-    Inline,
-    File(PathBuf),
-}
-
-fn resolve_mode(address: &str, root_dir: Option<&Path>) -> Result<ScriptMode, String> {
-    let parsed = url::Url::parse(address).map_err(|e| format!("invalid address: {e}"))?;
-    let path = parsed.path().trim_start_matches('/');
-    if path.is_empty() {
-        return Ok(ScriptMode::Inline);
-    }
-    match root_dir {
-        None => Err("bash:///path address requires bash_exec.root_dir in config".to_string()),
-        Some(dir) => Ok(ScriptMode::File(dir.join(path))),
-    }
-}
-
-// ─── Task execution ───────────────────────────────────────────────────────────
+// ─── Orchestrator ─────────────────────────────────────────────────────────────
 
 async fn run_task(
     server: Arc<Server>,
     task_id: String,
     task_version: i64,
-    mode: ScriptMode,
-    working_dir: Option<WorkingDirResolved>,
+    backend: Arc<dyn ExecBackend>,
+    target: Option<String>,
 ) {
     let pid = format!("bash-exec-{}", fastrand::u64(..));
     let lease_timeout = server.config.tasks.lease_timeout;
@@ -135,7 +184,7 @@ async fn run_task(
     {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(error = %e, "bash-exec: task execution failed");
+            tracing::error!(error = %e, "bash-exec: task acquire failed");
             return;
         }
     };
@@ -161,103 +210,22 @@ async fn run_task(
         }
     };
 
-    // 2. Decode param.data — base64-encoded (CLI convention).
-    //    Inline mode: the decoded value IS the script.
-    //    File mode:   the decoded value is passed as RESONATE_PARAM to the script.
-    let param = decode_param(promise.param.data.as_deref());
-
-    // 3. Build the command.
-    let child = match mode {
-        ScriptMode::Inline => {
-            let script = match param {
-                Some(s) => s,
-                None => {
-                    reject_promise(
-                        &server.storage,
-                        &task_id,
-                        acquired_version,
-                        "param.data is missing",
-                    )
-                    .await;
-                    return;
-                }
-            };
-            Command::new("bash")
-                .arg("-c")
-                .arg(script)
-                .env("RESONATE_PROMISE_ID", &task_id)
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .spawn()
-        }
-        ScriptMode::File(path) => {
-            if !path.exists() {
-                reject_promise(
-                    &server.storage,
-                    &task_id,
-                    acquired_version,
-                    &format!("script not found: {}", path.display()),
-                )
-                .await;
-                return;
-            }
-            let args: Vec<String> = match param.as_deref() {
-                None | Some("") => vec![],
-                Some(s) => match serde_json::from_str::<Vec<serde_json::Value>>(s) {
-                    Ok(arr) => arr
-                        .iter()
-                        .map(|v| match v {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        })
-                        .collect(),
-                    Err(_) => {
-                        reject_promise(
-                            &server.storage,
-                            &task_id,
-                            acquired_version,
-                            "param.data must be a JSON array for named scripts",
-                        )
-                        .await;
-                        return;
-                    }
-                },
-            };
-            let mut cmd = Command::new("bash");
-            cmd.arg(&path)
-                .args(args)
-                .env("RESONATE_PROMISE_ID", &task_id)
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped());
-            if let Some(wd) = working_dir {
-                let dir = match wd {
-                    WorkingDirResolved::Fixed(d) => d,
-                    WorkingDirResolved::ScriptDir => path
-                        .parent()
-                        .map(|p| p.to_path_buf())
-                        .unwrap_or_else(|| path.clone()),
-                };
-                cmd.current_dir(dir);
-            }
-            cmd.spawn()
-        }
-    };
-
-    let child = match child {
-        Ok(c) => c,
-        Err(e) => {
+    // 2. Decode script — param.data is base64-encoded; the decoded value IS the script.
+    let script = match decode_param(promise.param.data.as_deref()) {
+        Some(s) => s,
+        None => {
             reject_promise(
                 &server.storage,
                 &task_id,
                 acquired_version,
-                &format!("failed to spawn bash: {e}"),
+                "param.data is missing or not valid base64/utf-8",
             )
             .await;
             return;
         }
     };
 
-    // 4. Heartbeat — refreshes the lease while bash runs.
+    // 3. Heartbeat — refreshes the lease while the backend runs.
     let heartbeat = {
         let storage = Arc::clone(&server.storage);
         let task_id = task_id.clone();
@@ -265,7 +233,7 @@ async fn run_task(
         let version = acquired_version;
         tokio::spawn(async move {
             let beat_ms = (lease_timeout / 3).max(1000) as u64;
-            let mut interval = tokio::time::interval(std::time::Duration::from_millis(beat_ms));
+            let mut interval = tokio::time::interval(Duration::from_millis(beat_ms));
             interval.tick().await;
             loop {
                 interval.tick().await;
@@ -279,63 +247,406 @@ async fn run_task(
         })
     };
 
-    // 5. Wait for bash to finish.
-    let output = child.wait_with_output().await;
+    // 4. Run.
+    tracing::debug!(task_id, backend = backend.name(), "bash-exec: running");
+    let outcome = backend
+        .run(ExecRequest {
+            task_id: task_id.clone(),
+            script,
+            target,
+            created_at: promise.created_at,
+            timeout_at: promise.timeout_at,
+        })
+        .await;
     heartbeat.abort();
 
-    // 6. Handle outcome.
-    match output {
-        Err(e) => {
-            reject_promise(
-                &server.storage,
-                &task_id,
-                acquired_version,
-                &format!("bash wait failed: {e}"),
-            )
-            .await;
+    // 5. Fulfill, reject, or drop-for-reschedule.
+    match outcome.result {
+        Err(msg) => reject_promise(&server.storage, &task_id, acquired_version, &msg).await,
+        Ok(status) if status.killed => {
+            // Process was killed (signal locally; SIGKILL/SIGTERM in container;
+            // "signaled" in sandbox). Treat as infrastructure failure: drop the
+            // task without settling so the lease expires and the message is
+            // re-dispatched to a fresh worker.
+            tracing::warn!(
+                task_id,
+                code = status.code,
+                "bash-exec: process killed, dropping task for reschedule"
+            );
         }
-        Ok(out) => {
-            let now = system_time_ms();
-            if out.status.success() {
-                let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                let _ = server
-                    .storage
-                    .transact({
-                        let task_id = task_id.clone();
-                        move |db| {
-                            db.task_fulfill(&TaskFulfillParams {
-                                task_id: &task_id,
-                                version: acquired_version,
-                                promise_id: &task_id,
-                                state: "resolved",
-                                value_headers: None,
-                                value_data: Some(&value),
-                                settled_at: now,
-                            })
-                        }
-                    })
-                    .await;
+        Ok(status) if status.code == 0 => {
+            let value = status.stdout.trim().to_string();
+            fulfill_promise(&server.storage, &task_id, acquired_version, &value).await;
+        }
+        Ok(status) => {
+            let stderr = status.stderr.trim();
+            let reason = if stderr.is_empty() {
+                format!("exit code {}", status.code)
             } else {
-                let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-                let code = out.status.code().unwrap_or(-1);
-                let reason = if stderr.is_empty() {
-                    format!("exit code {code}")
-                } else {
-                    stderr
-                };
-                reject_promise(&server.storage, &task_id, acquired_version, &reason).await;
+                stderr.to_string()
+            };
+            reject_promise(&server.storage, &task_id, acquired_version, &reason).await;
+        }
+    }
+}
+
+// ─── Backend: Local ───────────────────────────────────────────────────────────
+
+pub struct LocalBackend;
+
+#[async_trait]
+impl ExecBackend for LocalBackend {
+    fn name(&self) -> &'static str {
+        "local"
+    }
+
+    async fn run(&self, req: ExecRequest) -> ExecOutcome {
+        let mut cmd = Command::new("bash");
+        cmd.arg("-c").arg(&req.script);
+        for (k, v) in exec_env(&req) {
+            cmd.env(k, v);
+        }
+        let child = cmd
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn();
+        let child = match child {
+            Ok(c) => c,
+            Err(e) => return err(format!("failed to spawn bash: {e}")),
+        };
+        match child.wait_with_output().await {
+            Err(e) => err(format!("bash wait failed: {e}")),
+            Ok(out) => {
+                use std::os::unix::process::ExitStatusExt;
+                let killed = out.status.signal().is_some();
+                let code = out
+                    .status
+                    .code()
+                    .or_else(|| out.status.signal().map(|s| 128 + s))
+                    .unwrap_or(-1);
+                ok(
+                    code,
+                    String::from_utf8_lossy(&out.stdout).to_string(),
+                    String::from_utf8_lossy(&out.stderr).to_string(),
+                    killed,
+                )
             }
         }
     }
 }
 
+// ─── Backend: Docker ──────────────────────────────────────────────────────────
+
+pub struct DockerBackend;
+
+#[async_trait]
+impl ExecBackend for DockerBackend {
+    fn name(&self) -> &'static str {
+        "docker"
+    }
+
+    async fn run(&self, req: ExecRequest) -> ExecOutcome {
+        let image = match req.target.as_deref() {
+            Some(i) if !i.is_empty() => i,
+            _ => return err("docker backend requires an image (bash://docker/<image>)".into()),
+        };
+        let mut cmd = Command::new("docker");
+        cmd.args(["run", "--rm"]);
+        for (k, v) in exec_env(&req) {
+            cmd.arg("-e").arg(format!("{k}={v}"));
+        }
+        cmd.args(["--entrypoint", "bash", image, "-c", &req.script]);
+        let child = cmd
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn();
+        let child = match child {
+            Ok(c) => c,
+            Err(e) => return err(format!("failed to spawn docker: {e}")),
+        };
+        match child.wait_with_output().await {
+            Err(e) => err(format!("docker wait failed: {e}")),
+            Ok(out) => {
+                use std::os::unix::process::ExitStatusExt;
+                let code = out.status.code().unwrap_or(-1);
+                // `docker run` exits normally even when the container was killed —
+                // it propagates the container's exit code as 128+signal. Treat the
+                // common signal codes (137=SIGKILL, 143=SIGTERM) as kills, plus the
+                // case where the docker CLI itself was signal-killed.
+                let killed = out.status.signal().is_some() || matches!(code, 137 | 143);
+                ok(
+                    code,
+                    String::from_utf8_lossy(&out.stdout).to_string(),
+                    String::from_utf8_lossy(&out.stderr).to_string(),
+                    killed,
+                )
+            }
+        }
+    }
+}
+
+// ─── Backend: Tensorlake ──────────────────────────────────────────────────────
+//
+// Per-call lifecycle: create sandbox → wait for running → start process →
+// poll until exited → fetch stdout/stderr → delete sandbox.
+//
+// API key from TENSORLAKE_API_KEY env var. If absent at call time, the backend
+// returns a clear error instead of attempting any HTTP.
+
+pub struct TensorlakeBackend {
+    api_key: Option<String>,
+    client: reqwest::Client,
+}
+
+impl TensorlakeBackend {
+    pub fn from_env() -> Self {
+        Self {
+            api_key: std::env::var("TENSORLAKE_API_KEY").ok(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+const TENSORLAKE_API: &str = "https://api.tensorlake.ai";
+const SANDBOX_READY_TIMEOUT_MS: u64 = 120_000;
+const SANDBOX_POLL_INTERVAL_MS: u64 = 1_000;
+const PROCESS_POLL_INTERVAL_MS: u64 = 500;
+
+#[async_trait]
+impl ExecBackend for TensorlakeBackend {
+    fn name(&self) -> &'static str {
+        "tensorlake"
+    }
+
+    async fn run(&self, req: ExecRequest) -> ExecOutcome {
+        let api_key = match &self.api_key {
+            Some(k) => k.clone(),
+            None => return err("TENSORLAKE_API_KEY env var not set".into()),
+        };
+        // Empty image → omit from request, server picks the default environment.
+        let image = req.target.as_deref().filter(|s| !s.is_empty());
+
+        // 1. Create sandbox.
+        let mut body = json!({ "timeout_secs": 600 });
+        if let Some(img) = image {
+            body["image"] = json!(img);
+        }
+        let create: serde_json::Value = match self
+            .client
+            .post(format!("{TENSORLAKE_API}/sandboxes"))
+            .bearer_auth(&api_key)
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(r) => match r.json().await {
+                Ok(v) => v,
+                Err(e) => return err(format!("tensorlake create: bad json: {e}")),
+            },
+            Err(e) => return err(format!("tensorlake create: {e}")),
+        };
+        let sandbox_id = match create.get("sandbox_id").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => return err(format!("tensorlake create: no sandbox_id in {create}")),
+        };
+
+        // From here on, always best-effort delete the sandbox before returning.
+        let outcome = self
+            .run_in_sandbox(&api_key, &sandbox_id, &req)
+            .await;
+        let _ = self
+            .client
+            .delete(format!("{TENSORLAKE_API}/sandboxes/{sandbox_id}"))
+            .bearer_auth(&api_key)
+            .send()
+            .await;
+        outcome
+    }
+}
+
+impl TensorlakeBackend {
+    async fn run_in_sandbox(
+        &self,
+        api_key: &str,
+        sandbox_id: &str,
+        req: &ExecRequest,
+    ) -> ExecOutcome {
+        // 2. Wait for sandbox to become running.
+        let mut waited = 0u64;
+        loop {
+            let st = match self
+                .client
+                .get(format!("{TENSORLAKE_API}/sandboxes/{sandbox_id}"))
+                .bearer_auth(api_key)
+                .send()
+                .await
+            {
+                Ok(r) => r
+                    .json::<serde_json::Value>()
+                    .await
+                    .ok()
+                    .and_then(|v| {
+                        v.get("status")
+                            .and_then(|s| s.as_str())
+                            .map(|s| s.to_string())
+                    })
+                    .unwrap_or_default(),
+                Err(_) => String::new(),
+            };
+            match st.as_str() {
+                "running" => break,
+                "terminated" | "suspended" => {
+                    return err(format!("tensorlake: sandbox entered {st} before running"));
+                }
+                _ => {}
+            }
+            if waited >= SANDBOX_READY_TIMEOUT_MS {
+                return err("tensorlake: sandbox did not become running in time".into());
+            }
+            tokio::time::sleep(Duration::from_millis(SANDBOX_POLL_INTERVAL_MS)).await;
+            waited += SANDBOX_POLL_INTERVAL_MS;
+        }
+
+        let host = format!("https://{sandbox_id}.sandbox.tensorlake.ai");
+
+        // 3. Start the process.
+        let env_obj: serde_json::Map<String, serde_json::Value> = exec_env(req)
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), serde_json::Value::String(v)))
+            .collect();
+        let start: serde_json::Value = match self
+            .client
+            .post(format!("{host}/api/v1/processes"))
+            .bearer_auth(api_key)
+            .json(&json!({
+                "command": "bash",
+                "args": ["-c", &req.script],
+                "env": env_obj,
+                "stdout_mode": "capture",
+                "stderr_mode": "capture",
+            }))
+            .send()
+            .await
+        {
+            Ok(r) => match r.json().await {
+                Ok(v) => v,
+                Err(e) => return err(format!("tensorlake start: bad json: {e}")),
+            },
+            Err(e) => return err(format!("tensorlake start: {e}")),
+        };
+        let pid = match start.get("pid").and_then(|v| v.as_i64()) {
+            Some(p) => p,
+            None => return err(format!("tensorlake start: no pid in {start}")),
+        };
+
+        // 4. Poll until exited / signaled.
+        let final_status = loop {
+            let s: serde_json::Value = match self
+                .client
+                .get(format!("{host}/api/v1/processes/{pid}"))
+                .bearer_auth(api_key)
+                .send()
+                .await
+            {
+                Ok(r) => r.json().await.unwrap_or_else(|_| json!({})),
+                Err(_) => json!({}),
+            };
+            match s.get("status").and_then(|v| v.as_str()).unwrap_or("running") {
+                "exited" | "signaled" => break s,
+                _ => tokio::time::sleep(Duration::from_millis(PROCESS_POLL_INTERVAL_MS)).await,
+            }
+        };
+
+        let killed = final_status
+            .get("status")
+            .and_then(|v| v.as_str())
+            .map(|s| s == "signaled")
+            .unwrap_or(false);
+        let code = final_status
+            .get("exit_code")
+            .and_then(|v| v.as_i64())
+            .map(|c| c as i32)
+            .unwrap_or(-1);
+
+        // 5. Fetch combined output. The `?stream=stdout/stderr` filter is silently
+        // ignored by the API as of 2026-05; one fetch returns both streams
+        // interleaved as a `lines` array. We use it for both fields so the
+        // success path gets the script output and the failure path gets a
+        // useful rejection reason.
+        let combined = fetch_lines(
+            &self.client,
+            api_key,
+            &format!("{host}/api/v1/processes/{pid}/output"),
+        )
+        .await;
+
+        ok(code, combined.clone(), combined, killed)
+    }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn ok(code: i32, stdout: String, stderr: String, killed: bool) -> ExecOutcome {
+    ExecOutcome {
+        result: Ok(ExitStatus {
+            code,
+            stdout,
+            stderr,
+            killed,
+        }),
+    }
+}
+
+fn err(msg: String) -> ExecOutcome {
+    ExecOutcome { result: Err(msg) }
+}
+
+/// Tensorlake's `/output` endpoint returns `{"lines":[...], "line_count":N}`.
+/// Fetch and join with `\n`. Returns empty string on any error.
+async fn fetch_lines(client: &reqwest::Client, api_key: &str, url: &str) -> String {
+    let resp = match client.get(url).bearer_auth(api_key).send().await {
+        Ok(r) => r,
+        Err(_) => return String::new(),
+    };
+    let body: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(_) => return String::new(),
+    };
+    body.get("lines")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
+}
 
 fn decode_param(data: Option<&str>) -> Option<String> {
     use base64::Engine;
     let d = data.filter(|s| !s.is_empty())?;
     let bytes = base64::engine::general_purpose::STANDARD.decode(d).ok()?;
     String::from_utf8(bytes).ok()
+}
+
+async fn fulfill_promise(storage: &Storage, task_id: &str, version: i64, value: &str) {
+    let now = system_time_ms();
+    let task_id = task_id.to_string();
+    let value = value.to_string();
+    let _ = storage
+        .transact(move |db| {
+            db.task_fulfill(&TaskFulfillParams {
+                task_id: &task_id,
+                version,
+                promise_id: &task_id,
+                state: "resolved",
+                value_headers: None,
+                value_data: Some(&value),
+                settled_at: now,
+            })
+        })
+        .await;
 }
 
 async fn reject_promise(storage: &Storage, task_id: &str, version: i64, reason: &str) {
@@ -355,4 +666,75 @@ async fn reject_promise(storage: &Storage, task_id: &str, version: i64, reason: 
             })
         })
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_local_empty() {
+        assert!(matches!(parse_backend("bash://"), Ok(BackendChoice::Local)));
+    }
+
+    #[test]
+    fn parse_local_explicit() {
+        assert!(matches!(
+            parse_backend("bash://bash"),
+            Ok(BackendChoice::Local)
+        ));
+    }
+
+    #[test]
+    fn parse_local_rejects_path() {
+        assert!(parse_backend("bash:///some/path").is_err());
+    }
+
+    #[test]
+    fn parse_docker() {
+        match parse_backend("bash://docker/alpine").unwrap() {
+            BackendChoice::Docker { image } => assert_eq!(image, "alpine"),
+            _ => panic!("expected Docker"),
+        }
+    }
+
+    #[test]
+    fn parse_docker_with_tag() {
+        match parse_backend("bash://docker/library/ubuntu:latest").unwrap() {
+            BackendChoice::Docker { image } => assert_eq!(image, "library/ubuntu:latest"),
+            _ => panic!("expected Docker"),
+        }
+    }
+
+    #[test]
+    fn parse_docker_requires_image() {
+        assert!(parse_backend("bash://docker").is_err());
+        assert!(parse_backend("bash://docker/").is_err());
+    }
+
+    #[test]
+    fn parse_tensorlake() {
+        match parse_backend("bash://tensorlake/python-3.11").unwrap() {
+            BackendChoice::Tensorlake { image } => assert_eq!(image, "python-3.11"),
+            _ => panic!("expected Tensorlake"),
+        }
+    }
+
+    #[test]
+    fn parse_tensorlake_default_image() {
+        match parse_backend("bash://tensorlake/").unwrap() {
+            BackendChoice::Tensorlake { image } => assert_eq!(image, ""),
+            _ => panic!("expected Tensorlake"),
+        }
+    }
+
+    #[test]
+    fn parse_unknown_backend() {
+        assert!(parse_backend("bash://nope/foo").is_err());
+    }
+
+    #[test]
+    fn parse_wrong_scheme() {
+        assert!(parse_backend("http://x").is_err());
+    }
 }

--- a/src/transport/transport_exec_bash.rs
+++ b/src/transport/transport_exec_bash.rs
@@ -73,7 +73,10 @@ enum BackendChoice {
 fn parse_backend(address: &str) -> Result<BackendChoice, String> {
     let parsed = url::Url::parse(address).map_err(|e| format!("invalid address: {e}"))?;
     if parsed.scheme() != "bash" {
-        return Err(format!("expected bash:// scheme, got {}://", parsed.scheme()));
+        return Err(format!(
+            "expected bash:// scheme, got {}://",
+            parsed.scheme()
+        ));
     }
     let host = parsed.host_str().unwrap_or("");
     let path = parsed.path().trim_start_matches('/');
@@ -451,9 +454,7 @@ impl ExecBackend for TensorlakeBackend {
         };
 
         // From here on, always best-effort delete the sandbox before returning.
-        let outcome = self
-            .run_in_sandbox(&api_key, &sandbox_id, &req)
-            .await;
+        let outcome = self.run_in_sandbox(&api_key, &sandbox_id, &req).await;
         let _ = self
             .client
             .delete(format!("{TENSORLAKE_API}/sandboxes/{sandbox_id}"))
@@ -551,7 +552,11 @@ impl TensorlakeBackend {
                 Ok(r) => r.json().await.unwrap_or_else(|_| json!({})),
                 Err(_) => json!({}),
             };
-            match s.get("status").and_then(|v| v.as_str()).unwrap_or("running") {
+            match s
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("running")
+            {
                 "exited" | "signaled" => break s,
                 _ => tokio::time::sleep(Duration::from_millis(PROCESS_POLL_INTERVAL_MS)).await,
             }


### PR DESCRIPTION
Refactor the bash transport into an ExecBackend trait with three per-call backends, addressed by URL host:

- bash://                  → local bash (existing behavior, simplified)
- bash://docker/<image>    → docker run --rm --entrypoint bash
- bash://tensorlake/<image> → Tensorlake Sandboxes (create → exec → delete)

The orchestrator (acquire / heartbeat / fulfill / reject) lives once and is backend-agnostic. Killed runs (signal locally, exit 137/143 in docker, "signaled" in Tensorlake) drop the task without settling so the lease expires and the message is re-dispatched, instead of rejecting the promise. This generalizes the prior fix-bash-exec-signal-killed patch to all three backends.

Drops named-script support (bash:///path with arg array) — durable promises restart from the top, and named scripts living on the host break the moment the script is mounted into a container or sandbox. Inline-only is consistent across backends.

All scripts now receive three env vars regardless of backend: RESONATE_PROMISE_ID, RESONATE_PROMISE_CREATED_AT,
RESONATE_PROMISE_TIMEOUT_AT. The last two are stable across retries, which lets scripts loop until the deadline rather than for a fixed duration — making time-bounded bash idempotent across restart-from-top.

Tensorlake-specific notes:
- API key is read from TENSORLAKE_API_KEY env at backend construction.
- Empty image (bash://tensorlake/) → omit from create body, server picks the default sandbox environment.
- Doc index advertised /api/v2/processes/... but the live API is /api/v1 for everything; corrected.
- /output returns {"lines":[...], "line_count":N}, not raw text; parsed accordingly. The ?stream=stdout/stderr filter is silently ignored, so one combined fetch is used for both stdout and stderr fields.

Config simplifies: bash_exec.{root_dir, working_dir} removed; only bash_exec.enabled remains. MCP resonate-bash tool drops scriptPath/args in favor of an optional `target` address override.