### PR TITLE
chore: add dependabot config and reorder vector transforms

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # reviewers:
+    #   - "YOUR_USERNAME"
+    # assignees:
+    #   - "YOUR_USERNAME"
+    # open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     #   - "YOUR_USERNAME"
     # assignees:
     #   - "YOUR_USERNAME"
-    # open-pull-requests-limit: 5
+    # open-pull-requests-limit:10
 
     #  Optional: Group updates together to avoid opening too many PRs at once
     # groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     # assignees:
     #   - "YOUR_USERNAME"
     # open-pull-requests-limit: 5
+
+    #  Optional: Group updates together to avoid opening too many PRs at once
+    # groups:
+    #   all-dependencies:
+    #     patterns: ["*"]

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -21,14 +21,6 @@ type = "prometheus_remote_write"
 inputs = ["metrics_scrape"]
 endpoint = "http://victoriametrics:8428/api/v1/write"
 
-[transforms.format_logs]
-type = "remap"
-inputs = ["server_logs"]
-source = """
-._msg = del(.message)
-._time = del(.timestamp)
-"""
-
 [sinks.victorialogs]
 type = "http"
 inputs = ["format_logs"]
@@ -36,3 +28,11 @@ uri = "http://victorialogs:9428/insert/jsonline?_stream_fields=container_name&_m
 encoding.codec = "json"
 framing.method = "newline_delimited"
 healthcheck.enabled = false
+
+[transforms.format_logs]
+type = "remap"
+inputs = ["server_logs"]
+source = """
+._msg = del(.message)
+._time = del(.timestamp)
+"""


### PR DESCRIPTION
- Added `.github/dependabot.yml` to automate Rust dependency updates via Cargo.
- Configures weekly checks with optional reviewer, assignee, and PR limit settings.