### PR TITLE
docs: bring server README up to component standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,45 @@
-![resonate banner](./assets/resonate-banner.png)
+![resonate component banner](./assets/resonate-banner.png)
 
 # Resonate Server
+
+[![CI](https://github.com/resonatehq/resonate/actions/workflows/ci.yml/badge.svg)](https://github.com/resonatehq/resonate/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## About this component
 
 The Resonate Server is a highly efficient single binary that pairs with a Resonate SDK to bring durable execution to your application — reliable, distributed function execution that survives process restarts and failures. It acts as both a supervisor and orchestrator for Resonate Workers, persisting execution state so long-running functions always run to completion.
 
+- [Open an issue or pull request](https://github.com/resonatehq/resonate/issues)
 - [Evaluate Resonate for your next project](https://docs.resonatehq.io/evaluate/)
 - [Example application library](https://github.com/resonatehq-examples)
-- [The concepts that power Resonate](https://www.distributed-async-await.io/)
+- [Distributed Async Await — the concepts that power Resonate](https://www.distributed-async-await.io/)
 - [Join the Discord](https://resonatehq.io/discord)
-- [Subscribe to the Blog](https://journal.resonatehq.io/subscribe)
+- [Subscribe to the Journal](https://journal.resonatehq.io/subscribe)
 - [Follow on X](https://x.com/resonatehqio)
 - [Follow on LinkedIn](https://www.linkedin.com/company/resonatehqio)
 - [Subscribe on YouTube](https://www.youtube.com/@resonatehqio)
 
-## Resonate quickstart
+## Quickstart
 
-![resonate quickstart banner](./assets/quickstart-banner.png)
+![quickstart banner](./assets/quickstart-banner.png)
 
-### 1. Install the Resonate Server & CLI
+1. Install the Resonate Server & CLI
 
 ```shell
 brew install resonatehq/tap/resonate
 ```
 
-### 2. Install the Resonate SDK
-
-#### TypeScript
+2. Install the Resonate SDK
 
 ```shell
 npm install @resonatehq/sdk
 ```
 
-### 3. Write your first Resonate Function
+3. Write your first Resonate Function
 
 A countdown as a loop. Simple, but the function can run for minutes, hours, or days, despite restarts.
 
-#### TypeScript (countdown.ts)
+Save the following as `countdown.ts`:
 
 ```typescript
 import { Resonate, type Context } from "@resonatehq/sdk";
@@ -57,38 +59,33 @@ const resonate = new Resonate({ url: "http://localhost:8001" });
 resonate.register(countdown);
 ```
 
-[Working example](https://github.com/resonatehq-examples/example-quickstart-ts)
+[Clone a working example repo](https://github.com/resonatehq-examples/example-quickstart-ts)
 
-### 4. Start the server
+4. Start the server
 
 ```shell
 resonate serve
 ```
 
-### 5. Start the worker
-
-#### TypeScript
+5. Start the worker
 
 ```shell
 npx ts-node countdown.ts
 ```
 
-### 6. Activate the function
+6. Run the function
 
-Activate the function with execution ID `countdown.1`:
+Run the function with execution ID `countdown.1`:
 
 ```shell
 resonate invoke countdown.1 --func countdown --arg 5 --arg 60
 ```
 
-### 7. Result
+**Result**
 
-You will see the countdown in the terminal
-
-#### TypeScript
+You will see the countdown in the terminal running the worker:
 
 ```shell
-npx ts-node countdown.ts
 Countdown: 5
 Countdown: 4
 Countdown: 3
@@ -97,13 +94,21 @@ Countdown: 1
 Done!
 ```
 
-### What to try
+**What to try**
+
+After starting the function, inspect the current state of the execution using the `resonate tree` command. The tree command visualizes the call graph of the function execution as a graph of durable promises.
+
+```shell
+resonate tree countdown.1
+```
+
+Now try killing the worker mid-countdown and restarting. **The countdown picks up right where it left off without missing a beat.**
 
 ## More ways to install the server
 
 For more Resonate Server deployment information see the [Set up and run a Resonate Server](https://docs.resonatehq.io/operate/run-server) guide.
 
-## Install with Homebrew
+### Install with Homebrew
 
 You can download and install the Resonate Server using Homebrew with the following commands:
 
@@ -111,7 +116,7 @@ You can download and install the Resonate Server using Homebrew with the followi
 brew install resonatehq/tap/resonate
 ```
 
-This previous example installs the latest release.
+This installs the latest release.
 You can see all available releases and associated release artifacts on the [releases page](https://github.com/resonatehq/resonate/releases).
 
 Once installed, you can start the server with:
@@ -123,11 +128,11 @@ resonate serve
 You will see log output like the following:
 
 ```shell
-2026-04-02T05:05:32.480430Z  INFO resonate: Resonate Server starting on port 8001
-2026-04-02T05:05:32.480805Z  INFO resonate: Using SQLite backend: resonate.db
+2026-04-02T05:05:32.480430Z  INFO resonate: Resonate Server starting port=8001
+2026-04-02T05:05:32.480805Z  INFO resonate: Using SQLite backend path=resonate.db
 2026-04-02T05:05:32.486547Z  INFO resonate: SQLite initialized
-2026-04-02T05:05:32.492689Z  INFO resonate: Metrics server listening on 0.0.0.0:9090
-2026-04-02T05:05:32.492915Z  INFO resonate: Server listening on 0.0.0.0:8001
+2026-04-02T05:05:32.492689Z  INFO resonate: Metrics server listening port=9090
+2026-04-02T05:05:32.492915Z  INFO resonate: Server listening bind=0.0.0.0 port=8001 server_url=http://localhost:8001
 ```
 
 The output indicates that the server has HTTP endpoints available at port 8001 and a metrics endpoint at port 9090.
@@ -138,34 +143,38 @@ The SDKs are all configured to use these defaults unless otherwise specified.
 ### Run with Docker
 
 The Resonate Server repository contains a Dockerfile that you can use to build and run the server in a Docker container.
-You can also clone the repository and start the server using Docker Compose:
+You can also clone the repository and start the server using Docker Compose.
+The Compose services are gated behind profiles, so select a storage backend with `--profile`:
 
 ```shell
 git clone https://github.com/resonatehq/resonate
 cd resonate
-docker-compose up
+# SQLite backend
+docker compose --profile sqlite up
+# or, the Postgres backend
+docker compose --profile postgres up
 ```
 
 ### Build from source
 
-If you don't have Homebrew, we recommend building from source using Cargo.
+If Homebrew is unavailable, build from source using Cargo.
 Run the following commands to download the repository and build the server:
 
-```
+```shell
 git clone https://github.com/resonatehq/resonate
 cd resonate
 cargo build --release
 ```
 
-After it is built, you can compile and run it as a Go program using the following command:
+You can build and run the server in one step with Cargo:
 
-```
-cargo run serve
+```shell
+cargo run --release -- serve
 ```
 
-Or, you can run it as an executable using the following command:
+Or run the compiled binary directly:
 
-```
+```shell
 ./target/release/resonate serve
 ```
 


### PR DESCRIPTION
Brings the Resonate Server README in line with the SDK-repo README template and fixes several inaccuracies. Reviewed by a small team of agents (technical-accuracy, sibling-repo consistency, editorial/hygiene); all command and log claims below were verified against the source and a locally-run server.

## Standards alignment
- Add **CI** badge (`ci.yml` exists) and **Apache-2.0 license** badge (LICENSE is now on `main`)
- Add an **"Open an issue or pull request"** contribution link (issues URL — this repo has no `CONTRIBUTING.md`, so no broken `./CONTRIBUTING.md` link)
- Reformat the quickstart to match the canonical TS SDK template: numbered list, bold **Result** / **What to try**, consistent banner alt text and link labels
- Fill in the previously **empty `What to try` section** with the `resonate tree` + crash-recovery demo
- Fix heading hierarchy (Homebrew / Docker / Build-from-source are now peers under "More ways to install")

## Accuracy fixes
- **Build from source:** the server is a Rust binary, so `cargo run --release -- serve` / the compiled binary — not "compile and run it as a Go program"
- **Docker Compose:** services are gated behind `sqlite` / `postgres` profiles, so a bare `docker-compose up` starts nothing. Updated to `docker compose --profile sqlite up` (and the postgres variant)
- **Startup logs:** corrected the example output to the server's real structured-logging format (`port=8001`, `Using SQLite backend path=resonate.db`, `Server listening bind=0.0.0.0 port=8001 ...`) — verified by running the built binary
- Minor copy cleanups ("we recommend" → direct phrasing; "This previous example" → "This")

🤖 Generated with [Claude Code](https://claude.com/claude-code)