### PR TITLE
fix: handle pending/acquired awaiters in enqueue-resume path

### DIFF
--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -393,15 +393,22 @@ impl Oracle {
                 .promises
                 .get(&r.awaiter)
                 .and_then(|p| p.tags.get("resonate:target").cloned());
-            if task_state == Some(TaskState::Suspended) {
-                if let Some(t) = self.tasks.get_mut(&r.awaiter) {
-                    t.state = TaskState::Pending;
-                    // Don't add to t.resumes: SQLite has no ready-callback entry for direct resumes.
+            match task_state {
+                Some(TaskState::Suspended) => {
+                    if let Some(t) = self.tasks.get_mut(&r.awaiter) {
+                        t.state = TaskState::Pending;
+                    }
+                    self.set_t_timeout(&r.awaiter, TTimeoutKind::Retry, now + PENDING_RETRY_TTL);
+                    if let Some(addr) = addr {
+                        self.send_execute(&addr, &r.awaiter, version);
+                    }
                 }
-                self.set_t_timeout(&r.awaiter, TTimeoutKind::Retry, now + PENDING_RETRY_TTL);
-                if let Some(addr) = addr {
-                    self.send_execute(&addr, &r.awaiter, version);
+                Some(TaskState::Pending) | Some(TaskState::Acquired) => {
+                    if let Some(t) = self.tasks.get_mut(&r.awaiter) {
+                        t.resumes.insert(r.awaited.clone());
+                    }
                 }
+                _ => {}
             }
         }
 

--- a/src/persistence/persistence_mysql.rs
+++ b/src/persistence/persistence_mysql.rs
@@ -985,6 +985,19 @@ impl Db for MysqlDb<'_> {
                         .execute(self.tx().as_mut()),
                     )?;
                 }
+
+                // EnqueueResume #96/#97: insert ready callback for pending/acquired awaiters
+                rt_block_on(
+                    sqlx::query(
+                        "INSERT IGNORE INTO callbacks (awaited_id, awaiter_id, ready)
+                         SELECT ?, ?, true FROM tasks
+                         WHERE id = ? AND state IN ('pending', 'acquired')",
+                    )
+                    .bind(awaited_id)
+                    .bind(awaiter_id)
+                    .bind(awaiter_id)
+                    .execute(self.tx().as_mut()),
+                )?;
             }
             _ => {}
         }

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -731,6 +731,15 @@ impl Db for PostgresDb<'_> {
               SELECT t.id, t.version, p.target FROM resumed_tasks t JOIN promises p ON p.id = t.id
               ON CONFLICT (id) DO UPDATE SET version = EXCLUDED.version, address = EXCLUDED.address
               RETURNING id
+            ),
+            -- EnqueueResume #96/#97: insert ready callback for pending/acquired awaiters
+            inserted_ready_callback AS (
+              INSERT INTO callbacks (awaited_id, awaiter_id, ready)
+              SELECT $1, $2, true
+              WHERE EXISTS (SELECT 1 FROM awaited WHERE state != 'pending')
+                AND EXISTS (SELECT 1 FROM tasks WHERE id = $2 AND state IN ('pending', 'acquired'))
+              ON CONFLICT (awaited_id, awaiter_id) DO NOTHING
+              RETURNING awaited_id
             )
             SELECT 'awaited' AS type, id, state, param_headers::text, param_data, value_headers::text, value_data, tags::text, timeout_at, created_at, settled_at FROM awaited
             UNION ALL

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -585,6 +585,16 @@ impl<'a> Db for SqliteDb<'a> {
                         )?;
                     }
                 }
+
+                // EnqueueResume #96/#97: insert ready callback for pending/acquired awaiters
+                self.conn.execute(
+                    "INSERT OR IGNORE INTO callbacks (awaited_id, awaiter_id, ready)
+                     SELECT ?1, ?2, true
+                     WHERE EXISTS (
+                       SELECT 1 FROM tasks WHERE id = ?2 AND state IN ('pending', 'acquired')
+                     )",
+                    params![awaited_id, awaiter_id],
+                )?;
             }
         }
 


### PR DESCRIPTION
## Summary

- Expands oracle task-state handling to cover `Pending` and `Acquired` states in addition to `Suspended` — instead of re-executing, it queues the awaited promise into `task.resumes` for pickup on the next heartbeat cycle
- Adds a ready-callback insert across all three persistence backends (SQLite, Postgres, MySQL) so pending/acquired awaiters get correctly notified when their awaited promise settles

## Test plan

- [ ] Run existing test suite (`cargo test`)
- [ ] Manually verify a task in `pending` state correctly resumes after its awaited promise settles
- [ ] Manually verify a task in `acquired` state correctly resumes after its awaited promise settles
- [ ] Confirm no regression for the existing `suspended` → resume path

Fixes #96, #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)