### PR TITLE
allow '.' in caller-supplied ids

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2361,6 +2361,23 @@ async fn op_schedule_create(
                     &format_validation_errors(&e),
                 ));
             }
+            // Every promise this schedule fires carries the target, so it is
+            // held to the same standard promise create holds a target to.
+            if let Some(addr) = r.promise_tags.get("resonate:target") {
+                if !crate::transport::is_valid_address(addr) {
+                    tracing::warn!(
+                        schedule_id = %r.id,
+                        address = addr,
+                        "Schedule create rejected: invalid resonate:target address"
+                    );
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        "Invalid resonate:target address",
+                    ));
+                }
+            }
             if !util::is_valid_cron(&r.cron) {
                 tracing::warn!(
                     schedule_id = %r.id,

--- a/src/types.rs
+++ b/src/types.rs
@@ -652,7 +652,11 @@ fn validate_schedule_create_data(
     // A schedule id is caller-supplied and is stamped, via the promise id
     // template, onto the resonate:origin of every promise the schedule fires --
     // so it is bound by exactly the rules `validate_promise_create_data` applies
-    // to an origin, and '.' is not one of them (see the comment there).
+    // to an origin: '.' is not one of them, ':' is (see the comment there).
+    if data.id.contains(':') {
+        return Err(validator::ValidationError::new("colon_in_schedule_id")
+            .with_message("Schedule ID must not contain ':'".into()));
+    }
     if !data.promise_tags.contains_key("resonate:target") {
         return Err(validator::ValidationError::new("missing_target")
             .with_message("promiseTags must include a resonate:target tag".into()));

--- a/src/types.rs
+++ b/src/types.rs
@@ -649,10 +649,10 @@ pub struct ScheduleCreateData {
 fn validate_schedule_create_data(
     data: &ScheduleCreateData,
 ) -> Result<(), validator::ValidationError> {
-    if data.id.contains('.') {
-        return Err(validator::ValidationError::new("dot_in_schedule_id")
-            .with_message("Schedule ID must not contain '.'".into()));
-    }
+    // A schedule id is caller-supplied and is stamped, via the promise id
+    // template, onto the resonate:origin of every promise the schedule fires --
+    // so it is bound by exactly the rules `validate_promise_create_data` applies
+    // to an origin, and '.' is not one of them (see the comment there).
     if !data.promise_tags.contains_key("resonate:target") {
         return Err(validator::ValidationError::new("missing_target")
             .with_message("promiseTags must include a resonate:target tag".into()));

--- a/src/types.rs
+++ b/src/types.rs
@@ -287,10 +287,11 @@ fn validate_promise_create_data(
             .with_message("Promise ID must not contain null bytes".into()));
     }
     if let Some(origin) = data.tags.get("resonate:origin") {
-        if origin.contains('.') {
-            return Err(validator::ValidationError::new("dot_in_origin")
-                .with_message("resonate:origin must not contain '.'".into()));
-        }
+        // '.' is deliberately *not* rejected: it separates lineage segments below
+        // the origin, which are only ever read once the origin has been split off
+        // at the first ':', so a caller-supplied dotted root id ('my.app.workflow'
+        // -> 'my.app.workflow:1' -> 'my.app.workflow:1.1') round-trips intact.
+        //
         // The origin is everything before an id's first ':' (see `origin()`), so
         // an origin that itself holds one is unrepresentable: no id could ever
         // split back to it. Rejecting it here keeps ':' reserved as the


### PR DESCRIPTION
Stacked on #1128 (`no-colon-in-origin`), so the diff is only what this change is about. Retarget to `main` once that merges.

## Why

`dot_in_origin` dates from when `.` was the only separator in a promise id. Since #1127 an id is `<origin>:<lineage>`: the origin is everything before the **first** `:`, and `.` only separates lineage segments *below* it.

A `.` in the origin is therefore unambiguous — it is only ever read after the origin has been split off — so a caller-supplied dotted root id round-trips intact:

```
my.app.workflow -> my.app.workflow:1 -> my.app.workflow:1.1
```

Rejecting it only blocked a natural naming convention (`my.app.workflow`, reverse-DNS ids, etc.).

`colon_in_origin` stays: an origin holding a `:` is unrepresentable, since no id could ever split back to it.

## Two guards, same leftover

1. **`dot_in_origin`** (`validate_promise_create_data`) — removed.
2. **`dot_in_schedule_id`** (`validate_schedule_create_data`) — removed. A schedule id is stamped, through the promise id template, onto the `resonate:origin` of every promise the schedule fires, so it was rejected for exactly the reason above. Leaving it would make the SDKs and the server disagree: they validate a schedule id with the same rules as a run/rpc id, which now admit `.`, and the create would 400 here.

## Client side

Every SDK relaxes its call-site `validate_root_id` to match, moving `.` from the rejected list to the accepted one and dropping `dot_in_origin` from its ported copy of `validate_promise_create_data`:

- resonatehq/resonate-sdk-py#464
- resonatehq/resonate-sdk-ts#566
- resonatehq/resonate-sdk-go#41
- resonatehq/resonate-sdk-rs#59
- resonatehq/resonate-sdk-java#12

Each of those adds a test that replays a whole workflow tree minted under a dotted root through the ported server rules.

## Not touched

`dot_in_prefix` still guards the vestigial `resonate:prefix` tag. No SDK sends it any more, and the server writes it itself for scheduled promises (`processing_timeouts.rs`) — where it will now hold a `.` whenever the schedule id does. Worth deleting, but it is a separate cleanup.

## Validation

`cargo fmt --check`, `cargo check`, `cargo test` — all green.