### PR TITLE
feat: protocol updates — delay, origin checks, target-gated timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: resonatehq/resonate-test
+          ref: feat/protocol-updates # TODO: temporary, remove once merged
           token: ${{ secrets.TESTBED_TOKEN }}
           path: test/resonate-test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: resonatehq/resonate-test
-          ref: feat/protocol-updates # TODO: temporary, remove once merged
           token: ${{ secrets.TESTBED_TOKEN }}
           path: test/resonate-test
 

--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -974,7 +974,7 @@ fn gen_schedule_create(rng: &mut fastrand::Rng, now: i64) -> RequestEnvelope {
             "promiseId": format!("sched-promise-{{{{.id}}}}-{{{{.timestamp}}}}"),
             "promiseTimeout": promise_timeout,
             "promiseParam": {},
-            "promiseTags": {}
+            "promiseTags": { "resonate:target": WORKER_URL }
         }),
     )
 }

--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -625,9 +625,10 @@ fn pick_op(rng: &mut fastrand::Rng, oracle: &Oracle, covered: &HashMap<String, u
     let has_suspended = oracle.has_tasks_in_state(TaskState::Suspended);
     let has_halted = oracle.has_tasks_in_state(TaskState::Halted);
     let has_pending_p = oracle.has_pending_promises();
+    let has_pending_p_with_target = oracle.has_pending_promises_with_target();
     let has_schedules = oracle.has_schedules();
 
-    if uncovered("task.suspend") && has_acquired && has_pending_p {
+    if uncovered("task.suspend") && has_acquired && has_pending_p_with_target {
         return Op::TaskSuspend;
     }
     if uncovered("task.continue") && has_halted {
@@ -645,7 +646,10 @@ fn pick_op(rng: &mut fastrand::Rng, oracle: &Oracle, covered: &HashMap<String, u
     if uncovered("task.acquire") && has_pending_t {
         return Op::TaskAcquire;
     }
-    if uncovered("promise.register_callback") && has_pending_p && (has_acquired || has_pending_t) {
+    if uncovered("promise.register_callback")
+        && has_pending_p_with_target
+        && (has_acquired || has_pending_t)
+    {
         return Op::PromiseRegisterCallback;
     }
     if uncovered("promise.register_listener") && has_pending_p {
@@ -1002,10 +1006,10 @@ fn gen_debug_tick(rng: &mut fastrand::Rng, now: i64) -> (RequestEnvelope, i64) {
 }
 
 fn promise_id(n: u32) -> String {
-    format!("p{n}")
+    format!("diff.p{n}")
 }
 fn task_id(n: u32) -> String {
-    format!("t{n}")
+    format!("diff.t{n}")
 }
 fn schedule_id(n: u32) -> String {
     format!("s{n}")

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -261,7 +261,9 @@ impl Oracle {
                 );
             }
         } else {
-            self.set_p_timeout(&r.id, r.timeout_at);
+            if addr.is_some() {
+                self.set_p_timeout(&r.id, r.timeout_at);
+            }
             if let Some(ref addr) = addr {
                 self.tasks.insert(
                     r.id.clone(),
@@ -1145,7 +1147,9 @@ impl Oracle {
                             );
                         }
                     } else {
-                        self.set_p_timeout(&create_data.id, create_data.timeout_at);
+                        if addr.is_some() {
+                            self.set_p_timeout(&create_data.id, create_data.timeout_at);
+                        }
                         if let Some(ref a) = addr {
                             self.tasks.insert(
                                 create_data.id.clone(),
@@ -1740,19 +1744,14 @@ impl Oracle {
             }
         }
 
-        // Collect expired promise timeouts — tick only settles promises with resonate:target
-        let expired_promises: Vec<(String, PromiseState, i64)> = self
+        // Collect expired promise timeouts — after fix 1, p_timeouts only contains
+        // promises with resonate:target, and del_p_timeout is always called on settlement
+        // so all entries here are guaranteed to be Pending with a target.
+        let expired_promise_ids: Vec<String> = self
             .p_timeouts
             .iter()
             .filter(|pt| time >= pt.timeout)
-            .filter_map(|pt| {
-                self.promises
-                    .get(&pt.id)
-                    .filter(|p| {
-                        p.state == PromiseState::Pending && p.tags.contains_key("resonate:target")
-                    })
-                    .map(|p| (pt.id.clone(), Self::timeout_state(&p.tags), p.timeout_at))
-            })
+            .map(|pt| pt.id.clone())
             .collect();
 
         // Collect expired task lease timeouts
@@ -1782,18 +1781,22 @@ impl Oracle {
             .collect();
 
         // Phase 1: settle expired promises
-        for (id, state, timeout_at) in &expired_promises {
-            if let Some(p) = self.promises.get_mut(id) {
-                if p.state == PromiseState::Pending {
-                    p.state = *state;
-                    p.settled_at = Some(*timeout_at);
+        for id in &expired_promise_ids {
+            let computed = self
+                .promises
+                .get(id)
+                .map(|p| (Self::timeout_state(&p.tags), p.timeout_at));
+            if let Some((state, timeout_at)) = computed {
+                if let Some(p) = self.promises.get_mut(id) {
+                    p.state = state;
+                    p.settled_at = Some(timeout_at);
                 }
             }
             self.del_p_timeout(id);
         }
 
         // Phase 2+3: fulfill tasks, fire callbacks and listeners
-        for (id, _, _) in &expired_promises {
+        for id in &expired_promise_ids {
             self.trigger_settlement(id, time);
         }
 
@@ -1915,7 +1918,9 @@ impl Oracle {
                             );
                         }
                     } else {
-                        self.set_p_timeout(&promise_id, timeout_at);
+                        if addr.is_some() {
+                            self.set_p_timeout(&promise_id, timeout_at);
+                        }
                         if let Some(ref a) = addr {
                             self.tasks.insert(
                                 promise_id.clone(),
@@ -2282,6 +2287,12 @@ impl Oracle {
         self.promises
             .values()
             .any(|p| p.state == PromiseState::Pending)
+    }
+
+    pub fn has_pending_promises_with_target(&self) -> bool {
+        self.promises
+            .values()
+            .any(|p| p.state == PromiseState::Pending && p.tags.contains_key("resonate:target"))
     }
 
     pub fn has_schedules(&self) -> bool {

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -273,8 +273,21 @@ impl Oracle {
                         resumes: HashSet::new(),
                     },
                 );
-                self.set_t_timeout(&r.id, TTimeoutKind::Retry, created_at + PENDING_RETRY_TTL);
-                self.send_execute(addr, &r.id, 0);
+                let delay_at = r
+                    .tags
+                    .get("resonate:delay")
+                    .and_then(|v| v.parse::<i64>().ok());
+                if let Some(delay_at) = delay_at {
+                    if now < delay_at {
+                        self.set_t_timeout(&r.id, TTimeoutKind::Retry, delay_at);
+                    } else {
+                        self.set_t_timeout(&r.id, TTimeoutKind::Retry, created_at + PENDING_RETRY_TTL);
+                        self.send_execute(addr, &r.id, 0);
+                    }
+                } else {
+                    self.set_t_timeout(&r.id, TTimeoutKind::Retry, created_at + PENDING_RETRY_TTL);
+                    self.send_execute(addr, &r.id, 0);
+                }
             }
         }
         ResponseEnvelope::success(
@@ -673,7 +686,7 @@ impl Oracle {
                 req.kind.clone(),
                 req.head.corr_id.clone(),
                 422,
-                "Promise exists without a target task",
+                "The promise does not have a resonate:target tag",
             );
         }
 
@@ -778,14 +791,6 @@ impl Oracle {
                     req.head.corr_id.clone(),
                     404,
                     "Task not found",
-                )
-            }
-            Some(p) if p.state != PromiseState::Pending => {
-                return ResponseEnvelope::error(
-                    req.kind.clone(),
-                    req.head.corr_id.clone(),
-                    409,
-                    "Task is not pending",
                 )
             }
             Some(p) => Self::to_promise_record(now, &r.id, p),
@@ -1148,12 +1153,33 @@ impl Oracle {
                                     resumes: HashSet::new(),
                                 },
                             );
-                            self.set_t_timeout(
-                                &create_data.id,
-                                TTimeoutKind::Retry,
-                                created_at + PENDING_RETRY_TTL,
-                            );
-                            self.send_execute(a, &create_data.id, 0);
+                            let delay_at = create_data
+                                .tags
+                                .get("resonate:delay")
+                                .and_then(|v| v.parse::<i64>().ok());
+                            if let Some(delay_at) = delay_at {
+                                if now < delay_at {
+                                    self.set_t_timeout(
+                                        &create_data.id,
+                                        TTimeoutKind::Retry,
+                                        delay_at,
+                                    );
+                                } else {
+                                    self.set_t_timeout(
+                                        &create_data.id,
+                                        TTimeoutKind::Retry,
+                                        created_at + PENDING_RETRY_TTL,
+                                    );
+                                    self.send_execute(a, &create_data.id, 0);
+                                }
+                            } else {
+                                self.set_t_timeout(
+                                    &create_data.id,
+                                    TTimeoutKind::Retry,
+                                    created_at + PENDING_RETRY_TTL,
+                                );
+                                self.send_execute(a, &create_data.id, 0);
+                            }
                         }
                     }
                     Some(record)
@@ -1261,14 +1287,7 @@ impl Oracle {
                 })
                 .and_then(|t| t.ttl);
             if let Some(ttl) = ttl {
-                let promise_pending = self
-                    .promises
-                    .get(&task_ref.id)
-                    .map(|p| p.state == PromiseState::Pending)
-                    .unwrap_or(false);
-                if promise_pending {
-                    self.set_t_timeout(&task_ref.id, TTimeoutKind::Lease, now + ttl);
-                }
+                self.set_t_timeout(&task_ref.id, TTimeoutKind::Lease, now + ttl);
             }
         }
         ResponseEnvelope::new(req.kind.clone(), req.head.corr_id.clone(), 200, json!({}))
@@ -1334,19 +1353,6 @@ impl Oracle {
             Some(t) => t.state,
         };
         if task_state != TaskState::Halted {
-            return ResponseEnvelope::error(
-                req.kind.clone(),
-                req.head.corr_id.clone(),
-                409,
-                "Task is not halted",
-            );
-        }
-        let promise_pending = self
-            .promises
-            .get(&r.id)
-            .map(|p| p.state == PromiseState::Pending)
-            .unwrap_or(false);
-        if !promise_pending {
             return ResponseEnvelope::error(
                 req.kind.clone(),
                 req.head.corr_id.clone(),
@@ -1719,8 +1725,18 @@ impl Oracle {
                 )
             }
         };
+        if let Some(debug_time) = req.head.debug_time {
+            if debug_time != time {
+                return ResponseEnvelope::error(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    400,
+                    "resonate:debug_time must equal data.time",
+                );
+            }
+        }
 
-        // Collect expired promise timeouts
+        // Collect expired promise timeouts — tick only settles promises with resonate:target
         let expired_promises: Vec<(String, PromiseState, i64)> = self
             .p_timeouts
             .iter()
@@ -1728,7 +1744,9 @@ impl Oracle {
             .filter_map(|pt| {
                 self.promises
                     .get(&pt.id)
-                    .filter(|p| p.state == PromiseState::Pending)
+                    .filter(|p| {
+                        p.state == PromiseState::Pending && p.tags.contains_key("resonate:target")
+                    })
                     .map(|p| (pt.id.clone(), Self::timeout_state(&p.tags), p.timeout_at))
             })
             .collect();
@@ -1908,7 +1926,7 @@ impl Oracle {
                             self.set_t_timeout(
                                 &promise_id,
                                 TTimeoutKind::Retry,
-                                created_at + PENDING_RETRY_TTL,
+                                time + PENDING_RETRY_TTL,
                             );
                             self.send_execute(a, &promise_id, 0);
                         }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -281,7 +281,11 @@ impl Oracle {
                     if now < delay_at {
                         self.set_t_timeout(&r.id, TTimeoutKind::Retry, delay_at);
                     } else {
-                        self.set_t_timeout(&r.id, TTimeoutKind::Retry, created_at + PENDING_RETRY_TTL);
+                        self.set_t_timeout(
+                            &r.id,
+                            TTimeoutKind::Retry,
+                            created_at + PENDING_RETRY_TTL,
+                        );
                         self.send_execute(addr, &r.id, 0);
                     }
                 } else {

--- a/src/persistence/persistence_mysql.rs
+++ b/src/persistence/persistence_mysql.rs
@@ -796,7 +796,7 @@ impl Db for MysqlDb<'_> {
         let was_created = res.rows_affected() > 0;
         if was_created {
             // New promise — set up timeout and optional task infrastructure
-            if !already_timedout {
+            if !already_timedout && address.is_some() {
                 rt_block_on(
                     sqlx::query(
                         "INSERT IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?, ?)",
@@ -1309,7 +1309,7 @@ impl Db for MysqlDb<'_> {
             )?;
 
             if res.rows_affected() > 0 {
-                if !already_timedout {
+                if !already_timedout && address.is_some() {
                     rt_block_on(
                         sqlx::query(
                             "INSERT IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?, ?)",
@@ -2034,15 +2034,17 @@ impl Db for MysqlDb<'_> {
                     )?;
                 }
             } else {
-                // 6a. Promise timeout
-                rt_block_on(
-                    sqlx::query(
-                        "INSERT IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?, ?)",
-                    )
-                    .bind(computed_timeout_at)
-                    .bind(&computed_promise_id)
-                    .execute(self.tx().as_mut()),
-                )?;
+                // 6a. Promise timeout (only for promises with resonate:target)
+                if address.is_some() {
+                    rt_block_on(
+                        sqlx::query(
+                            "INSERT IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?, ?)",
+                        )
+                        .bind(computed_timeout_at)
+                        .bind(&computed_promise_id)
+                        .execute(self.tx().as_mut()),
+                    )?;
+                }
 
                 // 6b. Task infrastructure if address is present
                 if let Some(ref addr) = address {
@@ -2055,7 +2057,7 @@ impl Db for MysqlDb<'_> {
                         rt_block_on(
                             sqlx::query(
                                 "INSERT IGNORE INTO task_timeouts (timeout_at, id, timeout_type, ttl) VALUES (?, ?, 0, ?)"
-                            ).bind(fired_at + trt).bind(&computed_promise_id).bind(trt)
+                            ).bind(time + trt).bind(&computed_promise_id).bind(trt)
                              .execute(self.tx().as_mut())
                         )?;
                         rt_block_on(
@@ -2094,9 +2096,9 @@ impl Db for MysqlDb<'_> {
     fn process_timeouts(&self, time: i64) -> StorageResult<()> {
         let trt = self.task_retry_timeout;
 
-        // Statement 1: Expire all pending promises with timeout_at <= time
+        // Statement 1: Expire all pending promises with timeout_at <= time (with resonate:target)
         let expired_rows = rt_block_on(
-            sqlx::query("SELECT id FROM promises WHERE state = 'pending' AND timeout_at <= ?")
+            sqlx::query("SELECT id FROM promise_timeouts WHERE timeout_at <= ?")
                 .bind(time)
                 .fetch_all(self.tx().as_mut()),
         )?;

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -523,7 +523,7 @@ impl Db for PostgresDb<'_> {
             inserted_or_skipped_ptimeout AS (
               INSERT INTO promise_timeouts (timeout_at, id)
               SELECT $6, $1
-              WHERE NOT $9 AND EXISTS (SELECT 1 FROM inserted_or_skipped_promise)
+              WHERE NOT $9 AND $10::text IS NOT NULL AND EXISTS (SELECT 1 FROM inserted_or_skipped_promise)
               ON CONFLICT (id) DO NOTHING
               RETURNING id
             ),
@@ -1037,7 +1037,7 @@ impl Db for PostgresDb<'_> {
             inserted_or_skipped_ptimeout AS (
               INSERT INTO promise_timeouts (timeout_at, id)
               SELECT $8, $3
-              WHERE NOT $11 AND EXISTS (SELECT 1 FROM inserted_or_skipped_promise)
+              WHERE NOT $11 AND $12::text IS NOT NULL AND EXISTS (SELECT 1 FROM inserted_or_skipped_promise)
               ON CONFLICT (id) DO NOTHING
               RETURNING id
             ),
@@ -1793,7 +1793,7 @@ impl Db for PostgresDb<'_> {
             inserted_or_skipped_ptimeout AS (
               INSERT INTO promise_timeouts (timeout_at, id)
               SELECT p.timeout_at, p.id FROM inserted_or_skipped_promise p
-              WHERE p.state = 'pending'
+              WHERE p.state = 'pending' AND p.target IS NOT NULL
               ON CONFLICT (id) DO NOTHING
               RETURNING id
             ),
@@ -1808,7 +1808,7 @@ impl Db for PostgresDb<'_> {
             ),
             inserted_or_skipped_ttimeout AS (
               INSERT INTO task_timeouts (timeout_at, id, timeout_type, ttl)
-              SELECT ($2 + {trt}), t.id, 0, {trt}
+              SELECT ($5 + {trt}), t.id, 0, {trt}
               FROM inserted_or_skipped_task t
               WHERE t.state = 'pending'
               ON CONFLICT (id) DO NOTHING
@@ -1872,7 +1872,7 @@ impl Db for PostgresDb<'_> {
               UPDATE promises p
               SET state = CASE WHEN p.timer THEN 'resolved' ELSE 'rejected_timedout' END,
                   settled_at = p.timeout_at
-              WHERE p.state = 'pending' AND p.timeout_at <= $1
+              WHERE p.id IN (SELECT id FROM promise_timeouts WHERE timeout_at <= $1)
               RETURNING *
             ),
             deleted_ptimeout AS (

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -472,10 +472,12 @@ impl<'a> Db for SqliteDb<'a> {
                 }
             } else {
                 // Promise timeout
-                self.conn.execute(
-                    "INSERT OR IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?1, ?2)",
-                    params![timeout_at, id],
-                )?;
+                if address.is_some() {
+                    self.conn.execute(
+                        "INSERT OR IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?1, ?2)",
+                        params![timeout_at, id],
+                    )?;
+                }
                 // TaskInfraCreated
                 if let Some(addr) = address {
                     self.conn.execute(
@@ -1358,11 +1360,13 @@ impl<'a> Db for SqliteDb<'a> {
                     )?;
                 }
             } else {
-                // Step 6: Create promise_timeout
-                self.conn.execute(
-                    "INSERT OR IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?1, ?2)",
-                    params![promise_timeout_at, promise_id],
-                )?;
+                // Step 6: Create promise_timeout (only for promises with resonate:target)
+                if address.is_some() {
+                    self.conn.execute(
+                        "INSERT OR IGNORE INTO promise_timeouts (timeout_at, id) VALUES (?1, ?2)",
+                        params![promise_timeout_at, promise_id],
+                    )?;
+                }
 
                 // Step 7: Create task infrastructure if resonate:target is set
                 if let Some(addr) = &address {
@@ -1373,7 +1377,7 @@ impl<'a> Db for SqliteDb<'a> {
                     if self.conn.changes() > 0 {
                         self.conn.execute(
                             "INSERT OR IGNORE INTO task_timeouts (timeout_at, id, timeout_type, ttl) VALUES (?1, ?2, 0, ?3)",
-                            params![fired_at + self.task_retry_timeout, promise_id, self.task_retry_timeout],
+                            params![time + self.task_retry_timeout, promise_id, self.task_retry_timeout],
                         )?;
                         self.conn.execute(
                             "INSERT INTO outgoing_execute (id, version, address) VALUES (?1, 0, ?2)
@@ -1419,42 +1423,36 @@ impl<'a> Db for SqliteDb<'a> {
     fn process_timeouts(&self, time: i64) -> StorageResult<()> {
         // Statement 1: Process expired promise timeouts
         let mut stmt = self.conn.prepare(
-            "SELECT id, timer, timeout_at FROM promises WHERE state = 'pending' AND timeout_at <= ?1"
+            "SELECT id FROM promise_timeouts WHERE timeout_at <= ?1"
         )?;
-        let expired: Vec<(String, bool, i64)> = {
+        let expired_ids: Vec<String> = {
             let mut rows = stmt.query(params![time])?;
             let mut r = Vec::new();
             while let Some(row) = rows.next()? {
-                r.push((row.get(0)?, row.get(1)?, row.get(2)?));
+                r.push(row.get(0)?);
             }
             r
         };
 
         // Phase 1: Settle all expired promises
         let mut fulfilled_ids = Vec::new();
-        for (id, timer, timeout_at) in &expired {
-            let new_state = if *timer {
-                "resolved"
-            } else {
-                "rejected_timedout"
-            };
+        for id in &expired_ids {
             self.conn.execute(
-                "UPDATE promises SET state = ?2, settled_at = ?3 WHERE id = ?1 AND state = 'pending'",
-                params![id, new_state, timeout_at],
+                "UPDATE promises SET state = CASE WHEN timer THEN 'resolved' ELSE 'rejected_timedout' END, settled_at = timeout_at WHERE id = ?1 AND state = 'pending'",
+                params![id],
             )?;
-            self.conn
-                .execute("DELETE FROM promise_timeouts WHERE id = ?1", params![id])?;
+            self.conn.execute("DELETE FROM promise_timeouts WHERE id = ?1", params![id])?;
         }
 
         // Phase 2: SettlementEnqueued for all
-        for (id, _, _) in &expired {
+        for id in &expired_ids {
             if settlement_enqueued(self.conn, id)? {
                 fulfilled_ids.push(id.clone());
             }
         }
 
         // Phase 3: ResumptionEnqueued + ListenerUnblocked
-        for (id, _, _) in &expired {
+        for id in &expired_ids {
             resumption_enqueued(
                 self.conn,
                 id,

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -1422,9 +1422,9 @@ impl<'a> Db for SqliteDb<'a> {
 
     fn process_timeouts(&self, time: i64) -> StorageResult<()> {
         // Statement 1: Process expired promise timeouts
-        let mut stmt = self.conn.prepare(
-            "SELECT id FROM promise_timeouts WHERE timeout_at <= ?1"
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM promise_timeouts WHERE timeout_at <= ?1")?;
         let expired_ids: Vec<String> = {
             let mut rows = stmt.query(params![time])?;
             let mut r = Vec::new();
@@ -1441,7 +1441,8 @@ impl<'a> Db for SqliteDb<'a> {
                 "UPDATE promises SET state = CASE WHEN timer THEN 'resolved' ELSE 'rejected_timedout' END, settled_at = timeout_at WHERE id = ?1 AND state = 'pending'",
                 params![id],
             )?;
-            self.conn.execute("DELETE FROM promise_timeouts WHERE id = ?1", params![id])?;
+            self.conn
+                .execute("DELETE FROM promise_timeouts WHERE id = ?1", params![id])?;
         }
 
         // Phase 2: SettlementEnqueued for all

--- a/src/server.rs
+++ b/src/server.rs
@@ -1295,7 +1295,7 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                     kind_str.clone(),
                     corr_id.clone(),
                     422,
-                    "Promise exists without a target task",
+                    "The promise does not have a resonate:target tag",
                 )),
                 _ => Ok(ResponseEnvelope::error(
                     kind_str.clone(),
@@ -2601,6 +2601,16 @@ async fn op_debug_tick(state: &Arc<Server>, req: &RequestEnvelope) -> ResponseEn
             )
         }
     };
+    if let Some(debug_time) = req.head.debug_time {
+        if debug_time != time {
+            return ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                400,
+                "resonate:debug_time must equal data.time",
+            );
+        }
+    }
 
     match state
         .storage

--- a/src/types.rs
+++ b/src/types.rs
@@ -286,6 +286,52 @@ fn validate_promise_create_data(
         return Err(validator::ValidationError::new("null_bytes")
             .with_message("Promise ID must not contain null bytes".into()));
     }
+    if let Some(origin) = data.tags.get("resonate:origin") {
+        if origin.contains('.') {
+            return Err(validator::ValidationError::new("dot_in_origin")
+                .with_message("resonate:origin must not contain '.'".into()));
+        }
+        if data.id != origin.as_str() && !data.id.starts_with(&format!("{}.", origin)) {
+            return Err(validator::ValidationError::new("origin_prefix")
+                .with_message("Promise ID must be prefixed by resonate:origin".into()));
+        }
+    }
+    if let Some(branch) = data.tags.get("resonate:branch") {
+        if data.id != branch.as_str() && !data.id.starts_with(&format!("{}.", branch)) {
+            return Err(validator::ValidationError::new("branch_prefix")
+                .with_message("Promise ID must be prefixed by resonate:branch".into()));
+        }
+    }
+    if let Some(parent) = data.tags.get("resonate:parent") {
+        if data.id != parent.as_str() && !data.id.starts_with(&format!("{}.", parent)) {
+            return Err(validator::ValidationError::new("parent_prefix")
+                .with_message("Promise ID must be prefixed by resonate:parent".into()));
+        }
+    }
+    if let Some(prefix) = data.tags.get("resonate:prefix") {
+        if prefix.contains('.') {
+            return Err(validator::ValidationError::new("dot_in_prefix")
+                .with_message("resonate:prefix must not contain '.'".into()));
+        }
+    }
+    if let Some(delay_str) = data.tags.get("resonate:delay") {
+        let delay: i64 = delay_str
+            .parse()
+            .ok()
+            .filter(|&v: &i64| v >= 0)
+            .ok_or_else(|| {
+                validator::ValidationError::new("invalid_delay")
+                    .with_message("resonate:delay must be a non-negative integer".into())
+            })?;
+        if delay >= data.timeout_at {
+            return Err(validator::ValidationError::new("delay_exceeds_timeout")
+                .with_message("resonate:delay must be less than timeoutAt".into()));
+        }
+        if !data.tags.contains_key("resonate:target") {
+            return Err(validator::ValidationError::new("delay_without_target")
+                .with_message("resonate:delay requires a resonate:target tag".into()));
+        }
+    }
     Ok(())
 }
 
@@ -307,12 +353,20 @@ pub struct PromiseRegisterCallbackData {
     pub awaiter: String,
 }
 
+fn origin(id: &str) -> &str {
+    id.split_once('.').map(|(prefix, _)| prefix).unwrap_or(id)
+}
+
 fn validate_callback_data(
     data: &PromiseRegisterCallbackData,
 ) -> Result<(), validator::ValidationError> {
     if data.awaited == data.awaiter {
         return Err(validator::ValidationError::new("awaited_equals_awaiter")
             .with_message("Awaited and awaiter must be different promises".into()));
+    }
+    if origin(&data.awaiter) != origin(&data.awaited) {
+        return Err(validator::ValidationError::new("origin_mismatch")
+            .with_message("Awaiter and awaited must belong to the same origin".into()));
     }
     Ok(())
 }
@@ -355,6 +409,10 @@ fn validate_task_create_data(data: &TaskCreateData) -> Result<(), validator::Val
     if !data.action.data.tags.contains_key("resonate:target") {
         return Err(validator::ValidationError::new("missing_target")
             .with_message("Action must have a resonate:target tag".into()));
+    }
+    if data.action.data.tags.contains_key("resonate:delay") {
+        return Err(validator::ValidationError::new("delay_in_task_action")
+            .with_message("Action must not have a resonate:delay tag".into()));
     }
     Ok(())
 }
@@ -420,6 +478,10 @@ fn validate_task_suspend_data(data: &TaskSuspendData) -> Result<(), validator::V
         if action.data.awaited == data.id {
             return Err(validator::ValidationError::new("awaited_is_self")
                 .with_message("Action awaited promise must not equal the task ID".into()));
+        }
+        if origin(&action.data.awaited) != origin(&data.id) {
+            return Err(validator::ValidationError::new("origin_mismatch")
+                .with_message("Awaited promise must belong to the same origin as the task".into()));
         }
     }
     Ok(())
@@ -491,17 +553,32 @@ fn validate_task_fence_data(data: &TaskFenceData) -> Result<(), validator::Valid
     Ok(())
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TaskHeartbeatTask {
     pub id: String,
     pub version: i64,
 }
 
 #[derive(Debug, Deserialize, Validate)]
+#[validate(schema(function = "validate_task_heartbeat_data"))]
 pub struct TaskHeartbeatData {
     #[validate(length(min = 1, message = "Process ID is required"))]
     pub pid: String,
+    #[validate(length(min = 1, message = "Tasks array must not be empty"))]
     pub tasks: Vec<TaskHeartbeatTask>,
+}
+
+fn validate_task_heartbeat_data(data: &TaskHeartbeatData) -> Result<(), validator::ValidationError> {
+    if data.tasks.len() > 1 {
+        let first_origin = origin(&data.tasks[0].id);
+        for task in &data.tasks[1..] {
+            if origin(&task.id) != first_origin {
+                return Err(validator::ValidationError::new("origin_mismatch")
+                    .with_message("All tasks must belong to the same origin".into()));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Deserialize, Validate)]
@@ -531,6 +608,7 @@ pub struct ScheduleGetData {
 }
 
 #[derive(Debug, Deserialize, Validate)]
+#[validate(schema(function = "validate_schedule_create_data"))]
 pub struct ScheduleCreateData {
     #[validate(length(min = 1, message = "Schedule ID is required"))]
     pub id: String,
@@ -546,6 +624,20 @@ pub struct ScheduleCreateData {
     pub promise_param: PromiseValue,
     #[serde(rename = "promiseTags", default)]
     pub promise_tags: std::collections::HashMap<String, String>,
+}
+
+fn validate_schedule_create_data(
+    data: &ScheduleCreateData,
+) -> Result<(), validator::ValidationError> {
+    if data.id.contains('.') {
+        return Err(validator::ValidationError::new("dot_in_schedule_id")
+            .with_message("Schedule ID must not contain '.'".into()));
+    }
+    if !data.promise_tags.contains_key("resonate:target") {
+        return Err(validator::ValidationError::new("missing_target")
+            .with_message("promiseTags must include a resonate:target tag".into()));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Deserialize, Validate)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -480,8 +480,11 @@ fn validate_task_suspend_data(data: &TaskSuspendData) -> Result<(), validator::V
                 .with_message("Action awaited promise must not equal the task ID".into()));
         }
         if origin(&action.data.awaited) != origin(&data.id) {
-            return Err(validator::ValidationError::new("origin_mismatch")
-                .with_message("Awaited promise must belong to the same origin as the task".into()));
+            return Err(
+                validator::ValidationError::new("origin_mismatch").with_message(
+                    "Awaited promise must belong to the same origin as the task".into(),
+                ),
+            );
         }
     }
     Ok(())
@@ -568,7 +571,9 @@ pub struct TaskHeartbeatData {
     pub tasks: Vec<TaskHeartbeatTask>,
 }
 
-fn validate_task_heartbeat_data(data: &TaskHeartbeatData) -> Result<(), validator::ValidationError> {
+fn validate_task_heartbeat_data(
+    data: &TaskHeartbeatData,
+) -> Result<(), validator::ValidationError> {
     if data.tasks.len() > 1 {
         let first_origin = origin(&data.tasks[0].id);
         for task in &data.tasks[1..] {


### PR DESCRIPTION
## Summary

- **Delay support**: Promises with a `resonate:delay` tag (Unix ms timestamp) are held back until that time before being dispatched — the retry timeout fires at `delay_at` rather than immediately.
- **Target-gated timeouts**: Promise timeouts (`p_timeouts`) are only inserted for promises that carry a `resonate:target` tag. Plain fanout/barrier promises without a target no longer generate spurious timeout rows or get expired by the tick loop.
- **Task heartbeat / resume fixes**: Removed the stale `promise_pending` guard from `heartbeat` and `resume` — tasks can be heartbeated or resumed regardless of the promise state (e.g. after a crash recovery where the promise was already resolved).
- **Tick timeout fix**: Retry task timeout on tick is now anchored to `time` (the tick timestamp) rather than `fired_at` (the original creation time), so re-queued tasks get the full retry window.
- **Error message cleanup**: Unified the 422 "no target" message and removed the ambiguous "Task is not pending" 409 that was incorrectly fired from `resume`.
- **`resonate:debug_time` validation**: The tick endpoint now enforces that `debug_time` in the request header matches `data.time` when provided.
- **Differential test update**: Schedule-create now includes `resonate:target` in `promiseTags` so differential tests exercise the target-gated path.
- **CI**: Pins the test repo checkout to `feat/protocol-updates` (TODO comment to remove on merge).

## Test plan

- [ ] Differential tests pass (`diff/` with `feat/protocol-updates` test bed)
- [ ] CI green on this branch
- [ ] Manual smoke: create a promise without `resonate:target` — confirm no timeout row inserted, tick does not expire it
- [ ] Manual smoke: create a promise with `resonate:delay` in the future — confirm it is not dispatched until after `delay_at`
- [ ] Manual smoke: heartbeat a task whose promise is already resolved — confirm 200, no 409
- [ ] Remove `ref: feat/protocol-updates` from `.github/workflows/ci.yml` before or immediately after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)