### PR TITLE
Put the server, oracle, and transports behind core ports (ResonateServer / ResonateWorker / ResonateRouter)

### DIFF
--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -41,7 +41,7 @@ use resonate::{
         persistence_mysql::MysqlStorage, persistence_postgres::PostgresStorage,
         persistence_sqlite::SqliteStorage, Storage,
     },
-    server::{dispatch, Server},
+    server::Server,
 };
 use serde_json::{json, Value};
 
@@ -108,7 +108,7 @@ enum Backend {
 impl Backend {
     async fn dispatch(&self, envelope: &RequestEnvelope, now: i64) -> ResponseEnvelope {
         match self {
-            Backend::Server(srv) => dispatch(srv, envelope, now).await,
+            Backend::Server(srv) => srv.dispatch(envelope, now).await,
             Backend::Oracle(o) => {
                 let mut req = envelope.clone();
                 req.head.debug_time = Some(now);

--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -24,7 +24,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
-use resonate::types::TaskState;
+use resonate::core::types::TaskState;
 
 // Serializes tests that share the same Postgres/MySQL database so that
 // concurrent debug.reset calls from one test cannot truncate another's data.
@@ -35,13 +35,13 @@ fn db_lock() -> &'static Mutex<()> {
 
 use resonate::{
     config::Config,
+    core::types::{RequestEnvelope, RequestHead, ResponseEnvelope, SUPPORTED_VERSIONS},
     oracle::Oracle,
     persistence::{
         persistence_mysql::MysqlStorage, persistence_postgres::PostgresStorage,
         persistence_sqlite::SqliteStorage, Storage,
     },
     server::{dispatch, Server},
-    types::{RequestEnvelope, RequestHead, ResponseEnvelope, SUPPORTED_VERSIONS},
 };
 use serde_json::{json, Value};
 

--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -36,6 +36,7 @@ fn db_lock() -> &'static Mutex<()> {
 use resonate::{
     config::Config,
     core::types::{RequestEnvelope, RequestHead, ResponseEnvelope, SUPPORTED_VERSIONS},
+    core::ResonateServer,
     oracle::Oracle,
     persistence::{
         persistence_mysql::MysqlStorage, persistence_postgres::PostgresStorage,
@@ -100,26 +101,27 @@ fn req(kind: &str, data: Value) -> RequestEnvelope {
 // Backend abstraction
 // ---------------------------------------------------------------------------
 
-enum Backend {
-    Server(Arc<Server>),
-    Oracle(Arc<Mutex<Oracle>>),
-}
+// A backend is anything that answers the protocol. The real server, the
+// reference model, and (eventually) a client for a remote server are all the
+// same thing here — that is the point of the port.
+type Backend = Arc<dyn ResonateServer>;
 
-impl Backend {
-    async fn dispatch(&self, envelope: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-        match self {
-            Backend::Server(srv) => srv.dispatch(envelope, now).await,
-            Backend::Oracle(o) => {
-                let mut req = envelope.clone();
-                req.head.debug_time = Some(now);
-                o.lock().unwrap().apply(&req)
-            }
-        }
-    }
+/// Send one request to a backend at time `now`.
+///
+/// `now` rides in the envelope rather than alongside it: `process` resolves the
+/// effective time from `head.debug_time`, identically for every backend. The
+/// server gates that on `config.debug`, which `debug_config()` enables.
+async fn send(backend: &Backend, envelope: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+    let mut req = envelope.clone();
+    req.head.debug_time = Some(now);
+    backend
+        .process(&req)
+        .await
+        .expect("in-process backends are always available")
 }
 
 fn server_backend(storage: Storage) -> Backend {
-    Backend::Server(Arc::new(Server::new(debug_config(), None, storage)))
+    Arc::new(Server::new(debug_config(), None, storage))
 }
 
 // Pick a random element from a slice.
@@ -184,7 +186,7 @@ async fn differential_random() {
 
     let mut backends: Vec<(String, Backend)> = vec![
         ("sqlite".into(), server_backend(Storage::Sqlite(sqlite))),
-        ("oracle".into(), Backend::Oracle(Arc::clone(&oracle))),
+        ("oracle".into(), Arc::clone(&oracle) as Backend),
     ];
     if let Some(pg) = pg_backend {
         backends.push(("postgres".into(), pg));
@@ -385,7 +387,7 @@ fn percentile(sorted: &[u64], p: f64) -> u64 {
 async fn setup_all(backends: &[(String, Backend)], now: i64) {
     for envelope in &[req("debug.start", json!({})), req("debug.reset", json!({}))] {
         for (name, b) in backends {
-            let resp = b.dispatch(envelope, now).await;
+            let resp = send(b, envelope, now).await;
             assert_eq!(resp.head.status, 200, "{} failed on {name}", envelope.kind);
         }
     }
@@ -394,7 +396,7 @@ async fn setup_all(backends: &[(String, Backend)], now: i64) {
 async fn reset_all(backends: &[(String, Backend)], now: i64) {
     let envelope = req("debug.reset", json!({}));
     for (name, b) in backends {
-        let resp = b.dispatch(&envelope, now).await;
+        let resp = send(b, &envelope, now).await;
         assert_eq!(resp.head.status, 200, "debug.reset failed on {name}");
     }
 }
@@ -409,7 +411,7 @@ async fn send_all(
     let kind = envelope.kind.clone();
     for (name, b) in backends {
         let t0 = Instant::now();
-        let resp = b.dispatch(envelope, now).await;
+        let resp = send(b, envelope, now).await;
         let ns = t0.elapsed().as_nanos() as u64;
         timings
             .entry((name.clone(), kind.clone()))
@@ -424,7 +426,7 @@ async fn snap_all(backends: &[(String, Backend)], now: i64) -> Vec<(String, Valu
     let envelope = req("debug.snap", json!({}));
     let mut out = Vec::new();
     for (name, b) in backends {
-        let resp = b.dispatch(&envelope, now).await;
+        let resp = send(b, &envelope, now).await;
         assert_eq!(resp.head.status, 200, "debug.snap failed on {name}");
         let mut data = resp.data;
         normalize_snap(&mut data);

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,7 +4,7 @@ use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::types::{RequestEnvelope, ResponseEnvelope};
+use crate::core::types::{RequestEnvelope, ResponseEnvelope};
 
 // ---------------------------------------------------------------------------
 // Public key — tagged by key family so we know which algorithms to accept

--- a/src/config.rs
+++ b/src/config.rs
@@ -340,6 +340,25 @@ pub struct BashExecConfig {
     /// Enable the bash:// address scheme [default: false]
     #[serde(default)]
     pub enabled: bool,
+
+    /// Lease TTL (ms) this worker requests when acquiring a task, and the basis
+    /// for its heartbeat interval (a third of it).
+    ///
+    /// The lease has to outlast the script: if it expires the task is
+    /// redispatched to another worker while this one is still running.
+    ///
+    /// Unset means "follow `tasks.lease_timeout`" — the server-wide default
+    /// this worker used before it had a setting of its own. Set it when scripts
+    /// here run longer than tasks generally do.
+    #[serde(default)]
+    pub lease_timeout: Option<i64>,
+}
+
+impl BashExecConfig {
+    /// The lease TTL to request, falling back to the server-wide task default.
+    pub fn resolve_lease_timeout(&self, tasks: &TasksConfig) -> i64 {
+        self.lease_timeout.unwrap_or(tasks.lease_timeout)
+    }
 }
 
 /// Google Cloud Pub/Sub transport configuration.
@@ -623,6 +642,18 @@ impl Config {
             return Err("transports.gcps.concurrency must be at least 1 (got 0)".to_string());
         }
 
+        // `task.acquire` validates `ttl >= 1`, so a non-positive lease would
+        // make every acquire fail with a 400 and the worker would silently
+        // never run anything. Reject it here instead.
+
+        if let Some(ttl) = self.transports.bash_exec.lease_timeout {
+            if ttl < 1 {
+                return Err(format!(
+                    "transports.bash_exec.lease_timeout must be at least 1 (got {ttl})"
+                ));
+            }
+        }
+
         Ok(())
     }
 }
@@ -630,6 +661,47 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bash_lease_timeout_defaults_to_the_server_task_lease() {
+        let mut config = Config::default();
+        config.tasks.lease_timeout = 120_000;
+        assert_eq!(config.transports.bash_exec.lease_timeout, None);
+        assert_eq!(
+            config
+                .transports
+                .bash_exec
+                .resolve_lease_timeout(&config.tasks),
+            120_000,
+            "unset means follow tasks.lease_timeout, including when that is customised"
+        );
+    }
+
+    #[test]
+    fn bash_lease_timeout_overrides_the_server_task_lease() {
+        let mut config = Config::default();
+        config.tasks.lease_timeout = 15_000;
+        config.transports.bash_exec.lease_timeout = Some(600_000);
+        assert_eq!(
+            config
+                .transports
+                .bash_exec
+                .resolve_lease_timeout(&config.tasks),
+            600_000
+        );
+    }
+
+    #[test]
+    fn non_positive_bash_lease_timeout_is_rejected() {
+        for ttl in [0, -1] {
+            let mut config = Config::default();
+            config.transports.bash_exec.lease_timeout = Some(ttl);
+            let err = config
+                .validate()
+                .expect_err("task.acquire would 400 on every acquire");
+            assert!(err.contains("bash_exec.lease_timeout"), "{err}");
+        }
+    }
 
     #[test]
     fn default_config_is_valid() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -645,13 +645,22 @@ impl Config {
         // `task.acquire` validates `ttl >= 1`, so a non-positive lease would
         // make every acquire fail with a 400 and the worker would silently
         // never run anything. Reject it here instead.
-
+        //
+        // Both the override and the value it falls back to: guarding only the
+        // override would leave `tasks.lease_timeout = 0` reaching `task.acquire`
+        // through `resolve_lease_timeout`, which is the same failure.
         if let Some(ttl) = self.transports.bash_exec.lease_timeout {
             if ttl < 1 {
                 return Err(format!(
                     "transports.bash_exec.lease_timeout must be at least 1 (got {ttl})"
                 ));
             }
+        }
+        if self.tasks.lease_timeout < 1 {
+            return Err(format!(
+                "tasks.lease_timeout must be at least 1 (got {})",
+                self.tasks.lease_timeout
+            ));
         }
 
         Ok(())
@@ -689,6 +698,18 @@ mod tests {
                 .resolve_lease_timeout(&config.tasks),
             600_000
         );
+    }
+
+    #[test]
+    fn non_positive_task_lease_timeout_is_rejected() {
+        // It is what bash_exec.lease_timeout falls back to, so it reaches
+        // `task.acquire` as the ttl and must clear the same bar.
+        for ttl in [0, -1] {
+            let mut config = Config::default();
+            config.tasks.lease_timeout = ttl;
+            let err = config.validate().expect_err("would 400 every acquire");
+            assert!(err.contains("tasks.lease_timeout"), "{err}");
+        }
     }
 
     #[test]

--- a/src/core/address.rs
+++ b/src/core/address.rs
@@ -1,52 +1,8 @@
-//! Addresses — where a message is sent, and how the string form is parsed.
+//! Addresses — the only thing about an address that is not a worker's business.
 //!
-//! Shared vocabulary rather than transport detail: the server validates
-//! addresses on promises and tasks, the reference model validates them
-//! identically, and the router parses them to select a worker.
-
-/// Parsed address — determines which transport and where to deliver.
-#[derive(Debug, Clone)]
-pub enum Address {
-    /// HTTP/HTTPS webhook delivery
-    Http(HttpAddress),
-    /// Poll SSE delivery
-    Poll(PollAddress),
-    /// Google Cloud Pub/Sub delivery
-    Gcps(GcpsAddress),
-    /// Bash script execution (script is in param.data).
-    /// The bash transport re-parses the address to pick a backend
-    /// (local / docker / tensorlake), so we only mark it routable here.
-    #[allow(dead_code)]
-    Bash(BashAddress),
-}
-
-#[derive(Debug, Clone)]
-pub struct HttpAddress {
-    pub url: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct PollAddress {
-    pub cast: PollCast,
-    pub group: String,
-    pub id: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum PollCast {
-    Uni,
-    Any,
-}
-
-#[derive(Debug, Clone)]
-pub struct GcpsAddress {
-    pub project: String,
-    pub topic: String,
-}
-
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct BashAddress;
+//! A worker owns the syntax of its own scheme: what a `poll://` or `gcps://`
+//! address means belongs to the poll or Pub/Sub worker, not here. `core` knows
+//! only that an address is a URI, and the router knows only its scheme.
 
 /// Returns true if `address` is a valid Resonate address.
 ///
@@ -66,50 +22,14 @@ pub fn is_valid_address(address: &str) -> bool {
     url::Url::parse(address).is_ok()
 }
 
-/// Parse an address string into a typed Address.
+/// The scheme of `address`, or `None` if it is not a URI.
 ///
-/// Supports:
-/// - `http://...` / `https://...` — HTTP webhook delivery
-/// - `poll://cast@group[/id]` — Poll SSE delivery
-/// - `gcps://project/topic` — Google Cloud Pub/Sub delivery
-/// - `bash://` (local), `bash://docker/<image>`, `bash://tensorlake/<image>`
-pub fn parse_address(address: &str) -> Option<Address> {
-    let parsed = url::Url::parse(address).ok()?;
-
-    match parsed.scheme() {
-        "http" | "https" => Some(Address::Http(HttpAddress {
-            url: address.to_string(),
-        })),
-        "poll" => {
-            let cast = match parsed.username() {
-                "uni" => PollCast::Uni,
-                "any" => PollCast::Any,
-                _ => return None,
-            };
-            let group = parsed.host_str()?.to_string();
-            let path = parsed.path();
-            let id = if path.len() > 1 {
-                Some(path[1..].to_string())
-            } else {
-                None
-            };
-            Some(Address::Poll(PollAddress { cast, group, id }))
-        }
-        "gcps" => {
-            let project = parsed.host_str()?.to_string();
-            let path = parsed.path();
-            if path.len() <= 1 {
-                return None; // need at least /topic
-            }
-            let topic = path[1..].to_string();
-            if topic.is_empty() {
-                return None;
-            }
-            Some(Address::Gcps(GcpsAddress { project, topic }))
-        }
-        "bash" => Some(Address::Bash(BashAddress)),
-        _ => None,
-    }
+/// This is all the routing information there is: the router maps a scheme to a
+/// worker and hands over the untouched address.
+pub fn scheme_of(address: &str) -> Option<String> {
+    url::Url::parse(address)
+        .ok()
+        .map(|u| u.scheme().to_string())
 }
 
 #[cfg(test)]
@@ -148,18 +68,16 @@ mod tests {
     }
 
     #[test]
-    fn bash_address_parses() {
-        for addr in [
-            "bash://",
-            "bash://bash",
-            "bash://docker/alpine",
-            "bash://docker/library/ubuntu:latest",
-            "bash://tensorlake/python-3.11",
+    fn scheme_of_extracts_the_routing_key() {
+        for (addr, want) in [
+            ("http://w:1", Some("http")),
+            ("https://w/x", Some("https")),
+            ("poll://any@g", Some("poll")),
+            ("gcps://p/t", Some("gcps")),
+            ("bash://docker/alpine", Some("bash")),
+            ("not a url", None),
         ] {
-            assert!(
-                matches!(parse_address(addr), Some(Address::Bash(_))),
-                "expected Bash for {addr}"
-            );
+            assert_eq!(scheme_of(addr).as_deref(), want, "for {addr}");
         }
     }
 }

--- a/src/core/address.rs
+++ b/src/core/address.rs
@@ -48,9 +48,22 @@ pub struct GcpsAddress {
 #[allow(dead_code)]
 pub struct BashAddress;
 
-/// Returns true if the address is a valid, routable URL.
+/// Returns true if `address` is a valid Resonate address.
+///
+/// Validity is deliberately shallow: an address is valid if it parses as a URI
+/// with a scheme. Everything past the scheme belongs to whichever worker is
+/// registered for it, and this function must not know about it.
+///
+/// That shallowness is a requirement, not a simplification. Validation has to
+/// be a pure function of the string — identical on every deployment — because
+/// the reference model has no workers at all, and because a server's enabled
+/// transports must never change which requests it accepts. A scheme-aware
+/// check would make both untrue.
+///
+/// The consequence is that syntax errors past the scheme surface at delivery
+/// rather than at admission.
 pub fn is_valid_address(address: &str) -> bool {
-    parse_address(address).is_some()
+    url::Url::parse(address).is_ok()
 }
 
 /// Parse an address string into a typed Address.
@@ -102,6 +115,37 @@ pub fn parse_address(address: &str) -> Option<Address> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn valid_address_is_any_uri_with_a_scheme() {
+        for addr in [
+            "http://worker:9999",
+            "https://worker/path",
+            "poll://uni@group",
+            "poll://any@group/id",
+            "gcps://project/topic",
+            "bash://",
+            "bash://docker/alpine",
+            // Schemes core knows nothing about are valid — that is the point.
+            "unknown://x/y",
+            "mailto:a@b.c",
+            "foo:bar",
+            // Well-formed URI, malformed for its scheme. Admitted here; the
+            // worker registered for the scheme rejects it at delivery.
+            "poll://group",
+            "poll://bogus@group",
+            "gcps://project",
+        ] {
+            assert!(is_valid_address(addr), "expected valid: {addr}");
+        }
+    }
+
+    #[test]
+    fn invalid_address_is_not_a_uri() {
+        for addr in ["", "not a url", "/relative", "http://"] {
+            assert!(!is_valid_address(addr), "expected invalid: {addr}");
+        }
+    }
 
     #[test]
     fn bash_address_parses() {

--- a/src/core/address.rs
+++ b/src/core/address.rs
@@ -1,0 +1,121 @@
+//! Addresses — where a message is sent, and how the string form is parsed.
+//!
+//! Shared vocabulary rather than transport detail: the server validates
+//! addresses on promises and tasks, the reference model validates them
+//! identically, and the router parses them to select a worker.
+
+/// Parsed address — determines which transport and where to deliver.
+#[derive(Debug, Clone)]
+pub enum Address {
+    /// HTTP/HTTPS webhook delivery
+    Http(HttpAddress),
+    /// Poll SSE delivery
+    Poll(PollAddress),
+    /// Google Cloud Pub/Sub delivery
+    Gcps(GcpsAddress),
+    /// Bash script execution (script is in param.data).
+    /// The bash transport re-parses the address to pick a backend
+    /// (local / docker / tensorlake), so we only mark it routable here.
+    #[allow(dead_code)]
+    Bash(BashAddress),
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpAddress {
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PollAddress {
+    pub cast: PollCast,
+    pub group: String,
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PollCast {
+    Uni,
+    Any,
+}
+
+#[derive(Debug, Clone)]
+pub struct GcpsAddress {
+    pub project: String,
+    pub topic: String,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct BashAddress;
+
+/// Returns true if the address is a valid, routable URL.
+pub fn is_valid_address(address: &str) -> bool {
+    parse_address(address).is_some()
+}
+
+/// Parse an address string into a typed Address.
+///
+/// Supports:
+/// - `http://...` / `https://...` — HTTP webhook delivery
+/// - `poll://cast@group[/id]` — Poll SSE delivery
+/// - `gcps://project/topic` — Google Cloud Pub/Sub delivery
+/// - `bash://` (local), `bash://docker/<image>`, `bash://tensorlake/<image>`
+pub fn parse_address(address: &str) -> Option<Address> {
+    let parsed = url::Url::parse(address).ok()?;
+
+    match parsed.scheme() {
+        "http" | "https" => Some(Address::Http(HttpAddress {
+            url: address.to_string(),
+        })),
+        "poll" => {
+            let cast = match parsed.username() {
+                "uni" => PollCast::Uni,
+                "any" => PollCast::Any,
+                _ => return None,
+            };
+            let group = parsed.host_str()?.to_string();
+            let path = parsed.path();
+            let id = if path.len() > 1 {
+                Some(path[1..].to_string())
+            } else {
+                None
+            };
+            Some(Address::Poll(PollAddress { cast, group, id }))
+        }
+        "gcps" => {
+            let project = parsed.host_str()?.to_string();
+            let path = parsed.path();
+            if path.len() <= 1 {
+                return None; // need at least /topic
+            }
+            let topic = path[1..].to_string();
+            if topic.is_empty() {
+                return None;
+            }
+            Some(Address::Gcps(GcpsAddress { project, topic }))
+        }
+        "bash" => Some(Address::Bash(BashAddress)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bash_address_parses() {
+        for addr in [
+            "bash://",
+            "bash://bash",
+            "bash://docker/alpine",
+            "bash://docker/library/ubuntu:latest",
+            "bash://tensorlake/python-3.11",
+        ] {
+            assert!(
+                matches!(parse_address(addr), Some(Address::Bash(_))),
+                "expected Bash for {addr}"
+            );
+        }
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,64 @@
+//! Core — the ports and the vocabulary they speak.
+//!
+//! Everything here is definition only: traits, data types, and pure functions
+//! over them. `core` depends on nothing else in this crate; every other module
+//! is an adapter that depends on `core`. Keep it that way — no
+//! `use crate::{server, transport, persistence, oracle}` may ever appear
+//! below this module.
+
+// The ports are defined here before their adapters exist. Remove this once
+// `ResonateServer`, `ResonateWorker`, and `ResonateRouter` have implementations
+// — until then the binary crate root (which declares its own module tree and
+// so cannot see these as `pub`) lints every one of them as dead.
+#![allow(dead_code, unused_imports)]
+
+pub mod address;
+pub mod router;
+pub mod server;
+pub mod types;
+pub mod worker;
+
+pub use address::{is_valid_address, parse_address, Address};
+pub use router::ResonateRouter;
+pub use server::ResonateServer;
+pub use worker::ResonateWorker;
+
+use std::fmt;
+
+/// The one out-of-band failure: the peer could not be reached, so there is no
+/// answer at all.
+///
+/// This is deliberately the *only* error a port returns. Everything the peer
+/// can say about a request — not found, conflict, forbidden, internal error —
+/// is an in-band outcome carried in `ResponseHead::status`. `Unavailable`
+/// means the exchange did not complete.
+///
+/// **Retry contract:** the caller must assume the request *may already have
+/// been applied*. A connection refused before the first byte and a timeout
+/// after the last are both `Unavailable` and the caller cannot tell them
+/// apart, so retries must be idempotent.
+///
+/// `Unavailable` never crosses the wire — at the HTTP edge it renders as a
+/// 503. That is why it lives here and not in [`types`], which mirrors the
+/// canonical protocol types.
+#[derive(Debug, Clone)]
+pub struct Unavailable {
+    /// Human-readable cause, for logs and diagnostics.
+    pub message: String,
+}
+
+impl Unavailable {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for Unavailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unavailable: {}", self.message)
+    }
+}
+
+impl std::error::Error for Unavailable {}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,19 +6,13 @@
 //! `use crate::{server, transport, persistence, oracle}` may ever appear
 //! below this module.
 
-// The ports are defined here before their adapters exist. Remove this once
-// `ResonateServer`, `ResonateWorker`, and `ResonateRouter` have implementations
-// — until then the binary crate root (which declares its own module tree and
-// so cannot see these as `pub`) lints every one of them as dead.
-#![allow(dead_code, unused_imports)]
-
 pub mod address;
 pub mod router;
 pub mod server;
 pub mod types;
 pub mod worker;
 
-pub use address::{is_valid_address, parse_address, Address};
+pub use address::{is_valid_address, scheme_of};
 pub use router::ResonateRouter;
 pub use server::ResonateServer;
 pub use worker::ResonateWorker;

--- a/src/core/router.rs
+++ b/src/core/router.rs
@@ -1,0 +1,23 @@
+//! The routing port: an address string in, delivery to the right worker out.
+
+use async_trait::async_trait;
+
+use super::types::Message;
+use super::Unavailable;
+
+/// A Resonate router: resolves an address to a worker and delivers to it.
+///
+/// The router's knowledge of an address stops at the scheme. It parses the
+/// string as a URL, reads the scheme, and hands the whole untouched address to
+/// the [`ResonateWorker`](super::ResonateWorker) registered for it — so a new
+/// scheme is a registration, never a change to `core`.
+#[async_trait]
+pub trait ResonateRouter: Send + Sync {
+    /// Route and deliver one message.
+    ///
+    /// Returns `Err(Unavailable)` when the message could not be handed off:
+    /// the address does not parse as a URL, no worker is registered for its
+    /// scheme, or the worker itself was unreachable. Today's dispatcher logs
+    /// and drops in all three cases; returning them lets the caller decide.
+    async fn route(&self, address: &str, msg: &Message) -> Result<(), Unavailable>;
+}

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -12,15 +12,22 @@ use super::Unavailable;
 /// satisfy this trait — so callers (CLI, MCP, workers, differential tests) can
 /// be written once and pointed at any of them.
 ///
-/// `process` is the protocol boundary: everything a remote caller would also
-/// see belongs inside it, including envelope validation, protocol version
-/// checks, and resolving the effective `now` from `head.debug_time`. There is
-/// deliberately no `now` parameter — time is part of the request, which is
-/// what keeps the trait a pure function of its input.
+/// `process` resolves the effective `now` from `head.debug_time` (gated by the
+/// implementation's own debug setting). There is deliberately no `now`
+/// parameter — time is part of the request, which is what keeps the trait a
+/// pure function of its input.
 ///
 /// Everything about the *caller* rather than the request — authentication,
 /// metrics, tracing — belongs outside, in the adapter hosting the
 /// implementation.
+///
+/// **Not yet the full protocol boundary.** Envelope validation — empty `kind`,
+/// non-object `data`, unsupported `head.version` — still lives in the HTTP
+/// adapter, not here. So an in-process caller reaches the operations without
+/// those checks while an HTTP caller gets a 400, and the two are not yet
+/// interchangeable for malformed input. Moving those checks in (and teaching
+/// the reference model to apply them identically, so the differential covers
+/// them) is the remaining work to make this claim true.
 #[async_trait]
 pub trait ResonateServer: Send + Sync {
     /// Apply one request and return its response.

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -1,0 +1,32 @@
+//! The inbound port: something that answers Resonate protocol requests.
+
+use async_trait::async_trait;
+
+use super::types::{RequestEnvelope, ResponseEnvelope};
+use super::Unavailable;
+
+/// A Resonate server: one request in, one response out.
+///
+/// Implementations are interchangeable by construction — the in-process
+/// server, the in-memory reference model, and a client for a remote server all
+/// satisfy this trait — so callers (CLI, MCP, workers, differential tests) can
+/// be written once and pointed at any of them.
+///
+/// `process` is the protocol boundary: everything a remote caller would also
+/// see belongs inside it, including envelope validation, protocol version
+/// checks, and resolving the effective `now` from `head.debug_time`. There is
+/// deliberately no `now` parameter — time is part of the request, which is
+/// what keeps the trait a pure function of its input.
+///
+/// Everything about the *caller* rather than the request — authentication,
+/// metrics, tracing — belongs outside, in the adapter hosting the
+/// implementation.
+#[async_trait]
+pub trait ResonateServer: Send + Sync {
+    /// Apply one request and return its response.
+    ///
+    /// A non-2xx outcome is still a completed exchange: it comes back as `Ok`
+    /// with the status in `ResponseHead::status`. `Err` is reserved for "there
+    /// is no answer" — see [`Unavailable`] for the retry contract.
+    async fn process(&self, req: &RequestEnvelope) -> Result<ResponseEnvelope, Unavailable>;
+}

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -721,7 +721,9 @@ pub struct TaskCreateResponseData {
     pub preload: Vec<PromiseRecord>,
 }
 
-#[derive(Debug, Serialize)]
+// Deserialize as well as Serialize: an in-process worker reads this back off
+// its own `task.acquire` response.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TaskAcquireResponseData {
     pub task: TaskRecord,
     pub promise: PromiseRecord,

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -198,6 +198,35 @@ pub struct ExecuteMsgTask {
     pub version: i64,
 }
 
+/// Head of an `unblock` message. Empty on the wire, unlike [`MessageHead`].
+#[derive(Debug, Serialize)]
+pub struct UnblockMsgHead {}
+
+#[derive(Debug, Serialize)]
+pub struct UnblockMsg {
+    pub kind: String,
+    pub head: UnblockMsgHead,
+    pub data: UnblockMsgData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UnblockMsgData {
+    pub promise: PromiseRecord,
+}
+
+/// A message the server emits toward a worker — the vocabulary of
+/// [`ResonateWorker`](super::ResonateWorker) and
+/// [`ResonateRouter`](super::ResonateRouter).
+///
+/// Untagged: each variant already carries its own `kind` field, so this
+/// serializes exactly as the hand-built JSON it replaces.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum Message {
+    Execute(ExecuteMsg),
+    Unblock(UnblockMsg),
+}
+
 // --- Record Types ---
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -876,3 +876,66 @@ impl ResponseEnvelope {
         Self::new(kind, corr_id, 200, serde_json::to_value(data).unwrap())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // `Message` replaced a hand-built `serde_json::json!` for unblock and a
+    // `to_value(ExecuteMsg)` for execute. The enum is `untagged` precisely so
+    // the bytes on the wire do not change; these pin that down.
+
+    #[test]
+    fn execute_message_wire_format() {
+        let msg = Message::Execute(ExecuteMsg {
+            kind: "execute".to_string(),
+            head: MessageHead {
+                server_url: "http://localhost:8001".to_string(),
+            },
+            data: ExecuteMsgData {
+                task: ExecuteMsgTask {
+                    id: "t1".to_string(),
+                    version: 3,
+                },
+            },
+        });
+        assert_eq!(
+            serde_json::to_value(&msg).unwrap(),
+            json!({
+                "kind": "execute",
+                "head": { "serverUrl": "http://localhost:8001" },
+                "data": { "task": { "id": "t1", "version": 3 } }
+            })
+        );
+    }
+
+    #[test]
+    fn unblock_message_wire_format() {
+        let promise = PromiseRecord {
+            id: "p1".to_string(),
+            state: PromiseState::Resolved,
+            param: PromiseValue::default(),
+            value: PromiseValue::default(),
+            tags: std::collections::HashMap::new(),
+            timeout_at: 100,
+            created_at: 1,
+            settled_at: Some(50),
+        };
+        let expected_promise = serde_json::to_value(&promise).unwrap();
+        let msg = Message::Unblock(UnblockMsg {
+            kind: "unblock".to_string(),
+            head: UnblockMsgHead {},
+            data: UnblockMsgData { promise },
+        });
+        // Note the empty head — unblock has never carried a serverUrl.
+        assert_eq!(
+            serde_json::to_value(&msg).unwrap(),
+            json!({
+                "kind": "unblock",
+                "head": {},
+                "data": { "promise": expected_promise }
+            })
+        );
+    }
+}

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -888,6 +888,33 @@ mod tests {
     // `to_value(ExecuteMsg)` for execute. The enum is `untagged` precisely so
     // the bytes on the wire do not change; these pin that down.
 
+    /// The poll/SSE worker sends a serialized *string*, so key order is part of
+    /// its wire format — and `Value` comparison cannot see key order, which is
+    /// why the two tests below are not enough on their own.
+    #[test]
+    fn message_serializes_with_sorted_keys_like_the_value_hop() {
+        let msg = Message::Execute(ExecuteMsg {
+            kind: "execute".to_string(),
+            head: MessageHead {
+                server_url: "http://localhost:8001".to_string(),
+            },
+            data: ExecuteMsgData {
+                task: ExecuteMsgTask {
+                    id: "t1".to_string(),
+                    version: 3,
+                },
+            },
+        });
+        let via_value = serde_json::to_string(&serde_json::to_value(&msg).unwrap()).unwrap();
+        assert_eq!(
+            via_value,
+            r#"{"data":{"task":{"id":"t1","version":3}},"head":{"serverUrl":"http://localhost:8001"},"kind":"execute"}"#,
+            "SSE consumers have always received alphabetically ordered keys"
+        );
+        // Serializing the struct directly would emit declaration order instead.
+        assert_ne!(serde_json::to_string(&msg).unwrap(), via_value);
+    }
+
     #[test]
     fn execute_message_wire_format() {
         let msg = Message::Execute(ExecuteMsg {

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -1,0 +1,33 @@
+//! The outbound port: something that consumes the messages a server emits.
+
+use async_trait::async_trait;
+
+use super::types::Message;
+use super::Unavailable;
+
+/// A Resonate worker: the thing at the far end of an address.
+///
+/// The dual of [`ResonateServer`](super::ResonateServer). A server receives
+/// requests and returns responses; a worker receives messages and — for the
+/// ones that do real work — issues requests back at a server.
+///
+/// Most implementations are *proxies* for a worker running elsewhere: HTTP
+/// push, poll/SSE, and Pub/Sub each hand the message off and return. One,
+/// bash exec, is a real worker that runs in process. `send` therefore means
+/// **accepted for delivery**, not **executed**; a worker that happens to run
+/// to completion synchronously is a special case, not the contract.
+///
+/// The address arrives as an unparsed string on purpose. A worker owns the
+/// syntax of its own scheme — what a `poll://` or `gcps://` address means is
+/// the poll or Pub/Sub worker's business, not `core`'s. The
+/// [`ResonateRouter`](super::ResonateRouter) reads only the scheme, so adding
+/// a worker never requires editing `core`.
+#[async_trait]
+pub trait ResonateWorker: Send + Sync {
+    /// Deliver one message to the worker at `address`.
+    ///
+    /// The router guarantees only that `address` carries this worker's
+    /// registered scheme; everything past the scheme is this worker's to
+    /// parse and to reject.
+    async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod auth;
 pub mod config;
+pub mod core;
 pub mod metrics;
 pub mod oracle;
 pub mod persistence;
 pub mod processing;
 pub mod server;
 pub mod transport;
-pub mod types;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,18 @@
 mod auth;
 mod cli;
 mod config;
+mod core;
 mod mcp;
 mod metrics;
 mod persistence;
 mod processing;
 mod server;
 mod transport;
-mod types;
 mod util;
 
 use std::sync::Arc;
 
+use crate::core::types::ResponseEnvelope;
 use axum::{
     http::{
         header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, ORIGIN},
@@ -27,7 +28,6 @@ use persistence::{persistence_mysql::MysqlStorage, persistence_sqlite::SqliteSto
 use server::Server;
 use transport::transport_http_poll::PollRegistry;
 use transport::{BashTransport, GcpsTransport, HttpTransport, PollTransport};
-use types::ResponseEnvelope;
 
 #[derive(Parser)]
 #[command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,11 @@ use axum::{
 };
 use clap::{Parser, Subcommand};
 use config::Config;
+use core::{ResonateRouter, ResonateServer, ResonateWorker};
 use persistence::{persistence_mysql::MysqlStorage, persistence_sqlite::SqliteStorage, Storage};
 use server::Server;
+use std::collections::HashMap;
 use transport::transport_http_poll::PollRegistry;
-use transport::{BashTransport, GcpsTransport, HttpTransport, PollTransport};
 
 #[derive(Parser)]
 #[command(
@@ -244,12 +245,27 @@ async fn run_server(config: Config) -> Result<(), String> {
         http_poll_buffer_size = poll_buffer_size,
         "Transport config"
     );
-    let poll_registry = Arc::new(PollRegistry::new(poll_max_connections, poll_buffer_size));
+    // Every worker holds a handle to the server: an in-process worker calls it
+    // directly, and a remote worker uses it to report a delivery failure rather
+    // than dropping the message. `Server` never holds the router, so this stays
+    // a DAG.
+    let server: Arc<dyn ResonateServer> = state.clone();
+
+    let poll_registry = Arc::new(PollRegistry::new(
+        Arc::clone(&server),
+        poll_max_connections,
+        poll_buffer_size,
+    ));
     let connect_timeout =
         std::time::Duration::from_millis(state.config.transports.http_push.connect_timeout);
     let request_timeout =
         std::time::Duration::from_millis(state.config.transports.http_push.request_timeout);
-    let http_push: Option<Arc<dyn HttpTransport>> = if state.config.transports.http_push.enabled {
+
+    // Scheme -> worker. A disabled transport is simply not registered, and the
+    // router reports its addresses as undeliverable.
+    let mut workers: HashMap<String, Arc<dyn ResonateWorker>> = HashMap::new();
+
+    if state.config.transports.http_push.enabled {
         let outbound_auth = match &state.config.transports.http_push.auth {
             Some(auth_cfg) => {
                 let mode_label = format!("{:?}", auth_cfg.mode);
@@ -262,50 +278,53 @@ async fn run_server(config: Config) -> Result<(), String> {
                 transport::transport_http_push::Auth::None
             }
         };
-        Some(Arc::new(
-            transport::transport_http_push::HttpPushTransport::new(
+        let worker: Arc<dyn ResonateWorker> =
+            Arc::new(transport::transport_http_push::HttpPushTransport::new(
+                Arc::clone(&server),
                 connect_timeout,
                 request_timeout,
                 outbound_auth,
                 state.config.transports.http_push.concurrency,
-            ),
-        ))
+            ));
+        workers.insert("http".to_string(), Arc::clone(&worker));
+        workers.insert("https".to_string(), worker);
     } else {
         tracing::info!("HTTP push transport disabled");
-        None
-    };
-    let http_poll: Option<Arc<dyn PollTransport>> = if state.config.transports.http_poll.enabled {
-        Some(poll_registry.clone())
+    }
+
+    if state.config.transports.http_poll.enabled {
+        workers.insert("poll".to_string(), poll_registry.clone());
     } else {
         tracing::info!("HTTP poll transport disabled");
-        None
-    };
-    let gcps: Option<Arc<dyn GcpsTransport>> = if state.config.transports.gcps.enabled {
+    }
+
+    if state.config.transports.gcps.enabled {
         tracing::info!(
             concurrency = state.config.transports.gcps.concurrency,
             timeout_ms = state.config.transports.gcps.timeout,
             "GCP Pub/Sub transport enabled"
         );
-        Some(Arc::new(
-            transport::transport_gcps::GcpsPubSubTransport::new(
+        workers.insert(
+            "gcps".to_string(),
+            Arc::new(transport::transport_gcps::GcpsPubSubTransport::new(
+                Arc::clone(&server),
                 state.config.transports.gcps.concurrency,
                 std::time::Duration::from_millis(state.config.transports.gcps.timeout),
-            ),
-        ))
-    } else {
-        None
-    };
-    let bash: Option<Arc<dyn BashTransport>> = if state.config.transports.bash_exec.enabled {
+            )),
+        );
+    }
+
+    if state.config.transports.bash_exec.enabled {
         tracing::info!("Bash exec transport enabled (local + docker + tensorlake)");
-        Some(Arc::new(
-            transport::transport_exec_bash::BashExecTransport::new(Arc::clone(&state)),
-        ))
-    } else {
-        None
-    };
-    let dispatcher = Arc::new(transport::TransportDispatcher::new(
-        http_push, http_poll, gcps, bash,
-    ));
+        workers.insert(
+            "bash".to_string(),
+            Arc::new(transport::transport_exec_bash::BashExecTransport::new(
+                Arc::clone(&state),
+            )),
+        );
+    }
+
+    let router: Arc<dyn ResonateRouter> = Arc::new(transport::TransportDispatcher::new(workers));
 
     // Spawn background loops
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -320,11 +339,11 @@ async fn run_server(config: Config) -> Result<(), String> {
 
     let message_state = Arc::clone(&state);
     let message_shutdown = shutdown_rx.clone();
-    let message_dispatcher = Arc::clone(&dispatcher);
+    let message_router = Arc::clone(&router);
     handles.push(tokio::spawn(async move {
         processing::processing_messages::message_processing_loop(
             message_state,
-            message_dispatcher,
+            message_router,
             message_shutdown,
         )
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,12 @@ async fn run_server(config: Config) -> Result<(), String> {
         workers.insert(
             "bash".to_string(),
             Arc::new(transport::transport_exec_bash::BashExecTransport::new(
-                Arc::clone(&state),
+                Arc::clone(&server),
+                state
+                    .config
+                    .transports
+                    .bash_exec
+                    .resolve_lease_timeout(&state.config.tasks),
             )),
         );
     }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{json, Value};
 use validator::Validate;
 
-use crate::types::{
+use crate::core::types::{
     format_validation_errors, PromiseCreateData, PromiseGetData, PromiseRecord,
     PromiseRegisterCallbackData, PromiseRegisterListenerData, PromiseResponseData,
     PromiseSearchData, PromiseSearchResponseData, PromiseSettleData, PromiseState, PromiseValue,
@@ -204,7 +204,7 @@ impl Oracle {
             Err(e) => return e,
         };
         if let Some(addr) = r.tags.get("resonate:target") {
-            if !crate::transport::is_valid_address(addr) {
+            if !crate::core::is_valid_address(addr) {
                 return ResponseEnvelope::error(
                     req.kind.clone(),
                     req.head.corr_id.clone(),
@@ -449,7 +449,7 @@ impl Oracle {
             Ok(r) => r,
             Err(e) => return e,
         };
-        if !crate::transport::is_valid_address(&r.address) {
+        if !crate::core::is_valid_address(&r.address) {
             return ResponseEnvelope::error(
                 req.kind.clone(),
                 req.head.corr_id.clone(),
@@ -609,7 +609,7 @@ impl Oracle {
         };
         let action = &r.action.data;
         if let Some(addr) = action.tags.get("resonate:target") {
-            if !crate::transport::is_valid_address(addr) {
+            if !crate::core::is_valid_address(addr) {
                 return ResponseEnvelope::error(
                     req.kind.clone(),
                     req.head.corr_id.clone(),
@@ -1096,7 +1096,7 @@ impl Oracle {
                     );
                 }
                 if let Some(addr) = create_data.tags.get("resonate:target") {
-                    if !crate::transport::is_valid_address(addr) {
+                    if !crate::core::is_valid_address(addr) {
                         return ResponseEnvelope::error(
                             req.kind.clone(),
                             req.head.corr_id.clone(),

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -16,7 +16,10 @@ use crate::core::types::{
     TaskRecord, TaskReleaseData, TaskResponseData, TaskSearchData, TaskSearchResponseData,
     TaskState, TaskSuspendData, TaskSuspendPreloadData, PROTOCOL_VERSION,
 };
+use crate::core::{ResonateServer, Unavailable};
 use crate::util;
+use async_trait::async_trait;
+use std::sync::Mutex;
 
 const PENDING_RETRY_TTL: i64 = 30_000;
 
@@ -2297,5 +2300,27 @@ impl Oracle {
 
     pub fn has_schedules(&self) -> bool {
         !self.schedules.is_empty()
+    }
+}
+
+/// The reference model behind the same port as the real server.
+///
+/// `Oracle::apply` takes `&mut self`, so the impl lands on `Mutex<Oracle>` —
+/// the orphan rule permits it because the trait is local. That also states the
+/// truth honestly: the real server serves requests concurrently, and the
+/// reference model is its serialized equivalent.
+///
+/// Unlike [`Server`](crate::server::Server), the oracle honours
+/// `head.debug_time` unconditionally. It has no config to gate on and no clock
+/// of its own, and every caller of it is a test driving a synthetic clock.
+#[async_trait]
+impl ResonateServer for Mutex<Oracle> {
+    async fn process(&self, req: &RequestEnvelope) -> Result<ResponseEnvelope, Unavailable> {
+        // No await while the guard is held.
+        let resp = {
+            let mut oracle = self.lock().expect("oracle mutex poisoned");
+            oracle.apply(req)
+        };
+        Ok(resp)
     }
 }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -4,7 +4,7 @@ pub mod persistence_sqlite;
 
 use std::collections::HashMap;
 
-use crate::types::{PromiseRecord, ScheduleRecord, Snapshot, TaskRecord, TaskState};
+use crate::core::types::{PromiseRecord, ScheduleRecord, Snapshot, TaskRecord, TaskState};
 
 pub type StorageResult<T> = Result<T, StorageError>;
 

--- a/src/persistence/persistence_mysql.rs
+++ b/src/persistence/persistence_mysql.rs
@@ -6,7 +6,7 @@ use super::{
     TaskFenceSettleParams, TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskReleaseResult,
     TaskSuspendResult,
 };
-use crate::types::{
+use crate::core::types::{
     PromiseRecord, PromiseState, PromiseValue, ScheduleRecord, Snapshot, SnapshotCallback,
     SnapshotListener, SnapshotMessage, SnapshotPromiseTimeout, SnapshotTaskTimeout, TaskRecord,
     TaskState,

--- a/src/persistence/persistence_postgres.rs
+++ b/src/persistence/persistence_postgres.rs
@@ -6,7 +6,7 @@ use super::{
     TaskFenceSettleParams, TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskReleaseResult,
     TaskSuspendResult,
 };
-use crate::types::{
+use crate::core::types::{
     PromiseRecord, PromiseState, PromiseValue, ScheduleRecord, Snapshot, SnapshotCallback,
     SnapshotListener, SnapshotMessage, SnapshotPromiseTimeout, SnapshotTaskTimeout, TaskRecord,
     TaskState,

--- a/src/persistence/persistence_sqlite.rs
+++ b/src/persistence/persistence_sqlite.rs
@@ -8,7 +8,7 @@ use super::{
     TaskCreateResult, TaskFenceCreateParams, TaskFenceResult, TaskFenceSettleParams,
     TaskFulfillParams, TaskFulfillResult, TaskHaltResult, TaskReleaseResult, TaskSuspendResult,
 };
-use crate::types::{
+use crate::core::types::{
     PromiseRecord, PromiseState, PromiseValue, ScheduleRecord, Snapshot, SnapshotCallback,
     SnapshotListener, SnapshotMessage, SnapshotPromiseTimeout, SnapshotTaskTimeout, TaskRecord,
     TaskState,

--- a/src/processing/processing_messages.rs
+++ b/src/processing/processing_messages.rs
@@ -6,10 +6,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::core::types::{ExecuteMsg, ExecuteMsgData, ExecuteMsgTask, MessageHead};
 use crate::metrics;
 use crate::persistence::Storage;
 use crate::transport::TransportDispatcher;
-use crate::types::{ExecuteMsg, ExecuteMsgData, ExecuteMsgTask, MessageHead};
 
 /// Background message processing loop.
 pub async fn message_processing_loop(
@@ -128,11 +128,11 @@ mod tests {
     use serde_json::json;
 
     use crate::config::Config;
+    use crate::core::types::{RequestEnvelope, RequestHead, SUPPORTED_VERSIONS};
     use crate::persistence::{persistence_sqlite::SqliteStorage, Storage};
     use crate::server::{dispatch as server_dispatch, Server};
     use crate::transport::stubs::{RecordingHttpTransport, RecordingPollTransport};
     use crate::transport::{HttpTransport, PollTransport, TransportDispatcher};
-    use crate::types::{RequestEnvelope, RequestHead, SUPPORTED_VERSIONS};
 
     // ---- helpers ----
 

--- a/src/processing/processing_messages.rs
+++ b/src/processing/processing_messages.rs
@@ -130,7 +130,7 @@ mod tests {
     use crate::config::Config;
     use crate::core::types::{RequestEnvelope, RequestHead, SUPPORTED_VERSIONS};
     use crate::persistence::{persistence_sqlite::SqliteStorage, Storage};
-    use crate::server::{dispatch as server_dispatch, Server};
+    use crate::server::Server;
     use crate::transport::stubs::{RecordingHttpTransport, RecordingPollTransport};
     use crate::transport::{HttpTransport, PollTransport, TransportDispatcher};
 
@@ -158,7 +158,7 @@ mod tests {
     }
 
     async fn dispatch(server: &Arc<Server>, kind: &str, data: serde_json::Value) {
-        let resp = server_dispatch(server, &req(kind, data), 1_000_000).await;
+        let resp = server.dispatch(&req(kind, data), 1_000_000).await;
         assert_eq!(resp.head.status, 200, "{kind} failed: {:?}", resp.data);
     }
 

--- a/src/processing/processing_messages.rs
+++ b/src/processing/processing_messages.rs
@@ -6,15 +6,18 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::core::types::{ExecuteMsg, ExecuteMsgData, ExecuteMsgTask, MessageHead};
+use crate::core::types::{
+    ExecuteMsg, ExecuteMsgData, ExecuteMsgTask, Message, MessageHead, UnblockMsg, UnblockMsgData,
+    UnblockMsgHead,
+};
+use crate::core::ResonateRouter;
 use crate::metrics;
 use crate::persistence::Storage;
-use crate::transport::TransportDispatcher;
 
 /// Background message processing loop.
 pub async fn message_processing_loop(
     state: Arc<crate::server::Server>,
-    dispatcher: Arc<TransportDispatcher>,
+    router: Arc<dyn ResonateRouter>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) {
     let interval = Duration::from_millis(state.config.messages.poll_interval);
@@ -34,7 +37,7 @@ pub async fn message_processing_loop(
         }
 
         let server_url = state.config.server.url.clone().unwrap_or_default();
-        process_batch(&state.storage, &dispatcher, batch_size, &server_url).await;
+        process_batch(&state.storage, router.as_ref(), batch_size, &server_url).await;
     }
 }
 
@@ -43,7 +46,7 @@ pub async fn message_processing_loop(
 /// Called by the background loop and `debug.tick`.
 pub async fn process_batch(
     storage: &Storage,
-    dispatcher: &TransportDispatcher,
+    router: &dyn ResonateRouter,
     batch_size: i64,
     server_url: &str,
 ) {
@@ -84,7 +87,7 @@ pub async fn process_batch(
             address = %msg.address,
             "Dispatching execute message"
         );
-        let payload = ExecuteMsg {
+        let payload = Message::Execute(ExecuteMsg {
             kind: "execute".to_string(),
             head: MessageHead {
                 server_url: server_url.to_string(),
@@ -95,10 +98,10 @@ pub async fn process_batch(
                     version: msg.version,
                 },
             },
-        };
-        dispatcher
-            .send(&msg.address, &serde_json::to_value(&payload).unwrap())
-            .await;
+        });
+        if let Err(e) = router.route(&msg.address, &payload).await {
+            tracing::warn!(address = %msg.address, error = %e, "Execute message not delivered");
+        }
     }
 
     for msg in unblock_msgs {
@@ -109,14 +112,16 @@ pub async fn process_batch(
             address = %msg.address,
             "Dispatching unblock message"
         );
-        let payload = serde_json::json!({
-            "kind": "unblock",
-            "head": {},
-            "data": {
-                "promise": msg.promise
-            }
+        let payload = Message::Unblock(UnblockMsg {
+            kind: "unblock".to_string(),
+            head: UnblockMsgHead {},
+            data: UnblockMsgData {
+                promise: msg.promise,
+            },
         });
-        dispatcher.send(&msg.address, &payload).await;
+        if let Err(e) = router.route(&msg.address, &payload).await {
+            tracing::warn!(address = %msg.address, error = %e, "Unblock message not delivered");
+        }
     }
 }
 
@@ -129,10 +134,24 @@ mod tests {
 
     use crate::config::Config;
     use crate::core::types::{RequestEnvelope, RequestHead, SUPPORTED_VERSIONS};
+    use crate::core::ResonateWorker;
     use crate::persistence::{persistence_sqlite::SqliteStorage, Storage};
     use crate::server::Server;
-    use crate::transport::stubs::{RecordingHttpTransport, RecordingPollTransport};
-    use crate::transport::{HttpTransport, PollTransport, TransportDispatcher};
+    use crate::transport::stubs::RecordingWorker;
+    use crate::transport::TransportDispatcher;
+    use std::collections::HashMap;
+
+    /// A router with `stub` registered for `scheme` and nothing else, so an
+    /// address of any other scheme is undeliverable.
+    fn router_with(scheme: &str, stub: Arc<RecordingWorker>) -> TransportDispatcher {
+        let mut workers: HashMap<String, Arc<dyn ResonateWorker>> = HashMap::new();
+        workers.insert(scheme.to_string(), stub);
+        TransportDispatcher::new(workers)
+    }
+
+    fn empty_router() -> TransportDispatcher {
+        TransportDispatcher::new(HashMap::new())
+    }
 
     // ---- helpers ----
 
@@ -225,13 +244,8 @@ mod tests {
         let server = make_server();
         create_task_with_target(&server, "task-1", "http://stub-server/webhook").await;
 
-        let stub = Arc::new(RecordingHttpTransport::new());
-        let dispatcher = TransportDispatcher::new(
-            Some(stub.clone() as Arc<dyn HttpTransport>),
-            None,
-            None,
-            None,
-        );
+        let stub = Arc::new(RecordingWorker::new());
+        let dispatcher = router_with("http", stub.clone());
 
         process_batch(&server.storage, &dispatcher, 100, "http://localhost:8001").await;
 
@@ -249,17 +263,12 @@ mod tests {
         create_task_with_target(&server, "task-2", "http://stub-server/webhook").await;
 
         // First pass: http_push disabled — message is consumed from queue and dropped.
-        let disabled = TransportDispatcher::new(None, None, None, None);
+        let disabled = empty_router();
         process_batch(&server.storage, &disabled, 100, "http://localhost:8001").await;
 
         // Second pass: http_push now enabled — queue should already be empty.
-        let stub = Arc::new(RecordingHttpTransport::new());
-        let enabled = TransportDispatcher::new(
-            Some(stub.clone() as Arc<dyn HttpTransport>),
-            None,
-            None,
-            None,
-        );
+        let stub = Arc::new(RecordingWorker::new());
+        let enabled = router_with("http", stub.clone());
         process_batch(&server.storage, &enabled, 100, "http://localhost:8001").await;
 
         assert_eq!(
@@ -274,20 +283,16 @@ mod tests {
         let server = make_server();
         create_task_with_target(&server, "task-3", "poll://any@default").await;
 
-        let stub = Arc::new(RecordingPollTransport::new());
-        let dispatcher = TransportDispatcher::new(
-            None,
-            Some(stub.clone() as Arc<dyn PollTransport>),
-            None,
-            None,
-        );
+        let stub = Arc::new(RecordingWorker::new());
+        let dispatcher = router_with("poll", stub.clone());
 
         process_batch(&server.storage, &dispatcher, 100, "http://localhost:8001").await;
 
         let calls = stub.calls();
         assert_eq!(calls.len(), 1, "expected exactly one poll dispatch");
-        assert_eq!(calls[0].0, "default");
-        let body: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        // The worker receives the address verbatim, not a decomposed group.
+        assert_eq!(calls[0].0, "poll://any@default");
+        let body = &calls[0].1;
         assert_eq!(body["kind"], "execute");
         assert_eq!(body["data"]["task"]["id"], "task-3");
     }
@@ -297,16 +302,11 @@ mod tests {
         let server = make_server();
         create_task_with_target(&server, "task-4", "poll://any@default").await;
 
-        let disabled = TransportDispatcher::new(None, None, None, None);
+        let disabled = empty_router();
         process_batch(&server.storage, &disabled, 100, "http://localhost:8001").await;
 
-        let stub = Arc::new(RecordingPollTransport::new());
-        let enabled = TransportDispatcher::new(
-            None,
-            Some(stub.clone() as Arc<dyn PollTransport>),
-            None,
-            None,
-        );
+        let stub = Arc::new(RecordingWorker::new());
+        let enabled = router_with("poll", stub.clone());
         process_batch(&server.storage, &enabled, 100, "http://localhost:8001").await;
 
         assert_eq!(stub.calls().len(), 0);
@@ -333,20 +333,15 @@ mod tests {
         register_listener(&server, "p-unblock-1", "poll://uni@worker-group/worker-1").await;
         settle_promise(&server, "p-unblock-1").await;
 
-        let stub = Arc::new(RecordingPollTransport::new());
-        let dispatcher = TransportDispatcher::new(
-            None,
-            Some(stub.clone() as Arc<dyn PollTransport>),
-            None,
-            None,
-        );
+        let stub = Arc::new(RecordingWorker::new());
+        let dispatcher = router_with("poll", stub.clone());
 
         process_batch(&server.storage, &dispatcher, 100, "http://localhost:8001").await;
 
         let calls = stub.calls();
         assert_eq!(calls.len(), 1, "expected exactly one unblock dispatch");
-        assert_eq!(calls[0].0, "worker-group");
-        let body: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(calls[0].0, "poll://uni@worker-group/worker-1");
+        let body = &calls[0].1;
         assert_eq!(body["kind"], "unblock");
         assert_eq!(body["data"]["promise"]["id"], "p-unblock-1");
         assert_eq!(body["data"]["promise"]["state"], "resolved");
@@ -371,17 +366,12 @@ mod tests {
         settle_promise(&server, "p-unblock-2").await;
 
         // First pass: poll disabled — message consumed and dropped.
-        let disabled = TransportDispatcher::new(None, None, None, None);
+        let disabled = empty_router();
         process_batch(&server.storage, &disabled, 100, "http://localhost:8001").await;
 
         // Second pass: poll enabled — queue already drained.
-        let stub = Arc::new(RecordingPollTransport::new());
-        let enabled = TransportDispatcher::new(
-            None,
-            Some(stub.clone() as Arc<dyn PollTransport>),
-            None,
-            None,
-        );
+        let stub = Arc::new(RecordingWorker::new());
+        let enabled = router_with("poll", stub.clone());
         process_batch(&server.storage, &enabled, 100, "http://localhost:8001").await;
 
         assert_eq!(stub.calls().len(), 0);

--- a/src/processing/processing_messages.rs
+++ b/src/processing/processing_messages.rs
@@ -237,6 +237,62 @@ mod tests {
         .await;
     }
 
+    /// Is an undeliverable execute message *permanently* lost, or re-queued?
+    ///
+    /// `take_outgoing` deletes before delivery (at-most-once), so a failed
+    /// route loses that attempt. But a task left `pending` keeps its type-0
+    /// retry timeout, and `process_timeouts` re-inserts `outgoing_execute` when
+    /// it fires — so the message comes back.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn undeliverable_execute_message_is_requeued_not_lost() {
+        let server = make_server();
+        create_task_with_target(&server, "task-requeue", "http://stub-server/webhook").await;
+
+        // First pass with nothing registered: the message is dequeued and dropped.
+        process_batch(
+            &server.storage,
+            &empty_router(),
+            100,
+            "http://localhost:8001",
+        )
+        .await;
+
+        let stub = Arc::new(RecordingWorker::new());
+        process_batch(
+            &server.storage,
+            &router_with("http", stub.clone()),
+            100,
+            "http://localhost:8001",
+        )
+        .await;
+        assert_eq!(stub.calls().len(), 0, "that attempt really was consumed");
+
+        // Advance past the task retry timeout and let timeout processing run.
+        let retry_deadline = 1_000_000 + 60_000;
+        server
+            .storage
+            .transact(move |db| db.process_timeouts(retry_deadline))
+            .await
+            .unwrap();
+
+        // The message should be back.
+        process_batch(
+            &server.storage,
+            &router_with("http", stub.clone()),
+            100,
+            "http://localhost:8001",
+        )
+        .await;
+        let calls = stub.calls();
+        assert_eq!(
+            calls.len(),
+            1,
+            "a pending task re-queues its execute message on retry timeout — \
+             the message is lost for one attempt, not permanently"
+        );
+        assert_eq!(calls[0].0, "http://stub-server/webhook");
+    }
+
     // ---- execute-message tests ----
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,15 +15,7 @@ use serde_json::Value;
 
 use crate::auth;
 use crate::config::Config;
-use crate::metrics;
-use crate::persistence::{
-    PromiseCreateParams, PromiseSettleParams, ScheduleCreateParams, Storage, StorageError,
-    TaskAcquireParams, TaskCreateParams, TaskFenceCreateParams, TaskFenceSettleParams,
-    TaskFulfillParams,
-};
-use crate::processing::processing_timeouts;
-use crate::transport::transport_http_poll::PollRegistry;
-use crate::types::{
+use crate::core::types::{
     format_validation_errors, PromiseCreateData, PromiseGetData, PromiseRegisterCallbackData,
     PromiseRegisterListenerData, PromiseResponseData, PromiseSearchData, PromiseSearchResponseData,
     PromiseSettleData, PromiseState, RequestEnvelope, ResponseEnvelope, ScheduleCreateData,
@@ -34,6 +26,14 @@ use crate::types::{
     TaskReleaseData, TaskResponseData, TaskSearchData, TaskSearchResponseData, TaskState,
     TaskSuspendData, TaskSuspendPreloadData, SUPPORTED_VERSIONS,
 };
+use crate::metrics;
+use crate::persistence::{
+    PromiseCreateParams, PromiseSettleParams, ScheduleCreateParams, Storage, StorageError,
+    TaskAcquireParams, TaskCreateParams, TaskFenceCreateParams, TaskFenceSettleParams,
+    TaskFulfillParams,
+};
+use crate::processing::processing_timeouts;
+use crate::transport::transport_http_poll::PollRegistry;
 use crate::util;
 use validator::Validate;
 
@@ -581,7 +581,7 @@ async fn op_promise_create(
             }
             let address = r.tags.get("resonate:target").map(|s| s.as_str());
             if let Some(addr) = address {
-                if !crate::transport::is_valid_address(addr) {
+                if !crate::core::is_valid_address(addr) {
                     tracing::warn!(
                         promise_id = %r.id,
                         address = addr,
@@ -879,7 +879,7 @@ async fn op_promise_register_listener(
                     &format_validation_errors(&e),
                 ));
             }
-            if !crate::transport::is_valid_address(&r.address) {
+            if !crate::core::is_valid_address(&r.address) {
                 tracing::warn!(
                     awaited = %r.awaited,
                     address = %r.address,
@@ -1110,7 +1110,7 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
             let action_data = &r.action.data;
             let action_id = &action_data.id;
             if let Some(addr) = action_data.tags.get("resonate:target") {
-                if !crate::transport::is_valid_address(addr) {
+                if !crate::core::is_valid_address(addr) {
                     tracing::warn!(
                         task_id = %action_id,
                         address = %addr,
@@ -1792,7 +1792,7 @@ async fn op_task_fence(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> 
                     let already_timedout = now >= create_data.timeout_at;
                     let address = create_data.tags.get("resonate:target").map(|s| s.as_str());
                     if let Some(addr) = address {
-                        if !crate::transport::is_valid_address(addr) {
+                        if !crate::core::is_valid_address(addr) {
                             tracing::warn!(
                                 task_id = %r.id,
                                 address = addr,

--- a/src/server.rs
+++ b/src/server.rs
@@ -273,7 +273,7 @@ async fn handle_api(
 
     let now = util::resolve_time(req.head.debug_time);
 
-    let response = dispatch(state, &req, now).await;
+    let response = state.dispatch(&req, now).await;
     let status = response.head.status.to_string();
     let elapsed_ms = start.elapsed().as_millis();
 
@@ -404,862 +404,802 @@ impl Drop for PollGuard {
     }
 }
 
-pub async fn dispatch(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let kind = req.kind.as_str();
+impl Server {
+    pub async fn dispatch(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let kind = req.kind.as_str();
 
-    match kind {
-        // === Promise operations ===
-        "promise.get" => op_promise_get(state, req, now).await,
-        "promise.create" => op_promise_create(state, req, now).await,
-        "promise.settle" => op_promise_settle(state, req, now).await,
-        "promise.register_callback" => op_promise_register_callback(state, req, now).await,
-        "promise.register_listener" => op_promise_register_listener(state, req, now).await,
-        "promise.search" => op_promise_search(state, req, now).await,
+        match kind {
+            // === Promise operations ===
+            "promise.get" => self.op_promise_get(req, now).await,
+            "promise.create" => self.op_promise_create(req, now).await,
+            "promise.settle" => self.op_promise_settle(req, now).await,
+            "promise.register_callback" => self.op_promise_register_callback(req, now).await,
+            "promise.register_listener" => self.op_promise_register_listener(req, now).await,
+            "promise.search" => self.op_promise_search(req, now).await,
 
-        // === Task operations ===
-        "task.get" => op_task_get(state, req, now).await,
-        "task.create" => op_task_create(state, req, now).await,
-        "task.acquire" => op_task_acquire(state, req, now).await,
-        "task.release" => op_task_release(state, req, now).await,
-        "task.fulfill" => op_task_fulfill(state, req, now).await,
-        "task.suspend" => op_task_suspend(state, req, now).await,
-        "task.fence" => op_task_fence(state, req, now).await,
-        "task.heartbeat" => op_task_heartbeat(state, req, now).await,
-        "task.halt" => op_task_halt(state, req, now).await,
-        "task.continue" => op_task_continue(state, req, now).await,
-        "task.search" => op_task_search(state, req, now).await,
+            // === Task operations ===
+            "task.get" => self.op_task_get(req, now).await,
+            "task.create" => self.op_task_create(req, now).await,
+            "task.acquire" => self.op_task_acquire(req, now).await,
+            "task.release" => self.op_task_release(req, now).await,
+            "task.fulfill" => self.op_task_fulfill(req, now).await,
+            "task.suspend" => self.op_task_suspend(req, now).await,
+            "task.fence" => self.op_task_fence(req, now).await,
+            "task.heartbeat" => self.op_task_heartbeat(req, now).await,
+            "task.halt" => self.op_task_halt(req, now).await,
+            "task.continue" => self.op_task_continue(req, now).await,
+            "task.search" => self.op_task_search(req, now).await,
 
-        // === Schedule operations ===
-        "schedule.get" => op_schedule_get(state, req, now).await,
-        "schedule.create" => op_schedule_create(state, req, now).await,
-        "schedule.delete" => op_schedule_delete(state, req).await,
-        "schedule.search" => op_schedule_search(state, req).await,
+            // === Schedule operations ===
+            "schedule.get" => self.op_schedule_get(req, now).await,
+            "schedule.create" => self.op_schedule_create(req, now).await,
+            "schedule.delete" => self.op_schedule_delete(req).await,
+            "schedule.search" => self.op_schedule_search(req).await,
 
-        // === Debug operations ===
-        "debug.start" | "debug.stop" | "debug.reset" | "debug.snap" | "debug.tick"
-            if !state.config.debug =>
+            // === Debug operations ===
+            "debug.start" | "debug.stop" | "debug.reset" | "debug.snap" | "debug.tick"
+                if !self.config.debug =>
+            {
+                ResponseEnvelope::error(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    403,
+                    "Debug operations are disabled",
+                )
+            }
+            "debug.start" => {
+                self.debug_mode.store(true, Ordering::SeqCst);
+                tracing::info!("Debug mode started — background loops paused");
+                ResponseEnvelope::new(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    200,
+                    Value::Object(serde_json::Map::new()),
+                )
+            }
+            "debug.stop" => {
+                self.debug_mode.store(false, Ordering::SeqCst);
+                tracing::info!("Debug mode stopped — background loops resumed");
+                ResponseEnvelope::new(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    200,
+                    Value::Object(serde_json::Map::new()),
+                )
+            }
+            "debug.reset" => self.op_debug_reset(req).await,
+            "debug.snap" => self.op_debug_snap(req).await,
+            "debug.tick" => self.op_debug_tick(req).await,
+
+            _ => {
+                tracing::warn!(kind = %kind, "Invalid request: unknown operation");
+                ResponseEnvelope::error(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    400,
+                    &format!("Unknown operation: {}", kind),
+                )
+            }
+        }
+    }
+
+    // ============================================================================
+    // Promise operations
+    // ============================================================================
+
+    async fn op_promise_get(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: PromiseGetData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                db.try_timeout(&[&r.id], now)?;
+                match db.promise_get(&r.id)? {
+                    Some(promise) => {
+                        tracing::debug!(
+                            promise_id = %r.id,
+                            state = %promise.state,
+                            "Promise found"
+                        );
+                        Ok(ResponseEnvelope::success(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            &PromiseResponseData { promise },
+                        ))
+                    }
+                    None => {
+                        tracing::debug!(promise_id = %r.id, "Promise not found");
+                        Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Promise not found",
+                        ))
+                    }
+                }
+            })
+            .await
         {
-            ResponseEnvelope::error(
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
                 req.kind.clone(),
                 req.head.corr_id.clone(),
-                403,
-                "Debug operations are disabled",
-            )
+                500,
+                &format!("Internal error: {}", e),
+            ),
         }
-        "debug.start" => {
-            state.debug_mode.store(true, Ordering::SeqCst);
-            tracing::info!("Debug mode started — background loops paused");
-            ResponseEnvelope::new(
-                req.kind.clone(),
-                req.head.corr_id.clone(),
-                200,
-                Value::Object(serde_json::Map::new()),
-            )
-        }
-        "debug.stop" => {
-            state.debug_mode.store(false, Ordering::SeqCst);
-            tracing::info!("Debug mode stopped — background loops resumed");
-            ResponseEnvelope::new(
-                req.kind.clone(),
-                req.head.corr_id.clone(),
-                200,
-                Value::Object(serde_json::Map::new()),
-            )
-        }
-        "debug.reset" => op_debug_reset(state, req).await,
-        "debug.snap" => op_debug_snap(state, req).await,
-        "debug.tick" => op_debug_tick(state, req).await,
+    }
 
-        _ => {
-            tracing::warn!(kind = %kind, "Invalid request: unknown operation");
-            ResponseEnvelope::error(
+    async fn op_promise_create(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: PromiseCreateData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                let address = r.tags.get("resonate:target").map(|s| s.as_str());
+                if let Some(addr) = address {
+                    if !crate::core::is_valid_address(addr) {
+                        tracing::warn!(
+                            promise_id = %r.id,
+                            address = addr,
+                            "Promise create rejected: invalid resonate:target address"
+                        );
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            "Invalid resonate:target address",
+                        ));
+                    }
+                }
+                db.try_timeout(&[&r.id], now)?;
+                let tags_json = serde_json::to_string(&r.tags).unwrap();
+                let already_timedout = now >= r.timeout_at;
+                let (state, created_at, settled_at) = if already_timedout {
+                    let state = if r.tags.get("resonate:timer").map(|v| v.as_str()) == Some("true") {
+                        tracing::debug!(promise_id = %r.id, "Promise created already timedout (timer: resolved immediately)");
+                        PromiseState::Resolved
+                    } else {
+                        tracing::debug!(promise_id = %r.id, "Promise created already timedout");
+                        PromiseState::RejectedTimedout
+                    };
+                    (state, r.timeout_at, Some(r.timeout_at))
+                } else {
+                    (PromiseState::Pending, now, None)
+                };
+                let param_headers_json = r
+                    .param
+                    .headers
+                    .as_ref()
+                    .map(|h| serde_json::to_string(h).unwrap());
+                let result = db.promise_create(&PromiseCreateParams {
+                    id: &r.id,
+                    state: state.as_str(),
+                    param_headers: param_headers_json.as_deref(),
+                    param_data: r.param.data.as_deref(),
+                    tags: &tags_json,
+                    timeout_at: r.timeout_at,
+                    created_at,
+                    settled_at,
+                    already_timedout,
+                    address,
+                })?;
+                if result.was_created {
+                    tracing::info!(
+                        promise_id = %result.promise.id,
+                        state = %result.promise.state,
+                        timeout_at = result.promise.timeout_at,
+                        target = address.unwrap_or("none"),
+                        already_timedout = already_timedout,
+                        "Promise created"
+                    );
+                } else {
+                    tracing::debug!(
+                        promise_id = %result.promise.id,
+                        state = %result.promise.state,
+                        "Promise create: already exists (idempotent)"
+                    );
+                }
+                Ok(ResponseEnvelope::success(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    &PromiseResponseData { promise: result.promise },
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(StorageError::InvalidInput(msg)) => ResponseEnvelope::error(
                 req.kind.clone(),
                 req.head.corr_id.clone(),
                 400,
-                &format!("Unknown operation: {}", kind),
-            )
+                &format!("Invalid request: {}", msg),
+            ),
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
         }
     }
-}
 
-// ============================================================================
-// Promise operations
-// ============================================================================
-
-async fn op_promise_get(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: PromiseGetData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+    async fn op_promise_settle(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: PromiseSettleData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.id], now)?;
-            match db.promise_get(&r.id)? {
-                Some(promise) => {
-                    tracing::debug!(
-                        promise_id = %r.id,
-                        state = %promise.state,
-                        "Promise found"
-                    );
-                    Ok(ResponseEnvelope::success(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        &PromiseResponseData { promise },
-                    ))
-                }
-                None => {
-                    tracing::debug!(promise_id = %r.id, "Promise not found");
-                    Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Promise not found",
-                    ))
-                }
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_promise_create(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: PromiseCreateData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let address = r.tags.get("resonate:target").map(|s| s.as_str());
-            if let Some(addr) = address {
-                if !crate::core::is_valid_address(addr) {
-                    tracing::warn!(
-                        promise_id = %r.id,
-                        address = addr,
-                        "Promise create rejected: invalid resonate:target address"
-                    );
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        "Invalid resonate:target address",
+                        &format_validation_errors(&e),
                     ));
                 }
-            }
-            db.try_timeout(&[&r.id], now)?;
-            let tags_json = serde_json::to_string(&r.tags).unwrap();
-            let already_timedout = now >= r.timeout_at;
-            let (state, created_at, settled_at) = if already_timedout {
-                let state = if r.tags.get("resonate:timer").map(|v| v.as_str()) == Some("true") {
-                    tracing::debug!(promise_id = %r.id, "Promise created already timedout (timer: resolved immediately)");
-                    PromiseState::Resolved
-                } else {
-                    tracing::debug!(promise_id = %r.id, "Promise created already timedout");
-                    PromiseState::RejectedTimedout
-                };
-                (state, r.timeout_at, Some(r.timeout_at))
-            } else {
-                (PromiseState::Pending, now, None)
-            };
-            let param_headers_json = r
-                .param
-                .headers
-                .as_ref()
-                .map(|h| serde_json::to_string(h).unwrap());
-            let result = db.promise_create(&PromiseCreateParams {
-                id: &r.id,
-                state: state.as_str(),
-                param_headers: param_headers_json.as_deref(),
-                param_data: r.param.data.as_deref(),
-                tags: &tags_json,
-                timeout_at: r.timeout_at,
-                created_at,
-                settled_at,
-                already_timedout,
-                address,
-            })?;
-            if result.was_created {
-                tracing::info!(
-                    promise_id = %result.promise.id,
-                    state = %result.promise.state,
-                    timeout_at = result.promise.timeout_at,
-                    target = address.unwrap_or("none"),
-                    already_timedout = already_timedout,
-                    "Promise created"
-                );
-            } else {
-                tracing::debug!(
-                    promise_id = %result.promise.id,
-                    state = %result.promise.state,
-                    "Promise create: already exists (idempotent)"
-                );
-            }
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &PromiseResponseData { promise: result.promise },
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(StorageError::InvalidInput(msg)) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            400,
-            &format!("Invalid request: {}", msg),
-        ),
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_promise_settle(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: PromiseSettleData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.id], now)?;
-            let value_headers_json = r
-                .value
-                .headers
-                .as_ref()
-                .map(|h| serde_json::to_string(h).unwrap());
-            let result = db.promise_settle(&PromiseSettleParams {
-                id: &r.id,
-                state: r.state.as_str(),
-                value_headers: value_headers_json.as_deref(),
-                value_data: r.value.data.as_deref(),
-                settled_at: now,
-            })?;
-            match result.promise {
-                Some(promise) => {
-                    assert_ne!(
-                        promise.state,
-                        PromiseState::Pending,
-                        "invariant: returning 200 but promise is still pending"
-                    );
-                    if result.was_settled {
-                        tracing::info!(
-                            promise_id = %promise.id,
-                            state = %promise.state,
-                            "Promise settled"
+                db.try_timeout(&[&r.id], now)?;
+                let value_headers_json = r
+                    .value
+                    .headers
+                    .as_ref()
+                    .map(|h| serde_json::to_string(h).unwrap());
+                let result = db.promise_settle(&PromiseSettleParams {
+                    id: &r.id,
+                    state: r.state.as_str(),
+                    value_headers: value_headers_json.as_deref(),
+                    value_data: r.value.data.as_deref(),
+                    settled_at: now,
+                })?;
+                match result.promise {
+                    Some(promise) => {
+                        assert_ne!(
+                            promise.state,
+                            PromiseState::Pending,
+                            "invariant: returning 200 but promise is still pending"
                         );
-                    } else {
-                        tracing::debug!(
-                            promise_id = %promise.id,
-                            current_state = %promise.state,
-                            requested_state = %r.state,
-                            "Promise settle: already settled (idempotent)"
-                        );
+                        if result.was_settled {
+                            tracing::info!(
+                                promise_id = %promise.id,
+                                state = %promise.state,
+                                "Promise settled"
+                            );
+                        } else {
+                            tracing::debug!(
+                                promise_id = %promise.id,
+                                current_state = %promise.state,
+                                requested_state = %r.state,
+                                "Promise settle: already settled (idempotent)"
+                            );
+                        }
+                        Ok(ResponseEnvelope::success(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            &PromiseResponseData { promise },
+                        ))
                     }
-                    Ok(ResponseEnvelope::success(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        &PromiseResponseData { promise },
-                    ))
+                    None => {
+                        tracing::debug!(promise_id = %r.id, "Promise settle: promise not found");
+                        Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Promise not found",
+                        ))
+                    }
                 }
-                None => {
-                    tracing::debug!(promise_id = %r.id, "Promise settle: promise not found");
-                    Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Promise not found",
-                    ))
-                }
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
     }
-}
 
-async fn op_promise_register_callback(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: PromiseRegisterCallbackData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+    async fn op_promise_register_callback(
+        &self,
+        req: &RequestEnvelope,
+        now: i64,
+    ) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: PromiseRegisterCallbackData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
-                    ))
+                        &format_validation_errors(&e),
+                    ));
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.awaited, &r.awaiter], now)?;
-            let result = db.promise_register_callback(&r.awaited, &r.awaiter, now)?;
-            let p_awaited = match result.awaited {
-                Some(p) => p,
-                None => {
-                    tracing::debug!(promise_id = %r.awaited, "Callback registration: awaited promise not found");
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Awaited promise not found",
-                    ))
-                }
-            };
-            let p_awaiter = match result.awaiter {
-                Some(p) => p,
-                None => {
-                    tracing::debug!(promise_id = %r.awaiter, "Callback registration: awaiter promise not found");
+                db.try_timeout(&[&r.awaited, &r.awaiter], now)?;
+                let result = db.promise_register_callback(&r.awaited, &r.awaiter, now)?;
+                let p_awaited = match result.awaited {
+                    Some(p) => p,
+                    None => {
+                        tracing::debug!(promise_id = %r.awaited, "Callback registration: awaited promise not found");
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Awaited promise not found",
+                        ))
+                    }
+                };
+                let p_awaiter = match result.awaiter {
+                    Some(p) => p,
+                    None => {
+                        tracing::debug!(promise_id = %r.awaiter, "Callback registration: awaiter promise not found");
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            422,
+                            "Awaiter promise not found",
+                        ))
+                    }
+                };
+                if !p_awaiter.tags.contains_key("resonate:target") {
+                    tracing::debug!(awaiter = %r.awaiter, "Callback registration rejected: awaiter has no resonate:target");
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         422,
-                        "Awaiter promise not found",
-                    ))
-                }
-            };
-            if !p_awaiter.tags.contains_key("resonate:target") {
-                tracing::debug!(awaiter = %r.awaiter, "Callback registration rejected: awaiter has no resonate:target");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    422,
-                    "Awaiter promise has no resonate:target tag",
-                ));
-            }
-            tracing::info!(
-                awaited = %r.awaited,
-                awaiter = %r.awaiter,
-                awaited_state = %p_awaited.state,
-                "Callback registered"
-            );
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &PromiseResponseData { promise: p_awaited },
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_promise_register_listener(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: PromiseRegisterListenerData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            if !crate::core::is_valid_address(&r.address) {
-                tracing::warn!(
-                    awaited = %r.awaited,
-                    address = %r.address,
-                    "Listener registration rejected: invalid address"
-                );
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    "Invalid listener address",
-                ));
-            }
-            db.try_timeout(&[&r.awaited], now)?;
-            match db.promise_register_listener(&r.awaited, &r.address)? {
-                Some(promise) => {
-                    tracing::info!(
-                        awaited = %r.awaited,
-                        address = %r.address,
-                        promise_state = %promise.state,
-                        "Listener registered"
-                    );
-                    Ok(ResponseEnvelope::success(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        &PromiseResponseData { promise },
-                    ))
-                }
-                None => {
-                    tracing::debug!(awaited = %r.awaited, "Listener registration: awaited promise not found");
-                    Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Awaited promise not found",
-                    ))
-                }
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_promise_search(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    _now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: PromiseSearchData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let tags_json = r.tags.as_ref().map(|t| serde_json::to_string(t).unwrap());
-            let limit = match r.limit {
-                Some(n) if n > 1000 => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        "Invalid 'limit' — must be between 1 and 1000",
-                    ))
-                }
-                Some(n) => n,
-                None => 100,
-            };
-            let state_str = r.state.map(|s| s.as_str());
-            let results = db.promise_search(
-                state_str,
-                tags_json.as_deref(),
-                r.cursor.as_deref(),
-                limit + 1,
-            )?;
-            let has_more = results.len() as i64 > limit;
-            let promises: Vec<_> = results.into_iter().take(limit as usize).collect();
-            let next_cursor = if has_more {
-                promises.last().map(|p| p.id.clone())
-            } else {
-                None
-            };
-            tracing::debug!(
-                found = promises.len(),
-                has_more = has_more,
-                "Promise search completed"
-            );
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &PromiseSearchResponseData {
-                    promises,
-                    cursor: next_cursor,
-                },
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-// ============================================================================
-// Task operations
-// ============================================================================
-
-async fn op_task_get(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskGetData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.id], now)?;
-            match db.task_get(&r.id)? {
-                Some(task) => {
-                    tracing::debug!(
-                        task_id = %r.id,
-                        state = %task.state,
-                        version = task.version,
-                        "Task found"
-                    );
-                    Ok(ResponseEnvelope::success(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        &TaskResponseData { task },
-                    ))
-                }
-                None => {
-                    tracing::debug!(task_id = %r.id, "Task not found");
-                    Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Task not found",
-                    ))
-                }
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskCreateData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let action_data = &r.action.data;
-            let action_id = &action_data.id;
-            if let Some(addr) = action_data.tags.get("resonate:target") {
-                if !crate::core::is_valid_address(addr) {
-                    tracing::warn!(
-                        task_id = %action_id,
-                        address = %addr,
-                        "Task create rejected: invalid resonate:target address"
-                    );
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        "Invalid resonate:target address",
+                        "Awaiter promise has no resonate:target tag",
                     ));
                 }
-            }
-            db.try_timeout(&[action_id], now)?;
-            // Lock preamble: ensures CTE and subsequent reads see
-            // current state under READ COMMITTED.
-            let _ = db.lock_for_update(action_id)?;
-            let tags_json = serde_json::to_string(&action_data.tags).unwrap();
-            let already_timedout = now >= action_data.timeout_at;
-            let (p_state, created_at, settled_at) = if already_timedout {
-                let p_state =
-                    if action_data.tags.get("resonate:timer").map(|v| v.as_str()) == Some("true") {
-                        tracing::debug!(task_id = %action_id, "Task create: already timedout (timer: resolved immediately)");
-                        PromiseState::Resolved
-                    } else {
-                        tracing::debug!(task_id = %action_id, "Task create: already timedout");
-                        PromiseState::RejectedTimedout
-                    };
-                (
-                    p_state,
-                    action_data.timeout_at,
-                    Some(action_data.timeout_at),
-                )
-            } else {
-                (PromiseState::Pending, now, None)
-            };
-            let param_headers_json = action_data
-                .param
-                .headers
-                .as_ref()
-                .map(|h| serde_json::to_string(h).unwrap());
-            let res = db.task_create(&TaskCreateParams {
-                promise_id: action_id,
-                state: p_state.as_str(),
-                param_headers: param_headers_json.as_deref(),
-                param_data: action_data.param.data.as_deref(),
-                tags: &tags_json,
-                timeout_at: action_data.timeout_at,
-                created_at,
-                settled_at,
-                already_timedout,
-                ttl: r.ttl,
-                pid: &r.pid,
-            })?;
-
-            // If the promise is settled, process callbacks as a separate
-            // statement. This fires any callbacks registered by concurrent
-            // transactions (e.g. task.suspend) that committed after
-            // try_timeout's snapshot but before now.
-            if res.promise.state != PromiseState::Pending {
-                db.process_callbacks(action_id, now)?;
-            }
-
-            // When the CTE created the task, use CTE result directly.
-            if res.task_created {
-                let task_state_str = res.task_state.expect("invariant: task_state is Some when task_created");
-                let task_state = task_state_str.parse::<TaskState>().expect("invariant: task_state is a valid TaskState");
-                assert!(res.promise.state != PromiseState::Pending || task_state != TaskState::Fulfilled, "invariant: pending promise with fulfilled task");
-                assert!(res.promise.state == PromiseState::Pending || task_state == TaskState::Fulfilled, "invariant: settled promise with non-fulfilled task");
-                // Acquired tasks start at version 1 (first claim), fulfilled at 0
-                let task_version = if task_state == TaskState::Acquired { 1 } else { 0 };
-                let task = TaskRecord {
-                    id: action_id.to_string(),
-                    state: task_state,
-                    version: task_version,
-                    resumes: 0,
-                    ttl: if task_state == TaskState::Fulfilled { None } else { Some(r.ttl) },
-                    pid: if task_state == TaskState::Fulfilled { None } else { Some(r.pid.to_string()) },
-                };
-                let preload = if task_state == TaskState::Acquired {
-                    db.compute_preload(action_id)?
-                } else {
-                    vec![]
-                };
-                return Ok(ResponseEnvelope::success(
+                tracing::info!(
+                    awaited = %r.awaited,
+                    awaiter = %r.awaiter,
+                    awaited_state = %p_awaited.state,
+                    "Callback registered"
+                );
+                Ok(ResponseEnvelope::success(
                     kind_str.clone(),
                     corr_id.clone(),
-                    &TaskCreateResponseData {
-                        task,
-                        promise: res.promise,
-                        preload,
-                    },
-                ));
-            }
+                    &PromiseResponseData { promise: p_awaited },
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
 
-            // CTE didn't create the task (promise already existed).
-            // Branch on the state/version surfaced by the CTE.
-            match (res.task_state.as_deref(), res.task_version) {
-                (Some("fulfilled"), version) => {
-                    assert_ne!(res.promise.state, PromiseState::Pending, "invariant: pending promise with fulfilled task");
-                    Ok(ResponseEnvelope::success(
+    async fn op_promise_register_listener(
+        &self,
+        req: &RequestEnvelope,
+        now: i64,
+    ) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: PromiseRegisterListenerData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
-                        &TaskCreateResponseData {
-                            task: TaskRecord {
-                                id: action_id.to_string(),
-                                state: TaskState::Fulfilled,
-                                version: version.unwrap_or(0),
-                                resumes: 0,
-                                ttl: None,
-                                pid: None,
-                            },
-                            promise: res.promise,
-                            preload: vec![],
-                        },
-                    ))
+                        400,
+                        &format_validation_errors(&e),
+                    ));
                 }
-                (Some("pending"), Some(version)) => {
-                    let acquire_result = db.task_acquire(&TaskAcquireParams {
-                        task_id: action_id,
-                        version,
-                        time: now,
-                        ttl: r.ttl,
-                        pid: &r.pid,
-                    })?;
-                    if acquire_result.was_acquired {
-                        let task = TaskRecord {
-                            id: action_id.to_string(),
-                            state: TaskState::Acquired,
-                            version: version + 1,
-                            resumes: 0,
-                            ttl: Some(r.ttl),
-                            pid: Some(r.pid.to_string()),
-                        };
-                        assert_eq!(res.promise.state, PromiseState::Pending, "invariant: settled promise with non-fulfilled task");
-                        assert_eq!(acquire_result.task_version, Some(version + 1), "invariant: acquired task version must be version + 1");
-                        let preload = db.compute_preload(action_id)?;
+                if !crate::core::is_valid_address(&r.address) {
+                    tracing::warn!(
+                        awaited = %r.awaited,
+                        address = %r.address,
+                        "Listener registration rejected: invalid address"
+                    );
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        "Invalid listener address",
+                    ));
+                }
+                db.try_timeout(&[&r.awaited], now)?;
+                match db.promise_register_listener(&r.awaited, &r.address)? {
+                    Some(promise) => {
+                        tracing::info!(
+                            awaited = %r.awaited,
+                            address = %r.address,
+                            promise_state = %promise.state,
+                            "Listener registered"
+                        );
                         Ok(ResponseEnvelope::success(
                             kind_str.clone(),
                             corr_id.clone(),
-                            &TaskCreateResponseData {
-                                task,
-                                promise: res.promise,
-                                preload,
-                            },
+                            &PromiseResponseData { promise },
                         ))
-                    } else if acquire_result.task_state == Some(TaskState::Fulfilled) {
-                        let promise = acquire_result.promise.expect("fulfilled task must have a promise");
-                        assert_ne!(promise.state, PromiseState::Pending, "invariant: fulfilled task cannot have a pending promise");
+                    }
+                    None => {
+                        tracing::debug!(awaited = %r.awaited, "Listener registration: awaited promise not found");
+                        Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Awaited promise not found",
+                        ))
+                    }
+                }
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_promise_search(&self, req: &RequestEnvelope, _now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: PromiseSearchData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                let tags_json = r.tags.as_ref().map(|t| serde_json::to_string(t).unwrap());
+                let limit = match r.limit {
+                    Some(n) if n > 1000 => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            "Invalid 'limit' — must be between 1 and 1000",
+                        ))
+                    }
+                    Some(n) => n,
+                    None => 100,
+                };
+                let state_str = r.state.map(|s| s.as_str());
+                let results = db.promise_search(
+                    state_str,
+                    tags_json.as_deref(),
+                    r.cursor.as_deref(),
+                    limit + 1,
+                )?;
+                let has_more = results.len() as i64 > limit;
+                let promises: Vec<_> = results.into_iter().take(limit as usize).collect();
+                let next_cursor = if has_more {
+                    promises.last().map(|p| p.id.clone())
+                } else {
+                    None
+                };
+                tracing::debug!(
+                    found = promises.len(),
+                    has_more = has_more,
+                    "Promise search completed"
+                );
+                Ok(ResponseEnvelope::success(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    &PromiseSearchResponseData {
+                        promises,
+                        cursor: next_cursor,
+                    },
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    // ============================================================================
+    // Task operations
+    // ============================================================================
+
+    async fn op_task_get(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskGetData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                db.try_timeout(&[&r.id], now)?;
+                match db.task_get(&r.id)? {
+                    Some(task) => {
+                        tracing::debug!(
+                            task_id = %r.id,
+                            state = %task.state,
+                            version = task.version,
+                            "Task found"
+                        );
+                        Ok(ResponseEnvelope::success(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            &TaskResponseData { task },
+                        ))
+                    }
+                    None => {
+                        tracing::debug!(task_id = %r.id, "Task not found");
+                        Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Task not found",
+                        ))
+                    }
+                }
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_task_create(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskCreateData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                let action_data = &r.action.data;
+                let action_id = &action_data.id;
+                if let Some(addr) = action_data.tags.get("resonate:target") {
+                    if !crate::core::is_valid_address(addr) {
+                        tracing::warn!(
+                            task_id = %action_id,
+                            address = %addr,
+                            "Task create rejected: invalid resonate:target address"
+                        );
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            "Invalid resonate:target address",
+                        ));
+                    }
+                }
+                db.try_timeout(&[action_id], now)?;
+                // Lock preamble: ensures CTE and subsequent reads see
+                // current state under READ COMMITTED.
+                let _ = db.lock_for_update(action_id)?;
+                let tags_json = serde_json::to_string(&action_data.tags).unwrap();
+                let already_timedout = now >= action_data.timeout_at;
+                let (p_state, created_at, settled_at) = if already_timedout {
+                    let p_state =
+                        if action_data.tags.get("resonate:timer").map(|v| v.as_str()) == Some("true") {
+                            tracing::debug!(task_id = %action_id, "Task create: already timedout (timer: resolved immediately)");
+                            PromiseState::Resolved
+                        } else {
+                            tracing::debug!(task_id = %action_id, "Task create: already timedout");
+                            PromiseState::RejectedTimedout
+                        };
+                    (
+                        p_state,
+                        action_data.timeout_at,
+                        Some(action_data.timeout_at),
+                    )
+                } else {
+                    (PromiseState::Pending, now, None)
+                };
+                let param_headers_json = action_data
+                    .param
+                    .headers
+                    .as_ref()
+                    .map(|h| serde_json::to_string(h).unwrap());
+                let res = db.task_create(&TaskCreateParams {
+                    promise_id: action_id,
+                    state: p_state.as_str(),
+                    param_headers: param_headers_json.as_deref(),
+                    param_data: action_data.param.data.as_deref(),
+                    tags: &tags_json,
+                    timeout_at: action_data.timeout_at,
+                    created_at,
+                    settled_at,
+                    already_timedout,
+                    ttl: r.ttl,
+                    pid: &r.pid,
+                })?;
+
+                // If the promise is settled, process callbacks as a separate
+                // statement. This fires any callbacks registered by concurrent
+                // transactions (e.g. task.suspend) that committed after
+                // try_timeout's snapshot but before now.
+                if res.promise.state != PromiseState::Pending {
+                    db.process_callbacks(action_id, now)?;
+                }
+
+                // When the CTE created the task, use CTE result directly.
+                if res.task_created {
+                    let task_state_str = res.task_state.expect("invariant: task_state is Some when task_created");
+                    let task_state = task_state_str.parse::<TaskState>().expect("invariant: task_state is a valid TaskState");
+                    assert!(res.promise.state != PromiseState::Pending || task_state != TaskState::Fulfilled, "invariant: pending promise with fulfilled task");
+                    assert!(res.promise.state == PromiseState::Pending || task_state == TaskState::Fulfilled, "invariant: settled promise with non-fulfilled task");
+                    // Acquired tasks start at version 1 (first claim), fulfilled at 0
+                    let task_version = if task_state == TaskState::Acquired { 1 } else { 0 };
+                    let task = TaskRecord {
+                        id: action_id.to_string(),
+                        state: task_state,
+                        version: task_version,
+                        resumes: 0,
+                        ttl: if task_state == TaskState::Fulfilled { None } else { Some(r.ttl) },
+                        pid: if task_state == TaskState::Fulfilled { None } else { Some(r.pid.to_string()) },
+                    };
+                    let preload = if task_state == TaskState::Acquired {
+                        db.compute_preload(action_id)?
+                    } else {
+                        vec![]
+                    };
+                    return Ok(ResponseEnvelope::success(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        &TaskCreateResponseData {
+                            task,
+                            promise: res.promise,
+                            preload,
+                        },
+                    ));
+                }
+
+                // CTE didn't create the task (promise already existed).
+                // Branch on the state/version surfaced by the CTE.
+                match (res.task_state.as_deref(), res.task_version) {
+                    (Some("fulfilled"), version) => {
+                        assert_ne!(res.promise.state, PromiseState::Pending, "invariant: pending promise with fulfilled task");
                         Ok(ResponseEnvelope::success(
                             kind_str.clone(),
                             corr_id.clone(),
@@ -1267,400 +1207,257 @@ async fn op_task_create(state: &Arc<Server>, req: &RequestEnvelope, now: i64) ->
                                 task: TaskRecord {
                                     id: action_id.to_string(),
                                     state: TaskState::Fulfilled,
-                                    version: acquire_result.task_version.expect("invariant: fulfilled task must have a version"),
+                                    version: version.unwrap_or(0),
                                     resumes: 0,
                                     ttl: None,
                                     pid: None,
                                 },
-                                promise,
+                                promise: res.promise,
                                 preload: vec![],
                             },
                         ))
-                    } else {
-                        assert!(acquire_result.task_state.is_some(), "invariant: non-acquired result must have a task state");
-                        assert!(acquire_result.task_version.is_some(), "invariant: non-acquired result must have a task version");
-                        assert!(
-                            acquire_result.task_state.unwrap() != TaskState::Pending || acquire_result.task_version.unwrap() != version,
-                            "invariant: task state must not be pending or version must differ from request"
-                        );
-                        Ok(ResponseEnvelope::error(
+                    }
+                    (Some("pending"), Some(version)) => {
+                        let acquire_result = db.task_acquire(&TaskAcquireParams {
+                            task_id: action_id,
+                            version,
+                            time: now,
+                            ttl: r.ttl,
+                            pid: &r.pid,
+                        })?;
+                        if acquire_result.was_acquired {
+                            let task = TaskRecord {
+                                id: action_id.to_string(),
+                                state: TaskState::Acquired,
+                                version: version + 1,
+                                resumes: 0,
+                                ttl: Some(r.ttl),
+                                pid: Some(r.pid.to_string()),
+                            };
+                            assert_eq!(res.promise.state, PromiseState::Pending, "invariant: settled promise with non-fulfilled task");
+                            assert_eq!(acquire_result.task_version, Some(version + 1), "invariant: acquired task version must be version + 1");
+                            let preload = db.compute_preload(action_id)?;
+                            Ok(ResponseEnvelope::success(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                &TaskCreateResponseData {
+                                    task,
+                                    promise: res.promise,
+                                    preload,
+                                },
+                            ))
+                        } else if acquire_result.task_state == Some(TaskState::Fulfilled) {
+                            let promise = acquire_result.promise.expect("fulfilled task must have a promise");
+                            assert_ne!(promise.state, PromiseState::Pending, "invariant: fulfilled task cannot have a pending promise");
+                            Ok(ResponseEnvelope::success(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                &TaskCreateResponseData {
+                                    task: TaskRecord {
+                                        id: action_id.to_string(),
+                                        state: TaskState::Fulfilled,
+                                        version: acquire_result.task_version.expect("invariant: fulfilled task must have a version"),
+                                        resumes: 0,
+                                        ttl: None,
+                                        pid: None,
+                                    },
+                                    promise,
+                                    preload: vec![],
+                                },
+                            ))
+                        } else {
+                            assert!(acquire_result.task_state.is_some(), "invariant: non-acquired result must have a task state");
+                            assert!(acquire_result.task_version.is_some(), "invariant: non-acquired result must have a task version");
+                            assert!(
+                                acquire_result.task_state.unwrap() != TaskState::Pending || acquire_result.task_version.unwrap() != version,
+                                "invariant: task state must not be pending or version must differ from request"
+                            );
+                            Ok(ResponseEnvelope::error(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                409,
+                                "Already exists",
+                            ))
+                        }
+                    }
+                    (None, _) => Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        422,
+                        "The promise does not have a resonate:target tag",
+                    )),
+                    _ => Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        409,
+                        "Already exists",
+                    )),
+                }
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(StorageError::InvalidInput(msg)) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                400,
+                &format!("Invalid request: {}", msg),
+            ),
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_task_acquire(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskAcquireData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
                             kind_str.clone(),
                             corr_id.clone(),
-                            409,
-                            "Already exists",
+                            400,
+                            &format!("Invalid request: {}", e),
                         ))
                     }
-                }
-                (None, _) => Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    422,
-                    "The promise does not have a resonate:target tag",
-                )),
-                _ => Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Already exists",
-                )),
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(StorageError::InvalidInput(msg)) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            400,
-            &format!("Invalid request: {}", msg),
-        ),
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_task_acquire(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskAcquireData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
-                    ))
+                        &format_validation_errors(&e),
+                    ));
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.id], now)?;
-            let result = db.task_acquire(&TaskAcquireParams {
-                task_id: &r.id,
-                version: r.version,
-                time: now,
-                ttl: r.ttl,
-                pid: &r.pid,
-            })?;
-            match result.promise {
-                None => {
-                    tracing::debug!(task_id = %r.id, "Task acquire: task not found");
-                    Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        404,
-                        "Task not found",
-                    ))
-                }
-                Some(promise) => {
-                    assert!(result.task_state.is_some(), "invariant: acquired result must have a task state");
-                    assert!(result.task_version.is_some(), "invariant: acquired result must have a task version");
-                    assert!(
-                        result.task_state.unwrap() != TaskState::Pending || result.task_version.unwrap() != r.version,
-                        "invariant: task state must not be pending or version must differ from request"
-                    );
-                    if !result.was_acquired {
-                        let state = result.task_state.unwrap();
-                        let version = result.task_version.unwrap();
-                        if state != TaskState::Pending {
+                db.try_timeout(&[&r.id], now)?;
+                let result = db.task_acquire(&TaskAcquireParams {
+                    task_id: &r.id,
+                    version: r.version,
+                    time: now,
+                    ttl: r.ttl,
+                    pid: &r.pid,
+                })?;
+                match result.promise {
+                    None => {
+                        tracing::debug!(task_id = %r.id, "Task acquire: task not found");
+                        Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Task not found",
+                        ))
+                    }
+                    Some(promise) => {
+                        assert!(result.task_state.is_some(), "invariant: acquired result must have a task state");
+                        assert!(result.task_version.is_some(), "invariant: acquired result must have a task version");
+                        assert!(
+                            result.task_state.unwrap() != TaskState::Pending || result.task_version.unwrap() != r.version,
+                            "invariant: task state must not be pending or version must differ from request"
+                        );
+                        if !result.was_acquired {
+                            let state = result.task_state.unwrap();
+                            let version = result.task_version.unwrap();
+                            if state != TaskState::Pending {
+                                tracing::debug!(
+                                    task_id = %r.id,
+                                    current_state = %state,
+                                    "Task acquire rejected: not pending"
+                                );
+                                return Ok(ResponseEnvelope::error(
+                                    kind_str.clone(),
+                                    corr_id.clone(),
+                                    409,
+                                    "Task is not pending",
+                                ));
+                            }
                             tracing::debug!(
                                 task_id = %r.id,
-                                current_state = %state,
-                                "Task acquire rejected: not pending"
+                                expected_version = r.version,
+                                actual_version = version,
+                                "Task acquire rejected: version mismatch"
                             );
                             return Ok(ResponseEnvelope::error(
                                 kind_str.clone(),
                                 corr_id.clone(),
                                 409,
-                                "Task is not pending",
+                                "Version mismatch",
                             ));
                         }
-                        tracing::debug!(
-                            task_id = %r.id,
-                            expected_version = r.version,
-                            actual_version = version,
-                            "Task acquire rejected: version mismatch"
-                        );
+                        assert_eq!(result.task_version, Some(r.version + 1), "invariant: acquired task version must be request version + 1");
+                        // Use known values — no separate task_get that could
+                        // see stale state from concurrent transactions.
+                        let task = TaskRecord {
+                            id: r.id.to_string(),
+                            state: TaskState::Acquired,
+                            version: r.version + 1,
+                            resumes: 0,
+                            ttl: Some(r.ttl),
+                            pid: Some(r.pid.to_string()),
+                        };
+                        let preload = db.compute_preload(&r.id)?;
+                        Ok(ResponseEnvelope::success(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            &TaskAcquireResponseData {
+                                task,
+                                promise,
+                                preload,
+                            },
+                        ))
+                    }
+                }
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_task_release(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskReleaseData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
                         return Ok(ResponseEnvelope::error(
                             kind_str.clone(),
                             corr_id.clone(),
-                            409,
-                            "Version mismatch",
-                        ));
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
                     }
-                    assert_eq!(result.task_version, Some(r.version + 1), "invariant: acquired task version must be request version + 1");
-                    // Use known values — no separate task_get that could
-                    // see stale state from concurrent transactions.
-                    let task = TaskRecord {
-                        id: r.id.to_string(),
-                        state: TaskState::Acquired,
-                        version: r.version + 1,
-                        resumes: 0,
-                        ttl: Some(r.ttl),
-                        pid: Some(r.pid.to_string()),
-                    };
-                    let preload = db.compute_preload(&r.id)?;
-                    Ok(ResponseEnvelope::success(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        &TaskAcquireResponseData {
-                            task,
-                            promise,
-                            preload,
-                        },
-                    ))
-                }
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_task_release(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskReleaseData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
-                    ))
+                        &format_validation_errors(&e),
+                    ));
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.id], now)?;
-            let (_, task_exists) = db.lock_for_update(&r.id)?;
-            if !task_exists {
-                tracing::debug!(task_id = %r.id, "Task release: task not found");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Task not found",
-                ));
-            }
-            let result = db.task_release(&r.id, r.version, now, db.task_retry_timeout())?;
-            if result.task_released {
-                tracing::info!(task_id = %r.id, version = r.version, "Task released back to pending");
-                return Ok(ResponseEnvelope::new(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    200,
-                    serde_json::json!({}),
-                ));
-            }
-            if !result.task_exists {
-                tracing::debug!(task_id = %r.id, "Task release: task not found");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Task not found",
-                ));
-            }
-            tracing::debug!(task_id = %r.id, version = r.version, "Task release rejected: version mismatch or invalid state");
-            Ok(ResponseEnvelope::error(
-                kind_str.clone(),
-                corr_id.clone(),
-                409,
-                "Task version mismatch or invalid state",
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_task_fulfill(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskFulfillData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let action_data = &r.action.data;
-            db.try_timeout(&[&action_data.id], now)?;
-            // Lock preamble: lock promise + task to prevent stale snapshot
-            // in fulfillment CTE.
-            let (_, task_exists) = db.lock_for_update(&r.id)?;
-            if !task_exists {
-                tracing::debug!(task_id = %r.id, "Task fulfill: task not found");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Task not found",
-                ));
-            }
-            let value_headers_json = action_data
-                .value
-                .headers
-                .as_ref()
-                .map(|h| serde_json::to_string(h).unwrap());
-            let result = db.task_fulfill(&TaskFulfillParams {
-                task_id: &r.id,
-                version: r.version,
-                promise_id: &r.id,
-                state: action_data.state.as_str(),
-                value_headers: value_headers_json.as_deref(),
-                value_data: action_data.value.data.as_deref(),
-                settled_at: now,
-            })?;
-            if !result.task_exists {
-                tracing::debug!(task_id = %r.id, "Task fulfill: task not found");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Task not found",
-                ));
-            }
-            if !result.task_fulfilled {
-                tracing::debug!(task_id = %r.id, version = r.version, "Task fulfill rejected: version mismatch or invalid state");
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Task version mismatch or invalid state",
-                ));
-            }
-            let promise = result.promise.expect("invariant: task exists implies promise exists");
-            assert!(result.task_fulfilled, "invariant: returning 200 but task is not fulfilled");
-            assert_ne!(promise.state, PromiseState::Pending, "invariant: returning 200 but promise is still pending");
-            tracing::info!(
-                task_id = %r.id,
-                version = r.version,
-                promise_state = %promise.state,
-                "Task fulfilled and promise settled"
-            );
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &TaskFulfillResponseData { promise },
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_task_suspend(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskSuspendData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let awaited_ids: Vec<String> =
-                r.actions.iter().map(|a| a.data.awaited.clone()).collect();
-            let mut timeout_ids: Vec<&str> = vec![&r.id];
-            for aid in &awaited_ids {
-                timeout_ids.push(aid.as_str());
-            }
-            // Lock the task row BEFORE try_timeout to prevent
-            // try_timeout from fulfilling it via promise timeout.
-            let (_, task_exists) = db.lock_for_update(&r.id)?;
-            db.try_timeout(&timeout_ids, now)?;
-            let mut seen = std::collections::HashSet::new();
-            let unique_awaited: Vec<&str> = awaited_ids
-                .iter()
-                .filter(|id| seen.insert(id.as_str()))
-                .map(|s| s.as_str())
-                .collect();
-            let result = db.task_suspend(&r.id, r.version, &unique_awaited)?;
-            if !result.task_matched {
-                // Use lock_for_update result — no separate task_get that
-                // could see a concurrent task creation.
+                db.try_timeout(&[&r.id], now)?;
+                let (_, task_exists) = db.lock_for_update(&r.id)?;
                 if !task_exists {
+                    tracing::debug!(task_id = %r.id, "Task release: task not found");
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
@@ -1668,648 +1465,966 @@ async fn op_task_suspend(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -
                         "Task not found",
                     ));
                 }
-                tracing::debug!(
-                    task_id = %r.id,
-                    version = r.version,
-                    "Task suspend rejected: not acquired or version mismatch"
-                );
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Task is not acquired or version mismatch",
-                ));
-            }
-            if result.missing_count > 0 {
-                tracing::debug!(
-                    task_id = %r.id,
-                    missing_count = result.missing_count,
-                    "Task suspend rejected: awaited promise(s) not found"
-                );
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    422,
-                    "Awaited promise not found",
-                ));
-            }
-            if result.was_suspended {
-                tracing::info!(
-                    task_id = %r.id,
-                    version = r.version,
-                    awaited_count = unique_awaited.len(),
-                    "Task suspended, waiting on promises"
-                );
-                return Ok(ResponseEnvelope::new(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    200,
-                    serde_json::json!({}),
-                ));
-            }
-            // Immediate resume (settled awaited promises)
-            tracing::info!(
-                task_id = %r.id,
-                version = r.version,
-                "Task suspend: immediate resume, awaited promises already settled"
-            );
-            let preload = db.compute_preload(&r.id)?;
-            Ok(ResponseEnvelope::new(
-                kind_str.clone(),
-                corr_id.clone(),
-                300,
-                serde_json::to_value(&TaskSuspendPreloadData { preload }).unwrap(),
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_task_fence(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskFenceData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+                let result = db.task_release(&r.id, r.version, now, db.task_retry_timeout())?;
+                if result.task_released {
+                    tracing::info!(task_id = %r.id, version = r.version, "Task released back to pending");
+                    return Ok(ResponseEnvelope::new(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        200,
+                        serde_json::json!({}),
+                    ));
+                }
+                if !result.task_exists {
+                    tracing::debug!(task_id = %r.id, "Task release: task not found");
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
+                        404,
+                        "Task not found",
+                    ));
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
+                tracing::debug!(task_id = %r.id, version = r.version, "Task release rejected: version mismatch or invalid state");
+                Ok(ResponseEnvelope::error(
                     kind_str.clone(),
                     corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let action_kind = &r.action.kind;
-            let action_data = &r.action.data;
-            let action_id = action_data["id"].as_str().unwrap_or("");
-            db.try_timeout(&[&r.id, action_id], now)?;
-            // Lock preamble: ensures fence check sees current task state.
-            let _ = db.lock_for_update(&r.id)?;
+                    409,
+                    "Task version mismatch or invalid state",
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
 
-            match action_kind.as_str() {
-                "promise.create" => {
-                    let create_data: PromiseCreateData =
-                        match serde_json::from_value(action_data.clone()) {
-                            Ok(d) => d,
-                            Err(e) => {
-                                return Ok(ResponseEnvelope::error(
-                                    kind_str.clone(),
-                                    corr_id.clone(),
-                                    400,
-                                    &format!("Invalid action data: {}", e),
-                                ))
-                            }
-                        };
-                    if let Err(e) = create_data.validate() {
+    async fn op_task_fulfill(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskFulfillData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
                         return Ok(ResponseEnvelope::error(
                             kind_str.clone(),
                             corr_id.clone(),
                             400,
-                            &format_validation_errors(&e),
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                let action_data = &r.action.data;
+                db.try_timeout(&[&action_data.id], now)?;
+                // Lock preamble: lock promise + task to prevent stale snapshot
+                // in fulfillment CTE.
+                let (_, task_exists) = db.lock_for_update(&r.id)?;
+                if !task_exists {
+                    tracing::debug!(task_id = %r.id, "Task fulfill: task not found");
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        404,
+                        "Task not found",
+                    ));
+                }
+                let value_headers_json = action_data
+                    .value
+                    .headers
+                    .as_ref()
+                    .map(|h| serde_json::to_string(h).unwrap());
+                let result = db.task_fulfill(&TaskFulfillParams {
+                    task_id: &r.id,
+                    version: r.version,
+                    promise_id: &r.id,
+                    state: action_data.state.as_str(),
+                    value_headers: value_headers_json.as_deref(),
+                    value_data: action_data.value.data.as_deref(),
+                    settled_at: now,
+                })?;
+                if !result.task_exists {
+                    tracing::debug!(task_id = %r.id, "Task fulfill: task not found");
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        404,
+                        "Task not found",
+                    ));
+                }
+                if !result.task_fulfilled {
+                    tracing::debug!(task_id = %r.id, version = r.version, "Task fulfill rejected: version mismatch or invalid state");
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        409,
+                        "Task version mismatch or invalid state",
+                    ));
+                }
+                let promise = result.promise.expect("invariant: task exists implies promise exists");
+                assert!(result.task_fulfilled, "invariant: returning 200 but task is not fulfilled");
+                assert_ne!(promise.state, PromiseState::Pending, "invariant: returning 200 but promise is still pending");
+                tracing::info!(
+                    task_id = %r.id,
+                    version = r.version,
+                    promise_state = %promise.state,
+                    "Task fulfilled and promise settled"
+                );
+                Ok(ResponseEnvelope::success(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    &TaskFulfillResponseData { promise },
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_task_suspend(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskSuspendData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                let awaited_ids: Vec<String> =
+                    r.actions.iter().map(|a| a.data.awaited.clone()).collect();
+                let mut timeout_ids: Vec<&str> = vec![&r.id];
+                for aid in &awaited_ids {
+                    timeout_ids.push(aid.as_str());
+                }
+                // Lock the task row BEFORE try_timeout to prevent
+                // try_timeout from fulfilling it via promise timeout.
+                let (_, task_exists) = db.lock_for_update(&r.id)?;
+                db.try_timeout(&timeout_ids, now)?;
+                let mut seen = std::collections::HashSet::new();
+                let unique_awaited: Vec<&str> = awaited_ids
+                    .iter()
+                    .filter(|id| seen.insert(id.as_str()))
+                    .map(|s| s.as_str())
+                    .collect();
+                let result = db.task_suspend(&r.id, r.version, &unique_awaited)?;
+                if !result.task_matched {
+                    // Use lock_for_update result — no separate task_get that
+                    // could see a concurrent task creation.
+                    if !task_exists {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Task not found",
                         ));
                     }
-                    let tags_json = serde_json::to_string(&create_data.tags).unwrap();
-                    let already_timedout = now >= create_data.timeout_at;
-                    let address = create_data.tags.get("resonate:target").map(|s| s.as_str());
-                    if let Some(addr) = address {
-                        if !crate::core::is_valid_address(addr) {
-                            tracing::warn!(
-                                task_id = %r.id,
-                                address = addr,
-                                "Task fence rejected: invalid resonate:target address in fenced promise.create"
-                            );
+                    tracing::debug!(
+                        task_id = %r.id,
+                        version = r.version,
+                        "Task suspend rejected: not acquired or version mismatch"
+                    );
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        409,
+                        "Task is not acquired or version mismatch",
+                    ));
+                }
+                if result.missing_count > 0 {
+                    tracing::debug!(
+                        task_id = %r.id,
+                        missing_count = result.missing_count,
+                        "Task suspend rejected: awaited promise(s) not found"
+                    );
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        422,
+                        "Awaited promise not found",
+                    ));
+                }
+                if result.was_suspended {
+                    tracing::info!(
+                        task_id = %r.id,
+                        version = r.version,
+                        awaited_count = unique_awaited.len(),
+                        "Task suspended, waiting on promises"
+                    );
+                    return Ok(ResponseEnvelope::new(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        200,
+                        serde_json::json!({}),
+                    ));
+                }
+                // Immediate resume (settled awaited promises)
+                tracing::info!(
+                    task_id = %r.id,
+                    version = r.version,
+                    "Task suspend: immediate resume, awaited promises already settled"
+                );
+                let preload = db.compute_preload(&r.id)?;
+                Ok(ResponseEnvelope::new(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    300,
+                    serde_json::to_value(&TaskSuspendPreloadData { preload }).unwrap(),
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_task_fence(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskFenceData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                let action_kind = &r.action.kind;
+                let action_data = &r.action.data;
+                let action_id = action_data["id"].as_str().unwrap_or("");
+                db.try_timeout(&[&r.id, action_id], now)?;
+                // Lock preamble: ensures fence check sees current task state.
+                let _ = db.lock_for_update(&r.id)?;
+
+                match action_kind.as_str() {
+                    "promise.create" => {
+                        let create_data: PromiseCreateData =
+                            match serde_json::from_value(action_data.clone()) {
+                                Ok(d) => d,
+                                Err(e) => {
+                                    return Ok(ResponseEnvelope::error(
+                                        kind_str.clone(),
+                                        corr_id.clone(),
+                                        400,
+                                        &format!("Invalid action data: {}", e),
+                                    ))
+                                }
+                            };
+                        if let Err(e) = create_data.validate() {
                             return Ok(ResponseEnvelope::error(
                                 kind_str.clone(),
                                 corr_id.clone(),
                                 400,
-                                "Invalid resonate:target address",
+                                &format_validation_errors(&e),
                             ));
                         }
-                    }
-                    let (p_state, created_at, settled_at) = if already_timedout {
-                        let p_state = if create_data.tags.get("resonate:timer").map(|v| v.as_str())
-                            == Some("true")
-                        {
-                            PromiseState::Resolved
-                        } else {
-                            PromiseState::RejectedTimedout
-                        };
-                        (
-                            p_state,
-                            create_data.timeout_at,
-                            Some(create_data.timeout_at),
-                        )
-                    } else {
-                        (PromiseState::Pending, now, None)
-                    };
-                    let param_headers_json = create_data
-                        .param
-                        .headers
-                        .as_ref()
-                        .map(|h| serde_json::to_string(h).unwrap());
-                    let result = db.task_fence_create(&TaskFenceCreateParams {
-                        task_id: &r.id,
-                        version: r.version,
-                        promise_id: &create_data.id,
-                        state: p_state.as_str(),
-                        param_headers: param_headers_json.as_deref(),
-                        param_data: create_data.param.data.as_deref(),
-                        tags: &tags_json,
-                        timeout_at: create_data.timeout_at,
-                        created_at,
-                        settled_at,
-                        already_timedout,
-                        address,
-                    })?;
-                    if !result.task_exists {
-                        tracing::debug!(task_id = %r.id, fenced_action = "promise.create", "Task fence rejected: task not found");
-                        return Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            404,
-                            "Task not found",
-                        ));
-                    }
-                    if !result.fence_ok {
-                        tracing::debug!(task_id = %r.id, version = r.version, fenced_action = "promise.create", "Task fence rejected: version mismatch");
-                        return Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            409,
-                            "Version mismatch",
-                        ));
-                    }
-                    tracing::info!(
-                        task_id = %r.id,
-                        version = r.version,
-                        fenced_action = "promise.create",
-                        promise_id = %create_data.id,
-                        "Task fence: promise.create executed"
-                    );
-                    let p = result.promise.expect("invariant: promise.create result must have a promise");
-                    let inner_data = serde_json::json!({ "promise": p });
-                    let inner_envelope = serde_json::json!({
-                        "kind": action_kind,
-                        "head": { "corrId": corr_id, "status": 200, "version": "2026-04-01" },
-                        "data": inner_data,
-                    });
-                    let preload = db.compute_preload(&r.id)?;
-                    Ok(ResponseEnvelope::success(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        &TaskFenceResponseData {
-                            action: inner_envelope,
-                            preload,
-                        },
-                    ))
-                }
-                "promise.settle" => {
-                    let settle_data: PromiseSettleData =
-                        match serde_json::from_value(action_data.clone()) {
-                            Ok(d) => d,
-                            Err(e) => {
+                        let tags_json = serde_json::to_string(&create_data.tags).unwrap();
+                        let already_timedout = now >= create_data.timeout_at;
+                        let address = create_data.tags.get("resonate:target").map(|s| s.as_str());
+                        if let Some(addr) = address {
+                            if !crate::core::is_valid_address(addr) {
+                                tracing::warn!(
+                                    task_id = %r.id,
+                                    address = addr,
+                                    "Task fence rejected: invalid resonate:target address in fenced promise.create"
+                                );
                                 return Ok(ResponseEnvelope::error(
                                     kind_str.clone(),
                                     corr_id.clone(),
                                     400,
-                                    &format!("Invalid action data: {}", e),
-                                ))
+                                    "Invalid resonate:target address",
+                                ));
                             }
+                        }
+                        let (p_state, created_at, settled_at) = if already_timedout {
+                            let p_state = if create_data.tags.get("resonate:timer").map(|v| v.as_str())
+                                == Some("true")
+                            {
+                                PromiseState::Resolved
+                            } else {
+                                PromiseState::RejectedTimedout
+                            };
+                            (
+                                p_state,
+                                create_data.timeout_at,
+                                Some(create_data.timeout_at),
+                            )
+                        } else {
+                            (PromiseState::Pending, now, None)
                         };
-                    if let Err(e) = settle_data.validate() {
+                        let param_headers_json = create_data
+                            .param
+                            .headers
+                            .as_ref()
+                            .map(|h| serde_json::to_string(h).unwrap());
+                        let result = db.task_fence_create(&TaskFenceCreateParams {
+                            task_id: &r.id,
+                            version: r.version,
+                            promise_id: &create_data.id,
+                            state: p_state.as_str(),
+                            param_headers: param_headers_json.as_deref(),
+                            param_data: create_data.param.data.as_deref(),
+                            tags: &tags_json,
+                            timeout_at: create_data.timeout_at,
+                            created_at,
+                            settled_at,
+                            already_timedout,
+                            address,
+                        })?;
+                        if !result.task_exists {
+                            tracing::debug!(task_id = %r.id, fenced_action = "promise.create", "Task fence rejected: task not found");
+                            return Ok(ResponseEnvelope::error(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                404,
+                                "Task not found",
+                            ));
+                        }
+                        if !result.fence_ok {
+                            tracing::debug!(task_id = %r.id, version = r.version, fenced_action = "promise.create", "Task fence rejected: version mismatch");
+                            return Ok(ResponseEnvelope::error(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                409,
+                                "Version mismatch",
+                            ));
+                        }
+                        tracing::info!(
+                            task_id = %r.id,
+                            version = r.version,
+                            fenced_action = "promise.create",
+                            promise_id = %create_data.id,
+                            "Task fence: promise.create executed"
+                        );
+                        let p = result.promise.expect("invariant: promise.create result must have a promise");
+                        let inner_data = serde_json::json!({ "promise": p });
+                        let inner_envelope = serde_json::json!({
+                            "kind": action_kind,
+                            "head": { "corrId": corr_id, "status": 200, "version": "2026-04-01" },
+                            "data": inner_data,
+                        });
+                        let preload = db.compute_preload(&r.id)?;
+                        Ok(ResponseEnvelope::success(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            &TaskFenceResponseData {
+                                action: inner_envelope,
+                                preload,
+                            },
+                        ))
+                    }
+                    "promise.settle" => {
+                        let settle_data: PromiseSettleData =
+                            match serde_json::from_value(action_data.clone()) {
+                                Ok(d) => d,
+                                Err(e) => {
+                                    return Ok(ResponseEnvelope::error(
+                                        kind_str.clone(),
+                                        corr_id.clone(),
+                                        400,
+                                        &format!("Invalid action data: {}", e),
+                                    ))
+                                }
+                            };
+                        if let Err(e) = settle_data.validate() {
+                            return Ok(ResponseEnvelope::error(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                400,
+                                &format_validation_errors(&e),
+                            ));
+                        }
+                        let value_headers_json = settle_data
+                            .value
+                            .headers
+                            .as_ref()
+                            .map(|h| serde_json::to_string(h).unwrap());
+                        let result = db.task_fence_settle(&TaskFenceSettleParams {
+                            task_id: &r.id,
+                            version: r.version,
+                            promise_id: &settle_data.id,
+                            state: settle_data.state.as_str(),
+                            value_headers: value_headers_json.as_deref(),
+                            value_data: settle_data.value.data.as_deref(),
+                            settled_at: now,
+                        })?;
+                        if !result.task_exists {
+                            tracing::debug!(task_id = %r.id, fenced_action = "promise.settle", "Task fence rejected: task not found");
+                            return Ok(ResponseEnvelope::error(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                404,
+                                "Task not found",
+                            ));
+                        }
+                        if !result.fence_ok {
+                            tracing::debug!(task_id = %r.id, version = r.version, fenced_action = "promise.settle", "Task fence rejected: version mismatch");
+                            return Ok(ResponseEnvelope::error(
+                                kind_str.clone(),
+                                corr_id.clone(),
+                                409,
+                                "Version mismatch",
+                            ));
+                        }
+                        tracing::info!(
+                            task_id = %r.id,
+                            version = r.version,
+                            fenced_action = "promise.settle",
+                            promise_id = %settle_data.id,
+                            settle_state = %settle_data.state,
+                            "Task fence: promise.settle executed"
+                        );
+                        let inner_status = if result.promise.is_some() { 200 } else { 404 };
+                        let inner_data = match &result.promise {
+                            Some(p) => {
+                                assert_ne!(p.state, PromiseState::Pending, "invariant: returning 200 but promise is still pending");
+                                serde_json::json!({ "promise": p })
+                            }
+                            None => serde_json::json!("Promise not found"),
+                        };
+                        let inner_envelope = serde_json::json!({
+                            "kind": action_kind,
+                            "head": { "corrId": corr_id, "status": inner_status, "version": "2026-04-01" },
+                            "data": inner_data,
+                        });
+                        let preload = db.compute_preload(&r.id)?;
+                        Ok(ResponseEnvelope::success(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            &TaskFenceResponseData {
+                                action: inner_envelope,
+                                preload,
+                            },
+                        ))
+                    }
+                    _ => {
+                        tracing::warn!(
+                            task_id = %r.id,
+                            action_kind = %action_kind,
+                            "Task fence rejected: invalid fence action kind"
+                        );
+                        Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            "Invalid fence action kind",
+                        ))
+                    }
+                }
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_task_heartbeat(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskHeartbeatData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
                         return Ok(ResponseEnvelope::error(
                             kind_str.clone(),
                             corr_id.clone(),
                             400,
-                            &format_validation_errors(&e),
-                        ));
+                            &format!("Invalid request: {}", e),
+                        ))
                     }
-                    let value_headers_json = settle_data
-                        .value
-                        .headers
-                        .as_ref()
-                        .map(|h| serde_json::to_string(h).unwrap());
-                    let result = db.task_fence_settle(&TaskFenceSettleParams {
-                        task_id: &r.id,
-                        version: r.version,
-                        promise_id: &settle_data.id,
-                        state: settle_data.state.as_str(),
-                        value_headers: value_headers_json.as_deref(),
-                        value_data: settle_data.value.data.as_deref(),
-                        settled_at: now,
-                    })?;
-                    if !result.task_exists {
-                        tracing::debug!(task_id = %r.id, fenced_action = "promise.settle", "Task fence rejected: task not found");
-                        return Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            404,
-                            "Task not found",
-                        ));
-                    }
-                    if !result.fence_ok {
-                        tracing::debug!(task_id = %r.id, version = r.version, fenced_action = "promise.settle", "Task fence rejected: version mismatch");
-                        return Ok(ResponseEnvelope::error(
-                            kind_str.clone(),
-                            corr_id.clone(),
-                            409,
-                            "Version mismatch",
-                        ));
-                    }
-                    tracing::info!(
-                        task_id = %r.id,
-                        version = r.version,
-                        fenced_action = "promise.settle",
-                        promise_id = %settle_data.id,
-                        settle_state = %settle_data.state,
-                        "Task fence: promise.settle executed"
-                    );
-                    let inner_status = if result.promise.is_some() { 200 } else { 404 };
-                    let inner_data = match &result.promise {
-                        Some(p) => {
-                            assert_ne!(p.state, PromiseState::Pending, "invariant: returning 200 but promise is still pending");
-                            serde_json::json!({ "promise": p })
-                        }
-                        None => serde_json::json!("Promise not found"),
-                    };
-                    let inner_envelope = serde_json::json!({
-                        "kind": action_kind,
-                        "head": { "corrId": corr_id, "status": inner_status, "version": "2026-04-01" },
-                        "data": inner_data,
-                    });
-                    let preload = db.compute_preload(&r.id)?;
-                    Ok(ResponseEnvelope::success(
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
-                        &TaskFenceResponseData {
-                            action: inner_envelope,
-                            preload,
-                        },
-                    ))
+                        400,
+                        &format_validation_errors(&e),
+                    ));
                 }
-                _ => {
-                    tracing::warn!(
-                        task_id = %r.id,
-                        action_kind = %action_kind,
-                        "Task fence rejected: invalid fence action kind"
-                    );
+                let task_pairs: Vec<(&str, i64)> =
+                    r.tasks.iter().map(|t| (t.id.as_str(), t.version)).collect();
+                db.task_heartbeat(&r.pid, &task_pairs, now)?;
+                tracing::debug!(
+                    pid = %r.pid,
+                    task_count = task_pairs.len(),
+                    "Task heartbeat processed"
+                );
+                Ok(ResponseEnvelope::new(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    200,
+                    serde_json::json!({}),
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_task_halt(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskHaltData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                db.try_timeout(&[&r.id], now)?;
+                let result = db.task_halt(&r.id)?;
+                if !result.task_exists {
+                    tracing::debug!(task_id = %r.id, "Task halt: not found");
                     Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
-                        400,
-                        "Invalid fence action kind",
+                        404,
+                        "Task not found",
+                    ))
+                } else if result.task_fulfilled {
+                    tracing::debug!(task_id = %r.id, "Task halt rejected: already fulfilled");
+                    Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        409,
+                        "Task is fulfilled",
+                    ))
+                } else {
+                    tracing::info!(task_id = %r.id, "Task halted");
+                    Ok(ResponseEnvelope::new(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        200,
+                        serde_json::json!({}),
                     ))
                 }
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
     }
-}
 
-async fn op_task_heartbeat(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskHeartbeatData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+    async fn op_task_continue(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskContinueData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
+                        &format_validation_errors(&e),
+                    ));
+                }
+                db.try_timeout(&[&r.id], now)?;
+                let result = db.task_continue(&r.id, now)?;
+                if !result.task_exists {
+                    tracing::debug!(task_id = %r.id, "Task continue: not found");
+                    Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        404,
+                        "Task not found",
+                    ))
+                } else if result.continued {
+                    tracing::info!(task_id = %r.id, "Task continued from halted state");
+                    Ok(ResponseEnvelope::new(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        200,
+                        serde_json::json!({}),
+                    ))
+                } else {
+                    tracing::debug!(task_id = %r.id, "Task continue rejected: not halted");
+                    Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        409,
+                        "Task is not halted",
                     ))
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let task_pairs: Vec<(&str, i64)> =
-                r.tasks.iter().map(|t| (t.id.as_str(), t.version)).collect();
-            db.task_heartbeat(&r.pid, &task_pairs, now)?;
-            tracing::debug!(
-                pid = %r.pid,
-                task_count = task_pairs.len(),
-                "Task heartbeat processed"
-            );
-            Ok(ResponseEnvelope::new(
-                kind_str.clone(),
-                corr_id.clone(),
-                200,
-                serde_json::json!({}),
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
     }
-}
 
-async fn op_task_halt(state: &Arc<Server>, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskHaltData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+    async fn op_task_search(&self, req: &RequestEnvelope, _now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: TaskSearchData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
-                    ))
+                        &format_validation_errors(&e),
+                    ));
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
+                let limit = match r.limit {
+                    Some(n) if n > 1000 => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            "Invalid 'limit' — must be between 1 and 1000",
+                        ))
+                    }
+                    Some(n) => n,
+                    None => 100,
+                };
+                let state_str = r.state.map(|s| s.as_str());
+                let results = db.task_search(state_str, r.cursor.as_deref(), limit + 1)?;
+                let has_more = results.len() as i64 > limit;
+                let tasks: Vec<_> = results.into_iter().take(limit as usize).collect();
+                let next_cursor = if has_more {
+                    tasks.last().map(|t| t.id.clone())
+                } else {
+                    None
+                };
+                tracing::debug!(
+                    found = tasks.len(),
+                    has_more = has_more,
+                    "Task search completed"
+                );
+                Ok(ResponseEnvelope::success(
                     kind_str.clone(),
                     corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.id], now)?;
-            let result = db.task_halt(&r.id)?;
-            if !result.task_exists {
-                tracing::debug!(task_id = %r.id, "Task halt: not found");
-                Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Task not found",
+                    &TaskSearchResponseData {
+                        tasks,
+                        cursor: next_cursor,
+                    },
                 ))
-            } else if result.task_fulfilled {
-                tracing::debug!(task_id = %r.id, "Task halt rejected: already fulfilled");
-                Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Task is fulfilled",
-                ))
-            } else {
-                tracing::info!(task_id = %r.id, "Task halted");
-                Ok(ResponseEnvelope::new(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    200,
-                    serde_json::json!({}),
-                ))
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
     }
-}
 
-async fn op_task_continue(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskContinueData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+    // ============================================================================
+    // Schedule operations
+    // ============================================================================
+
+    async fn op_schedule_get(&self, req: &RequestEnvelope, _now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: ScheduleGetData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
-                    ))
+                        &format_validation_errors(&e),
+                    ));
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            db.try_timeout(&[&r.id], now)?;
-            let result = db.task_continue(&r.id, now)?;
-            if !result.task_exists {
-                tracing::debug!(task_id = %r.id, "Task continue: not found");
-                Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Task not found",
-                ))
-            } else if result.continued {
-                tracing::info!(task_id = %r.id, "Task continued from halted state");
-                Ok(ResponseEnvelope::new(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    200,
-                    serde_json::json!({}),
-                ))
-            } else {
-                tracing::debug!(task_id = %r.id, "Task continue rejected: not halted");
-                Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    409,
-                    "Task is not halted",
-                ))
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
+                match db.schedule_get(&r.id)? {
+                    Some(schedule) => {
+                        tracing::debug!(
+                            schedule_id = %r.id,
+                            cron = %schedule.cron,
+                            next_run_at = schedule.next_run_at,
+                            "Schedule found"
+                        );
+                        Ok(ResponseEnvelope::success(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            &ScheduleResponseData { schedule },
+                        ))
+                    }
+                    None => {
+                        tracing::debug!(schedule_id = %r.id, "Schedule not found");
+                        Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            404,
+                            "Schedule not found",
+                        ))
+                    }
+                }
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
     }
-}
 
-async fn op_task_search(state: &Arc<Server>, req: &RequestEnvelope, _now: i64) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: TaskSearchData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
+    async fn op_schedule_create(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: ScheduleCreateData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
                         400,
-                        &format!("Invalid request: {}", e),
-                    ))
+                        &format_validation_errors(&e),
+                    ));
                 }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let limit = match r.limit {
-                Some(n) if n > 1000 => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        "Invalid 'limit' — must be between 1 and 1000",
-                    ))
-                }
-                Some(n) => n,
-                None => 100,
-            };
-            let state_str = r.state.map(|s| s.as_str());
-            let results = db.task_search(state_str, r.cursor.as_deref(), limit + 1)?;
-            let has_more = results.len() as i64 > limit;
-            let tasks: Vec<_> = results.into_iter().take(limit as usize).collect();
-            let next_cursor = if has_more {
-                tasks.last().map(|t| t.id.clone())
-            } else {
-                None
-            };
-            tracing::debug!(
-                found = tasks.len(),
-                has_more = has_more,
-                "Task search completed"
-            );
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &TaskSearchResponseData {
-                    tasks,
-                    cursor: next_cursor,
-                },
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-// ============================================================================
-// Schedule operations
-// ============================================================================
-
-async fn op_schedule_get(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    _now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: ScheduleGetData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            match db.schedule_get(&r.id)? {
-                Some(schedule) => {
-                    tracing::debug!(
+                if !util::is_valid_cron(&r.cron) {
+                    tracing::warn!(
                         schedule_id = %r.id,
-                        cron = %schedule.cron,
-                        next_run_at = schedule.next_run_at,
-                        "Schedule found"
+                        cron = %r.cron,
+                        "Schedule create rejected: invalid cron expression"
                     );
-                    Ok(ResponseEnvelope::success(
+                    return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
-                        &ScheduleResponseData { schedule },
-                    ))
+                        400,
+                        "Invalid cron expression",
+                    ));
                 }
-                None => {
-                    tracing::debug!(schedule_id = %r.id, "Schedule not found");
+                let promise_tags_json = serde_json::to_string(&r.promise_tags).unwrap();
+                let next_run_at = util::compute_next_cron(&r.cron, now);
+                let promise_param_headers_json = r
+                    .promise_param
+                    .headers
+                    .as_ref()
+                    .map(|h| serde_json::to_string(h).unwrap());
+                let schedule = db.schedule_create(&ScheduleCreateParams {
+                    id: &r.id,
+                    cron: &r.cron,
+                    promise_id: &r.promise_id,
+                    promise_timeout: r.promise_timeout,
+                    promise_param_headers: promise_param_headers_json.as_deref(),
+                    promise_param_data: r.promise_param.data.as_deref(),
+                    promise_tags: &promise_tags_json,
+                    created_at: now,
+                    next_run_at,
+                })?;
+                tracing::info!(
+                    schedule_id = %schedule.id,
+                    cron = %schedule.cron,
+                    next_run_at = schedule.next_run_at,
+                    "Schedule created"
+                );
+                Ok(ResponseEnvelope::success(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    &ScheduleResponseData { schedule },
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Internal error: {}", e),
+            ),
+        }
+    }
+
+    async fn op_schedule_delete(&self, req: &RequestEnvelope) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: ScheduleDeleteData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                if db.schedule_delete(&r.id)? {
+                    tracing::info!(schedule_id = %r.id, "Schedule deleted");
+                    Ok(ResponseEnvelope::new(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        200,
+                        serde_json::json!({}),
+                    ))
+                } else {
+                    tracing::debug!(schedule_id = %r.id, "Schedule delete: not found");
                     Ok(ResponseEnvelope::error(
                         kind_str.clone(),
                         corr_id.clone(),
@@ -2317,317 +2432,176 @@ async fn op_schedule_get(
                         "Schedule not found",
                     ))
                 }
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_schedule_create(
-    state: &Arc<Server>,
-    req: &RequestEnvelope,
-    now: i64,
-) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: ScheduleCreateData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            if !util::is_valid_cron(&r.cron) {
-                tracing::warn!(
-                    schedule_id = %r.id,
-                    cron = %r.cron,
-                    "Schedule create rejected: invalid cron expression"
-                );
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    "Invalid cron expression",
-                ));
-            }
-            let promise_tags_json = serde_json::to_string(&r.promise_tags).unwrap();
-            let next_run_at = util::compute_next_cron(&r.cron, now);
-            let promise_param_headers_json = r
-                .promise_param
-                .headers
-                .as_ref()
-                .map(|h| serde_json::to_string(h).unwrap());
-            let schedule = db.schedule_create(&ScheduleCreateParams {
-                id: &r.id,
-                cron: &r.cron,
-                promise_id: &r.promise_id,
-                promise_timeout: r.promise_timeout,
-                promise_param_headers: promise_param_headers_json.as_deref(),
-                promise_param_data: r.promise_param.data.as_deref(),
-                promise_tags: &promise_tags_json,
-                created_at: now,
-                next_run_at,
-            })?;
-            tracing::info!(
-                schedule_id = %schedule.id,
-                cron = %schedule.cron,
-                next_run_at = schedule.next_run_at,
-                "Schedule created"
-            );
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &ScheduleResponseData { schedule },
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_schedule_delete(state: &Arc<Server>, req: &RequestEnvelope) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: ScheduleDeleteData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            if db.schedule_delete(&r.id)? {
-                tracing::info!(schedule_id = %r.id, "Schedule deleted");
-                Ok(ResponseEnvelope::new(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    200,
-                    serde_json::json!({}),
-                ))
-            } else {
-                tracing::debug!(schedule_id = %r.id, "Schedule delete: not found");
-                Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    404,
-                    "Schedule not found",
-                ))
-            }
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-async fn op_schedule_search(state: &Arc<Server>, req: &RequestEnvelope) -> ResponseEnvelope {
-    let data = req.data.clone();
-    let kind_str = req.kind.clone();
-    let corr_id = req.head.corr_id.clone();
-    match state
-        .storage
-        .transact(move |db| {
-            let r: ScheduleSearchData = match serde_json::from_value(data.clone()) {
-                Ok(d) => d,
-                Err(e) => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        &format!("Invalid request: {}", e),
-                    ))
-                }
-            };
-            if let Err(e) = r.validate() {
-                return Ok(ResponseEnvelope::error(
-                    kind_str.clone(),
-                    corr_id.clone(),
-                    400,
-                    &format_validation_errors(&e),
-                ));
-            }
-            let tags_json = r.tags.as_ref().map(|t| serde_json::to_string(t).unwrap());
-            let limit = match r.limit {
-                Some(n) if n > 1000 => {
-                    return Ok(ResponseEnvelope::error(
-                        kind_str.clone(),
-                        corr_id.clone(),
-                        400,
-                        "Invalid 'limit' — must be between 1 and 1000",
-                    ))
-                }
-                Some(n) => n,
-                None => 10,
-            };
-            let schedules =
-                db.schedule_search(tags_json.as_deref(), r.cursor.as_deref(), limit + 1)?;
-            let limit_usize = limit as usize;
-            let has_more = schedules.len() > limit_usize;
-            let result_schedules: Vec<_> = schedules.into_iter().take(limit_usize).collect();
-            let next_cursor = if has_more {
-                result_schedules.last().map(|s| s.id.clone())
-            } else {
-                None
-            };
-            tracing::debug!(
-                found = result_schedules.len(),
-                has_more = has_more,
-                "Schedule search completed"
-            );
-            Ok(ResponseEnvelope::success(
-                kind_str.clone(),
-                corr_id.clone(),
-                &ScheduleSearchResponseData {
-                    schedules: result_schedules,
-                    cursor: next_cursor,
-                },
-            ))
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Internal error: {}", e),
-        ),
-    }
-}
-
-// ============================================================================
-// Debug operations
-// ============================================================================
-
-async fn op_debug_reset(state: &Arc<Server>, req: &RequestEnvelope) -> ResponseEnvelope {
-    match state.storage.transact(move |db| db.debug_reset()).await {
-        Ok(()) => {
-            tracing::warn!("Debug reset: all data cleared");
-            ResponseEnvelope::new(
-                req.kind.clone(),
-                req.head.corr_id.clone(),
-                200,
-                Value::Object(serde_json::Map::new()),
-            )
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "Debug reset failed");
-            ResponseEnvelope::error(
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
                 req.kind.clone(),
                 req.head.corr_id.clone(),
                 500,
-                &format!("Reset failed: {}", e),
-            )
+                &format!("Internal error: {}", e),
+            ),
         }
     }
-}
 
-async fn op_debug_snap(state: &Arc<Server>, req: &RequestEnvelope) -> ResponseEnvelope {
-    match state.storage.query(move |db| db.snap()).await {
-        Ok(snapshot) => {
-            let data = serde_json::to_value(snapshot).unwrap_or(Value::Null);
-            ResponseEnvelope::new(req.kind.clone(), req.head.corr_id.clone(), 200, data)
-        }
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Snap failed: {}", e),
-        ),
-    }
-}
-
-async fn op_debug_tick(state: &Arc<Server>, req: &RequestEnvelope) -> ResponseEnvelope {
-    let time = match req.data.get("time").and_then(|v| v.as_i64()) {
-        Some(t) => t,
-        None => {
-            return ResponseEnvelope::error(
+    async fn op_schedule_search(&self, req: &RequestEnvelope) -> ResponseEnvelope {
+        let data = req.data.clone();
+        let kind_str = req.kind.clone();
+        let corr_id = req.head.corr_id.clone();
+        match self
+            .storage
+            .transact(move |db| {
+                let r: ScheduleSearchData = match serde_json::from_value(data.clone()) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            &format!("Invalid request: {}", e),
+                        ))
+                    }
+                };
+                if let Err(e) = r.validate() {
+                    return Ok(ResponseEnvelope::error(
+                        kind_str.clone(),
+                        corr_id.clone(),
+                        400,
+                        &format_validation_errors(&e),
+                    ));
+                }
+                let tags_json = r.tags.as_ref().map(|t| serde_json::to_string(t).unwrap());
+                let limit = match r.limit {
+                    Some(n) if n > 1000 => {
+                        return Ok(ResponseEnvelope::error(
+                            kind_str.clone(),
+                            corr_id.clone(),
+                            400,
+                            "Invalid 'limit' — must be between 1 and 1000",
+                        ))
+                    }
+                    Some(n) => n,
+                    None => 10,
+                };
+                let schedules =
+                    db.schedule_search(tags_json.as_deref(), r.cursor.as_deref(), limit + 1)?;
+                let limit_usize = limit as usize;
+                let has_more = schedules.len() > limit_usize;
+                let result_schedules: Vec<_> = schedules.into_iter().take(limit_usize).collect();
+                let next_cursor = if has_more {
+                    result_schedules.last().map(|s| s.id.clone())
+                } else {
+                    None
+                };
+                tracing::debug!(
+                    found = result_schedules.len(),
+                    has_more = has_more,
+                    "Schedule search completed"
+                );
+                Ok(ResponseEnvelope::success(
+                    kind_str.clone(),
+                    corr_id.clone(),
+                    &ScheduleSearchResponseData {
+                        schedules: result_schedules,
+                        cursor: next_cursor,
+                    },
+                ))
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => ResponseEnvelope::error(
                 req.kind.clone(),
                 req.head.corr_id.clone(),
-                400,
-                "Missing or invalid 'time' field",
-            )
-        }
-    };
-    if let Some(debug_time) = req.head.debug_time {
-        if debug_time != time {
-            return ResponseEnvelope::error(
-                req.kind.clone(),
-                req.head.corr_id.clone(),
-                400,
-                "resonate:debug_time must equal data.time",
-            );
+                500,
+                &format!("Internal error: {}", e),
+            ),
         }
     }
 
-    match state
-        .storage
-        .transact(move |db| processing_timeouts::process_all_timeouts(db, time))
-        .await
-    {
-        Ok(_) => ResponseEnvelope::new(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            200,
-            Value::Array(vec![]),
-        ),
-        Err(e) => ResponseEnvelope::error(
-            req.kind.clone(),
-            req.head.corr_id.clone(),
-            500,
-            &format!("Tick failed: {}", e),
-        ),
+    // ============================================================================
+    // Debug operations
+    // ============================================================================
+
+    async fn op_debug_reset(&self, req: &RequestEnvelope) -> ResponseEnvelope {
+        match self.storage.transact(move |db| db.debug_reset()).await {
+            Ok(()) => {
+                tracing::warn!("Debug reset: all data cleared");
+                ResponseEnvelope::new(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    200,
+                    Value::Object(serde_json::Map::new()),
+                )
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Debug reset failed");
+                ResponseEnvelope::error(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    500,
+                    &format!("Reset failed: {}", e),
+                )
+            }
+        }
+    }
+
+    async fn op_debug_snap(&self, req: &RequestEnvelope) -> ResponseEnvelope {
+        match self.storage.query(move |db| db.snap()).await {
+            Ok(snapshot) => {
+                let data = serde_json::to_value(snapshot).unwrap_or(Value::Null);
+                ResponseEnvelope::new(req.kind.clone(), req.head.corr_id.clone(), 200, data)
+            }
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Snap failed: {}", e),
+            ),
+        }
+    }
+
+    async fn op_debug_tick(&self, req: &RequestEnvelope) -> ResponseEnvelope {
+        let time = match req.data.get("time").and_then(|v| v.as_i64()) {
+            Some(t) => t,
+            None => {
+                return ResponseEnvelope::error(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    400,
+                    "Missing or invalid 'time' field",
+                )
+            }
+        };
+        if let Some(debug_time) = req.head.debug_time {
+            if debug_time != time {
+                return ResponseEnvelope::error(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    400,
+                    "resonate:debug_time must equal data.time",
+                );
+            }
+        }
+
+        match self
+            .storage
+            .transact(move |db| processing_timeouts::process_all_timeouts(db, time))
+            .await
+        {
+            Ok(_) => ResponseEnvelope::new(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                200,
+                Value::Array(vec![]),
+            ),
+            Err(e) => ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                500,
+                &format!("Tick failed: {}", e),
+            ),
+        }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,6 +26,7 @@ use crate::core::types::{
     TaskReleaseData, TaskResponseData, TaskSearchData, TaskSearchResponseData, TaskState,
     TaskSuspendData, TaskSuspendPreloadData, SUPPORTED_VERSIONS,
 };
+use crate::core::{ResonateServer, Unavailable};
 use crate::metrics;
 use crate::persistence::{
     PromiseCreateParams, PromiseSettleParams, ScheduleCreateParams, Storage, StorageError,
@@ -35,6 +36,7 @@ use crate::persistence::{
 use crate::processing::processing_timeouts;
 use crate::transport::transport_http_poll::PollRegistry;
 use crate::util;
+use async_trait::async_trait;
 use validator::Validate;
 
 /// The running server — owns configuration, storage, and auth.
@@ -181,7 +183,7 @@ async fn handle_api(
     let start = std::time::Instant::now();
     // Deserialize the envelope using serde. On failure, attempt to extract
     // kind from the raw JSON so the error response can include it.
-    let mut req: RequestEnvelope = match serde_json::from_slice(&body) {
+    let req: RequestEnvelope = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
             let (kind, corr_id) = extract_error_context(&body);
@@ -245,11 +247,6 @@ async fn handle_api(
         "Received request"
     );
 
-    // Gate debug_time behind config
-    if !state.config.debug {
-        req.head.debug_time = None;
-    }
-
     if let Some(auth) = &state.auth {
         if let Err(err_response) = auth::auth_check(auth, &req) {
             let status = err_response.head.status.to_string();
@@ -271,9 +268,13 @@ async fn handle_api(
         }
     }
 
-    let now = util::resolve_time(req.head.debug_time);
-
-    let response = state.dispatch(&req, now).await;
+    let response = match state.process(&req).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            tracing::error!(kind = %kind, corr_id = %corr_id, error = %e, "Server unavailable");
+            ResponseEnvelope::error(kind.clone(), corr_id.clone(), 503, &e.to_string())
+        }
+    };
     let status = response.head.status.to_string();
     let elapsed_ms = start.elapsed().as_millis();
 
@@ -401,6 +402,21 @@ impl Drop for PollGuard {
         tokio::spawn(async move {
             registry.deregister(&group, conn_id).await;
         });
+    }
+}
+
+#[async_trait]
+impl ResonateServer for Server {
+    async fn process(&self, req: &RequestEnvelope) -> Result<ResponseEnvelope, Unavailable> {
+        // Debug-time overrides are gated by config, so a caller cannot move the
+        // server's clock. The gate lives here rather than at the HTTP edge so
+        // that every caller of the port is subject to it.
+        let debug_time = if self.config.debug {
+            req.head.debug_time
+        } else {
+            None
+        };
+        Ok(self.dispatch(req, util::resolve_time(debug_time)).await)
     }
 }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -3,143 +3,41 @@ pub mod transport_gcps;
 pub mod transport_http_poll;
 pub mod transport_http_push;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::core::address::{parse_address, Address, GcpsAddress, HttpAddress, PollAddress};
+use crate::core::types::Message;
+use crate::core::{scheme_of, ResonateRouter, ResonateWorker, Unavailable};
 
-// ---- Per-transport traits ----
+// ---- Router ----
 
-#[async_trait]
-pub trait HttpTransport: Send + Sync {
-    async fn send(&self, addr: &HttpAddress, payload: &serde_json::Value);
-}
-
-#[async_trait]
-pub trait PollTransport: Send + Sync {
-    async fn send(&self, addr: &PollAddress, payload: &str) -> bool;
-}
-
-#[async_trait]
-pub trait GcpsTransport: Send + Sync {
-    async fn send(&self, addr: &GcpsAddress, payload: &serde_json::Value);
-}
-
-#[async_trait]
-pub trait BashTransport: Send + Sync {
-    async fn send(&self, address: &str, payload: &serde_json::Value);
-}
-
-// ---- Trait impls for real transport types ----
-
-#[async_trait]
-impl HttpTransport for transport_http_push::HttpPushTransport {
-    async fn send(&self, addr: &HttpAddress, payload: &serde_json::Value) {
-        transport_http_push::HttpPushTransport::send(self, addr, payload).await
-    }
-}
-
-#[async_trait]
-impl PollTransport for transport_http_poll::PollRegistry {
-    async fn send(&self, addr: &PollAddress, payload: &str) -> bool {
-        transport_http_poll::PollRegistry::send_poll(self, addr, payload).await
-    }
-}
-
-#[async_trait]
-impl GcpsTransport for transport_gcps::GcpsPubSubTransport {
-    async fn send(&self, addr: &GcpsAddress, payload: &serde_json::Value) {
-        transport_gcps::GcpsPubSubTransport::send(self, addr, payload).await
-    }
-}
-
-#[async_trait]
-impl BashTransport for transport_exec_bash::BashExecTransport {
-    async fn send(&self, address: &str, payload: &serde_json::Value) {
-        transport_exec_bash::BashExecTransport::send(self, address, payload).await
-    }
-}
-
-// ---- Dispatcher ----
-
-/// Dispatches messages to the appropriate transport by parsing the address once.
-/// Routes by URL scheme: http/https → push, poll → SSE, gcps → GCP Pub/Sub, bash → bash exec.
+/// Routes a message to the worker registered for its address scheme.
+///
+/// The router's knowledge of an address stops at the scheme: it reads the
+/// scheme, looks up a worker, and hands over the untouched address string.
+/// Registering a new scheme is therefore the whole cost of adding a worker —
+/// nothing here, and nothing in `core`, has to change.
 pub struct TransportDispatcher {
-    http: Option<Arc<dyn HttpTransport>>,
-    poll: Option<Arc<dyn PollTransport>>,
-    gcps: Option<Arc<dyn GcpsTransport>>,
-    bash: Option<Arc<dyn BashTransport>>,
+    workers: HashMap<String, Arc<dyn ResonateWorker>>,
 }
 
 impl TransportDispatcher {
-    pub fn new(
-        http: Option<Arc<dyn HttpTransport>>,
-        poll: Option<Arc<dyn PollTransport>>,
-        gcps: Option<Arc<dyn GcpsTransport>>,
-        bash: Option<Arc<dyn BashTransport>>,
-    ) -> Self {
-        Self {
-            http,
-            poll,
-            gcps,
-            bash,
-        }
+    pub fn new(workers: HashMap<String, Arc<dyn ResonateWorker>>) -> Self {
+        Self { workers }
     }
+}
 
-    /// Parse the address, route to the correct transport, deliver.
-    pub async fn send(&self, address: &str, payload: &serde_json::Value) {
-        let kind = payload
-            .get("kind")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-        match parse_address(address) {
-            Some(Address::Http(addr)) => match &self.http {
-                Some(http) => {
-                    tracing::debug!(transport = "http", address = %addr.url, kind = kind, "Dispatching message via HTTP push");
-                    http.send(&addr, payload).await;
-                }
-                None => {
-                    tracing::warn!(address = %address, "HTTP push transport disabled, message dropped")
-                }
-            },
-            Some(Address::Poll(addr)) => match &self.poll {
-                Some(poll) => {
-                    tracing::debug!(transport = "poll", group = %addr.group, kind = kind, "Dispatching message via poll/SSE");
-                    let sse_data = serde_json::to_string(payload).unwrap_or_default();
-                    poll.send(&addr, &sse_data).await;
-                }
-                None => {
-                    tracing::warn!(address = %address, "HTTP poll transport disabled, message dropped")
-                }
-            },
-            Some(Address::Gcps(addr)) => match &self.gcps {
-                Some(gcps) => {
-                    tracing::debug!(transport = "gcps", project = %addr.project, topic = %addr.topic, kind = kind, "Dispatching message via GCP Pub/Sub");
-                    gcps.send(&addr, payload).await;
-                }
-                None => {
-                    tracing::warn!(address = %address, "GCP Pub/Sub transport not configured, message dropped")
-                }
-            },
-            Some(Address::Bash(_)) => match &self.bash {
-                Some(bash) => {
-                    tracing::debug!(
-                        transport = "bash",
-                        address,
-                        kind,
-                        "Dispatching message via bash exec"
-                    );
-                    bash.send(address, payload).await;
-                }
-                None => {
-                    tracing::warn!(address = %address, "Bash exec transport not configured, message dropped")
-                }
-            },
-            None => {
-                tracing::warn!(address = %address, "Invalid address, message cannot be routed");
-            }
-        }
+#[async_trait]
+impl ResonateRouter for TransportDispatcher {
+    async fn route(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
+        let scheme = scheme_of(address)
+            .ok_or_else(|| Unavailable::new(format!("address is not a URI: {address}")))?;
+        let worker = self.workers.get(&scheme).ok_or_else(|| {
+            Unavailable::new(format!("no worker registered for scheme '{scheme}'"))
+        })?;
+        worker.send(address, msg).await
     }
 }
 
@@ -148,112 +46,57 @@ impl TransportDispatcher {
 #[cfg(test)]
 pub mod stubs {
     use super::*;
+    use crate::core::types::{RequestEnvelope, ResponseEnvelope};
+    use crate::core::ResonateServer;
     use std::sync::Mutex;
 
-    /// Records every (url, payload) pair delivered via HTTP push.
-    pub struct RecordingHttpTransport {
+    /// A server that answers nothing. Workers hold a `ResonateServer` handle
+    /// for the failure path; tests that never exercise it can use this.
+    pub struct NoopServer;
+
+    #[async_trait]
+    impl ResonateServer for NoopServer {
+        async fn process(&self, _req: &RequestEnvelope) -> Result<ResponseEnvelope, Unavailable> {
+            Err(Unavailable::new("NoopServer answers nothing"))
+        }
+    }
+
+    /// Records every `(address, message)` pair it is asked to deliver.
+    ///
+    /// One stub serves every scheme now that workers share a trait — register
+    /// it under whichever scheme the test is exercising.
+    pub struct RecordingWorker {
         pub calls: Mutex<Vec<(String, serde_json::Value)>>,
     }
 
-    impl RecordingHttpTransport {
+    impl RecordingWorker {
         pub fn new() -> Self {
             Self {
                 calls: Mutex::new(vec![]),
             }
         }
 
+        /// Delivered messages as `(address, serialized message)`.
         pub fn calls(&self) -> Vec<(String, serde_json::Value)> {
             self.calls.lock().unwrap().clone()
         }
     }
 
+    impl Default for RecordingWorker {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     #[async_trait]
-    impl HttpTransport for RecordingHttpTransport {
-        async fn send(&self, addr: &HttpAddress, payload: &serde_json::Value) {
+    impl ResonateWorker for RecordingWorker {
+        async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
+            let value = serde_json::to_value(msg).expect("message serializes");
             self.calls
                 .lock()
                 .unwrap()
-                .push((addr.url.clone(), payload.clone()));
-        }
-    }
-
-    /// Records every (group, payload_str) pair delivered via poll/SSE.
-    pub struct RecordingPollTransport {
-        pub calls: Mutex<Vec<(String, String)>>,
-    }
-
-    impl RecordingPollTransport {
-        pub fn new() -> Self {
-            Self {
-                calls: Mutex::new(vec![]),
-            }
-        }
-
-        pub fn calls(&self) -> Vec<(String, String)> {
-            self.calls.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl PollTransport for RecordingPollTransport {
-        async fn send(&self, addr: &PollAddress, payload: &str) -> bool {
-            self.calls
-                .lock()
-                .unwrap()
-                .push((addr.group.clone(), payload.to_string()));
-            true
-        }
-    }
-
-    /// Records every (project/topic, payload) pair delivered via GCP Pub/Sub.
-    pub struct RecordingGcpsTransport {
-        pub calls: Mutex<Vec<(String, serde_json::Value)>>,
-    }
-
-    impl RecordingGcpsTransport {
-        pub fn new() -> Self {
-            Self {
-                calls: Mutex::new(vec![]),
-            }
-        }
-
-        pub fn calls(&self) -> Vec<(String, serde_json::Value)> {
-            self.calls.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl GcpsTransport for RecordingGcpsTransport {
-        async fn send(&self, addr: &GcpsAddress, payload: &serde_json::Value) {
-            let key = format!("{}/{}", addr.project, addr.topic);
-            self.calls.lock().unwrap().push((key, payload.clone()));
-        }
-    }
-
-    /// Records every (address, payload) pair delivered via bash exec.
-    pub struct RecordingBashTransport {
-        pub calls: Mutex<Vec<(String, serde_json::Value)>>,
-    }
-
-    impl RecordingBashTransport {
-        pub fn new() -> Self {
-            Self {
-                calls: Mutex::new(vec![]),
-            }
-        }
-
-        pub fn calls(&self) -> Vec<(String, serde_json::Value)> {
-            self.calls.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl BashTransport for RecordingBashTransport {
-        async fn send(&self, address: &str, payload: &serde_json::Value) {
-            self.calls
-                .lock()
-                .unwrap()
-                .push((address.to_string(), payload.clone()));
+                .push((address.to_string(), value));
+            Ok(())
         }
     }
 }
@@ -262,128 +105,97 @@ pub mod stubs {
 mod tests {
     use super::stubs::*;
     use super::*;
-    use serde_json::json;
+    use crate::core::types::{ExecuteMsg, ExecuteMsgData, ExecuteMsgTask, MessageHead};
 
-    fn payload(kind: &str) -> serde_json::Value {
-        json!({ "kind": kind, "head": {}, "data": {} })
+    fn execute_msg() -> Message {
+        Message::Execute(ExecuteMsg {
+            kind: "execute".to_string(),
+            head: MessageHead {
+                server_url: "http://localhost:8001".to_string(),
+            },
+            data: ExecuteMsgData {
+                task: ExecuteMsgTask {
+                    id: "t1".to_string(),
+                    version: 1,
+                },
+            },
+        })
     }
 
-    fn dispatcher_with_http(stub: Arc<RecordingHttpTransport>) -> TransportDispatcher {
-        TransportDispatcher::new(Some(stub as Arc<dyn HttpTransport>), None, None, None)
+    fn router_with(scheme: &str, stub: Arc<RecordingWorker>) -> TransportDispatcher {
+        let mut workers: HashMap<String, Arc<dyn ResonateWorker>> = HashMap::new();
+        workers.insert(scheme.to_string(), stub);
+        TransportDispatcher::new(workers)
     }
 
-    fn dispatcher_with_poll(stub: Arc<RecordingPollTransport>) -> TransportDispatcher {
-        TransportDispatcher::new(None, Some(stub as Arc<dyn PollTransport>), None, None)
+    fn empty_router() -> TransportDispatcher {
+        TransportDispatcher::new(HashMap::new())
     }
-
-    fn dispatcher_with_gcps(stub: Arc<RecordingGcpsTransport>) -> TransportDispatcher {
-        TransportDispatcher::new(None, None, Some(stub as Arc<dyn GcpsTransport>), None)
-    }
-
-    fn dispatcher_with_bash(stub: Arc<RecordingBashTransport>) -> TransportDispatcher {
-        TransportDispatcher::new(None, None, None, Some(stub as Arc<dyn BashTransport>))
-    }
-
-    // ---- http_push ----
 
     #[tokio::test]
-    async fn http_push_enabled_routes_to_stub() {
-        let stub = Arc::new(RecordingHttpTransport::new());
-        let dispatcher = dispatcher_with_http(stub.clone());
-        dispatcher
-            .send("http://example.com/callback", &payload("execute"))
-            .await;
+    async fn routes_by_scheme_to_the_registered_worker() {
+        for (scheme, address) in [
+            ("http", "http://example.com/callback"),
+            ("https", "https://example.com/secure"),
+            ("poll", "poll://any@default"),
+            ("gcps", "gcps://my-project/my-topic"),
+            ("bash", "bash://docker/alpine"),
+        ] {
+            let stub = Arc::new(RecordingWorker::new());
+            let router = router_with(scheme, stub.clone());
+            router.route(address, &execute_msg()).await.unwrap();
+
+            let calls = stub.calls();
+            assert_eq!(calls.len(), 1, "for {address}");
+            // The worker receives the address verbatim — the router does not
+            // decompose it.
+            assert_eq!(calls[0].0, address);
+            assert_eq!(calls[0].1["kind"], "execute");
+        }
+    }
+
+    #[tokio::test]
+    async fn unregistered_scheme_is_reported_not_dropped() {
+        for address in [
+            "http://example.com/callback",
+            "poll://any@default",
+            "gcps://my-project/my-topic",
+            "bash://docker/alpine",
+        ] {
+            let err = empty_router()
+                .route(address, &execute_msg())
+                .await
+                .expect_err("no worker is registered");
+            assert!(
+                err.to_string().contains("no worker registered"),
+                "for {address}: {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn non_uri_address_is_reported() {
+        let stub = Arc::new(RecordingWorker::new());
+        let router = router_with("http", stub.clone());
+        let err = router
+            .route("not a url", &execute_msg())
+            .await
+            .expect_err("not a URI");
+        assert!(err.to_string().contains("not a URI"), "{err}");
+        assert!(stub.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_worker_serves_every_address_of_its_scheme() {
+        let stub = Arc::new(RecordingWorker::new());
+        let router = router_with("poll", stub.clone());
+        for address in ["poll://any@a", "poll://uni@b/id", "poll://malformed"] {
+            router.route(address, &execute_msg()).await.unwrap();
+        }
         let calls = stub.calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "http://example.com/callback");
-        assert_eq!(calls[0].1["kind"], "execute");
-    }
-
-    #[tokio::test]
-    async fn http_push_disabled_drops_without_error() {
-        let dispatcher = TransportDispatcher::new(None, None, None, None);
-        // Should return without panicking — message silently dropped
-        dispatcher
-            .send("http://example.com/callback", &payload("execute"))
-            .await;
-    }
-
-    #[tokio::test]
-    async fn https_push_enabled_routes_to_stub() {
-        let stub = Arc::new(RecordingHttpTransport::new());
-        let dispatcher = dispatcher_with_http(stub.clone());
-        dispatcher
-            .send("https://example.com/secure", &payload("execute"))
-            .await;
-        let calls = stub.calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "https://example.com/secure");
-    }
-
-    // ---- http_poll ----
-
-    #[tokio::test]
-    async fn http_poll_enabled_routes_to_stub() {
-        let stub = Arc::new(RecordingPollTransport::new());
-        let dispatcher = dispatcher_with_poll(stub.clone());
-        dispatcher
-            .send("poll://any@default", &payload("execute"))
-            .await;
-        let calls = stub.calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "default");
-        let body: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
-        assert_eq!(body["kind"], "execute");
-    }
-
-    #[tokio::test]
-    async fn http_poll_disabled_drops_without_error() {
-        let dispatcher = TransportDispatcher::new(None, None, None, None);
-        dispatcher
-            .send("poll://any@default", &payload("execute"))
-            .await;
-    }
-
-    // ---- gcps ----
-
-    #[tokio::test]
-    async fn gcps_enabled_routes_to_stub() {
-        let stub = Arc::new(RecordingGcpsTransport::new());
-        let dispatcher = dispatcher_with_gcps(stub.clone());
-        dispatcher
-            .send("gcps://my-project/my-topic", &payload("execute"))
-            .await;
-        let calls = stub.calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "my-project/my-topic");
-        assert_eq!(calls[0].1["kind"], "execute");
-    }
-
-    #[tokio::test]
-    async fn gcps_disabled_drops_without_error() {
-        let dispatcher = TransportDispatcher::new(None, None, None, None);
-        dispatcher
-            .send("gcps://my-project/my-topic", &payload("execute"))
-            .await;
-    }
-
-    // ---- bash ----
-
-    #[tokio::test]
-    async fn bash_enabled_routes_to_stub() {
-        let stub = Arc::new(RecordingBashTransport::new());
-        let dispatcher = dispatcher_with_bash(stub.clone());
-        // bash:// is the inline-script address scheme
-        dispatcher.send("bash://", &payload("execute")).await;
-        let calls = stub.calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "bash://");
-        assert_eq!(calls[0].1["kind"], "execute");
-    }
-
-    #[tokio::test]
-    async fn bash_disabled_drops_without_error() {
-        let dispatcher = TransportDispatcher::new(None, None, None, None);
-        dispatcher.send("bash://", &payload("execute")).await;
+        assert_eq!(calls.len(), 3);
+        // Including the malformed one: rejecting it is the worker's job, not
+        // the router's.
+        assert_eq!(calls[2].0, "poll://malformed");
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use crate::core::address::{parse_address, Address, GcpsAddress, HttpAddress, PollAddress};
+
 // ---- Per-transport traits ----
 
 #[async_trait]
@@ -138,103 +140,6 @@ impl TransportDispatcher {
                 tracing::warn!(address = %address, "Invalid address, message cannot be routed");
             }
         }
-    }
-}
-
-// ---- Address types ----
-
-/// Parsed address — determines which transport and where to deliver.
-#[derive(Debug, Clone)]
-pub enum Address {
-    /// HTTP/HTTPS webhook delivery
-    Http(HttpAddress),
-    /// Poll SSE delivery
-    Poll(PollAddress),
-    /// Google Cloud Pub/Sub delivery
-    Gcps(GcpsAddress),
-    /// Bash script execution (script is in param.data).
-    /// The bash transport re-parses the address to pick a backend
-    /// (local / docker / tensorlake), so we only mark it routable here.
-    #[allow(dead_code)]
-    Bash(BashAddress),
-}
-
-#[derive(Debug, Clone)]
-pub struct HttpAddress {
-    pub url: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct PollAddress {
-    pub cast: PollCast,
-    pub group: String,
-    pub id: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum PollCast {
-    Uni,
-    Any,
-}
-
-#[derive(Debug, Clone)]
-pub struct GcpsAddress {
-    pub project: String,
-    pub topic: String,
-}
-
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct BashAddress;
-
-/// Returns true if the address is a valid, routable URL.
-pub fn is_valid_address(address: &str) -> bool {
-    parse_address(address).is_some()
-}
-
-/// Parse an address string into a typed Address.
-///
-/// Supports:
-/// - `http://...` / `https://...` — HTTP webhook delivery
-/// - `poll://cast@group[/id]` — Poll SSE delivery
-/// - `gcps://project/topic` — Google Cloud Pub/Sub delivery
-/// - `bash://` (local), `bash://docker/<image>`, `bash://tensorlake/<image>`
-pub fn parse_address(address: &str) -> Option<Address> {
-    let parsed = url::Url::parse(address).ok()?;
-
-    match parsed.scheme() {
-        "http" | "https" => Some(Address::Http(HttpAddress {
-            url: address.to_string(),
-        })),
-        "poll" => {
-            let cast = match parsed.username() {
-                "uni" => PollCast::Uni,
-                "any" => PollCast::Any,
-                _ => return None,
-            };
-            let group = parsed.host_str()?.to_string();
-            let path = parsed.path();
-            let id = if path.len() > 1 {
-                Some(path[1..].to_string())
-            } else {
-                None
-            };
-            Some(Address::Poll(PollAddress { cast, group, id }))
-        }
-        "gcps" => {
-            let project = parsed.host_str()?.to_string();
-            let path = parsed.path();
-            if path.len() <= 1 {
-                return None; // need at least /topic
-            }
-            let topic = path[1..].to_string();
-            if topic.is_empty() {
-                return None;
-            }
-            Some(Address::Gcps(GcpsAddress { project, topic }))
-        }
-        "bash" => Some(Address::Bash(BashAddress)),
-        _ => None,
     }
 }
 
@@ -480,21 +385,5 @@ mod tests {
     async fn bash_disabled_drops_without_error() {
         let dispatcher = TransportDispatcher::new(None, None, None, None);
         dispatcher.send("bash://", &payload("execute")).await;
-    }
-
-    #[test]
-    fn bash_address_parses() {
-        for addr in [
-            "bash://",
-            "bash://bash",
-            "bash://docker/alpine",
-            "bash://docker/library/ubuntu:latest",
-            "bash://tensorlake/python-3.11",
-        ] {
-            assert!(
-                matches!(parse_address(addr), Some(Address::Bash(_))),
-                "expected Bash for {addr}"
-            );
-        }
     }
 }

--- a/src/transport/transport_exec_bash.rs
+++ b/src/transport/transport_exec_bash.rs
@@ -5,11 +5,11 @@ use async_trait::async_trait;
 use serde_json::json;
 use tokio::process::Command;
 
-use crate::core::types::Message;
-use crate::core::{ResonateWorker, Unavailable};
-use crate::persistence::{Storage, TaskAcquireParams, TaskFulfillParams};
-use crate::server::Server;
-use crate::util::system_time_ms;
+use crate::core::types::{
+    Message, RequestEnvelope, RequestHead, ResponseEnvelope, TaskAcquireResponseData,
+    PROTOCOL_VERSION,
+};
+use crate::core::{ResonateServer, ResonateWorker, Unavailable};
 
 // ─── Backend trait ────────────────────────────────────────────────────────────
 //
@@ -110,16 +110,24 @@ fn parse_backend(address: &str) -> Result<BackendChoice, String> {
 // ─── Transport ────────────────────────────────────────────────────────────────
 
 pub struct BashExecTransport {
-    server: Arc<Server>,
+    /// This worker runs in the server's own process, so it holds the port
+    /// directly instead of reaching it over the wire. Every state change it
+    /// makes goes through `process` — the same path a remote worker's HTTP
+    /// calls take.
+    server: Arc<dyn ResonateServer>,
+    /// Lease TTL for tasks this worker acquires. Configuration of the worker,
+    /// not of the server it talks to.
+    lease_timeout: i64,
     local: Arc<LocalBackend>,
     docker: Arc<DockerBackend>,
     tensorlake: Arc<TensorlakeBackend>,
 }
 
 impl BashExecTransport {
-    pub fn new(server: Arc<Server>) -> Self {
+    pub fn new(server: Arc<dyn ResonateServer>, lease_timeout: i64) -> Self {
         Self {
             server,
+            lease_timeout,
             local: Arc::new(LocalBackend),
             docker: Arc::new(DockerBackend),
             tensorlake: Arc::new(TensorlakeBackend::from_env()),
@@ -149,8 +157,17 @@ impl BashExecTransport {
         };
 
         let server = Arc::clone(&self.server);
+        let lease_timeout = self.lease_timeout;
         tokio::spawn(async move {
-            run_task(server, task_id, task_version, backend, target).await;
+            run_task(
+                server,
+                lease_timeout,
+                task_id,
+                task_version,
+                backend,
+                target,
+            )
+            .await;
         });
         Ok(())
     }
@@ -165,33 +182,91 @@ impl ResonateWorker for BashExecTransport {
 
 // ─── Orchestrator ─────────────────────────────────────────────────────────────
 
+/// Issue one protocol request at the server this worker is attached to.
+///
+/// In-process, so no HTTP hop and no auth — but the same `process` entry point,
+/// and therefore the same validation, ghost-timeout handling and response
+/// shaping that a remote worker's request would go through.
+async fn request(
+    server: &dyn ResonateServer,
+    kind: &str,
+    data: serde_json::Value,
+) -> Result<ResponseEnvelope, Unavailable> {
+    server
+        .process(&RequestEnvelope {
+            kind: kind.to_string(),
+            head: RequestHead {
+                corr_id: format!("bash-exec-{}", fastrand::u64(..)),
+                version: PROTOCOL_VERSION.to_string(),
+                auth: None,
+                debug_time: None,
+            },
+            data,
+        })
+        .await
+}
+
+/// Settle the task's promise via `task.fulfill`.
+///
+/// The promise id is the task id in this flow — `op_task_fulfill` settles
+/// `data.id`, and `action.data.id` is what the ghost timeout runs against.
+async fn settle_task(
+    server: &dyn ResonateServer,
+    task_id: &str,
+    version: i64,
+    state: &str,
+    value: &str,
+) {
+    let resp = request(
+        server,
+        "task.fulfill",
+        json!({
+            "id": task_id,
+            "version": version,
+            "action": {
+                "kind": "promise.settle",
+                "head": {},
+                "data": { "id": task_id, "state": state, "value": { "data": value } }
+            }
+        }),
+    )
+    .await;
+
+    match resp {
+        Ok(r) if (200..300).contains(&r.head.status) => {}
+        Ok(r) => tracing::warn!(
+            task_id,
+            status = r.head.status,
+            state,
+            "bash-exec: task fulfill rejected"
+        ),
+        Err(e) => tracing::error!(task_id, error = %e, "bash-exec: task fulfill failed"),
+    }
+}
+
 async fn run_task(
-    server: Arc<Server>,
+    server: Arc<dyn ResonateServer>,
+    lease_timeout: i64,
     task_id: String,
     task_version: i64,
     backend: Arc<dyn ExecBackend>,
     target: Option<String>,
 ) {
     let pid = format!("bash-exec-{}", fastrand::u64(..));
-    let lease_timeout = server.config.tasks.lease_timeout;
 
-    // 1. Acquire — racing is normal; storage errors are transient (drop, let lease expire).
-    let acquire_result = match server
-        .storage
-        .transact({
-            let task_id = task_id.clone();
-            let pid = pid.clone();
-            move |db| {
-                db.task_acquire(&TaskAcquireParams {
-                    task_id: &task_id,
-                    version: task_version,
-                    time: system_time_ms(),
-                    ttl: lease_timeout,
-                    pid: &pid,
-                })
-            }
-        })
-        .await
+    // 1. Acquire — racing is normal (409); anything else is transient, so drop
+    //    the task and let the lease expire rather than settling the promise.
+    let resp = match request(
+        server.as_ref(),
+        "task.acquire",
+        json!({
+            "id": task_id,
+            "version": task_version,
+            "pid": pid,
+            "ttl": lease_timeout
+        }),
+    )
+    .await
     {
         Ok(r) => r,
         Err(e) => {
@@ -200,35 +275,38 @@ async fn run_task(
         }
     };
 
-    if !acquire_result.was_acquired {
+    if resp.head.status == 409 {
         tracing::debug!(task_id, "bash-exec: task not acquired");
         return;
     }
+    if resp.head.status != 200 {
+        tracing::warn!(
+            task_id,
+            status = resp.head.status,
+            "bash-exec: task acquire rejected"
+        );
+        return;
+    }
 
-    let acquired_version = acquire_result.task_version.unwrap_or(task_version + 1);
-
-    let promise = match acquire_result.promise {
-        Some(p) => p,
-        None => {
-            reject_promise(
-                &server.storage,
-                &task_id,
-                acquired_version,
-                "no promise returned after acquire",
-            )
-            .await;
+    let acquired: TaskAcquireResponseData = match serde_json::from_value(resp.data) {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::error!(task_id, error = %e, "bash-exec: malformed acquire response");
             return;
         }
     };
+    let acquired_version = acquired.task.version;
+    let promise = acquired.promise;
 
     // 2. Decode script — param.data is base64-encoded; the decoded value IS the script.
     let script = match decode_param(promise.param.data.as_deref()) {
         Some(s) => s,
         None => {
-            reject_promise(
-                &server.storage,
+            settle_task(
+                server.as_ref(),
                 &task_id,
                 acquired_version,
+                "rejected",
                 "param.data is missing or not valid base64/utf-8",
             )
             .await;
@@ -238,7 +316,7 @@ async fn run_task(
 
     // 3. Heartbeat — refreshes the lease while the backend runs.
     let heartbeat = {
-        let storage = Arc::clone(&server.storage);
+        let server = Arc::clone(&server);
         let task_id = task_id.clone();
         let pid = pid.clone();
         let version = acquired_version;
@@ -248,12 +326,15 @@ async fn run_task(
             interval.tick().await;
             loop {
                 interval.tick().await;
-                let task_id = task_id.clone();
-                let pid = pid.clone();
-                let now = system_time_ms();
-                let _ = storage
-                    .transact(move |db| db.task_heartbeat(&pid, &[(&task_id, version)], now))
-                    .await;
+                let _ = request(
+                    server.as_ref(),
+                    "task.heartbeat",
+                    json!({
+                        "pid": pid,
+                        "tasks": [{ "id": task_id, "version": version }]
+                    }),
+                )
+                .await;
             }
         })
     };
@@ -273,7 +354,16 @@ async fn run_task(
 
     // 5. Fulfill, reject, or drop-for-reschedule.
     match outcome.result {
-        Err(msg) => reject_promise(&server.storage, &task_id, acquired_version, &msg).await,
+        Err(msg) => {
+            settle_task(
+                server.as_ref(),
+                &task_id,
+                acquired_version,
+                "rejected",
+                &msg,
+            )
+            .await
+        }
         Ok(status) if status.killed => {
             // Process was killed (signal locally; SIGKILL/SIGTERM in container;
             // "signaled" in sandbox). Treat as infrastructure failure: drop the
@@ -287,7 +377,14 @@ async fn run_task(
         }
         Ok(status) if status.code == 0 => {
             let value = status.stdout.trim().to_string();
-            fulfill_promise(&server.storage, &task_id, acquired_version, &value).await;
+            settle_task(
+                server.as_ref(),
+                &task_id,
+                acquired_version,
+                "resolved",
+                &value,
+            )
+            .await;
         }
         Ok(status) => {
             let stderr = status.stderr.trim();
@@ -296,7 +393,14 @@ async fn run_task(
             } else {
                 stderr.to_string()
             };
-            reject_promise(&server.storage, &task_id, acquired_version, &reason).await;
+            settle_task(
+                server.as_ref(),
+                &task_id,
+                acquired_version,
+                "rejected",
+                &reason,
+            )
+            .await;
         }
     }
 }
@@ -643,47 +747,189 @@ fn decode_param(data: Option<&str>) -> Option<String> {
     String::from_utf8(bytes).ok()
 }
 
-async fn fulfill_promise(storage: &Storage, task_id: &str, version: i64, value: &str) {
-    let now = system_time_ms();
-    let task_id = task_id.to_string();
-    let value = value.to_string();
-    let _ = storage
-        .transact(move |db| {
-            db.task_fulfill(&TaskFulfillParams {
-                task_id: &task_id,
-                version,
-                promise_id: &task_id,
-                state: "resolved",
-                value_headers: None,
-                value_data: Some(&value),
-                settled_at: now,
-            })
-        })
-        .await;
-}
-
-async fn reject_promise(storage: &Storage, task_id: &str, version: i64, reason: &str) {
-    let now = system_time_ms();
-    let task_id = task_id.to_string();
-    let reason = reason.to_string();
-    let _ = storage
-        .transact(move |db| {
-            db.task_fulfill(&TaskFulfillParams {
-                task_id: &task_id,
-                version,
-                promise_id: &task_id,
-                state: "rejected",
-                value_headers: None,
-                value_data: Some(&reason),
-                settled_at: now,
-            })
-        })
-        .await;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use base64::Engine;
+    use std::collections::HashMap;
+
+    use crate::config::Config;
+    use crate::core::types::PromiseState;
+    use crate::core::ResonateRouter;
+    use crate::persistence::{persistence_sqlite::SqliteStorage, Storage};
+    use crate::processing::processing_messages::process_batch;
+    use crate::server::Server;
+    use crate::transport::TransportDispatcher;
+
+    // ---- end-to-end: the worker drives the task through the protocol ----
+    //
+    // These are the only coverage of the acquire/run/settle path: the
+    // differential test never exercises a worker, so nothing else checks that
+    // `run_task`'s envelopes are accepted by the server.
+
+    fn test_server() -> Arc<Server> {
+        let storage = Storage::Sqlite(SqliteStorage::open(":memory:", 30_000).unwrap());
+        let mut config = Config::default();
+        config.server.url = Some("http://localhost:8001".to_string());
+        Arc::new(Server::new(config, None, storage))
+    }
+
+    /// Create a promise whose `resonate:target` is a bash address and whose
+    /// param carries `script`, then release the task so a message is queued.
+    async fn queue_bash_task(server: &Arc<Server>, id: &str, script: &str, address: &str) {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(script);
+        let create = json!({
+            "pid": "test-worker",
+            "ttl": 60_000,
+            "action": {
+                "kind": "promise.create",
+                "head": {},
+                "data": {
+                    "id": id,
+                    "timeoutAt": 9_000_000_000_000i64,
+                    "param": { "data": encoded },
+                    "tags": { "resonate:target": address }
+                }
+            }
+        });
+        let resp = server
+            .dispatch(&envelope("task.create", create), 1_000)
+            .await;
+        assert_eq!(resp.head.status, 200, "task.create: {:?}", resp.data);
+
+        let resp = server
+            .dispatch(
+                &envelope("task.release", json!({"id": id, "version": 1})),
+                1_000,
+            )
+            .await;
+        assert_eq!(resp.head.status, 200, "task.release: {:?}", resp.data);
+    }
+
+    fn envelope(kind: &str, data: serde_json::Value) -> RequestEnvelope {
+        RequestEnvelope {
+            kind: kind.to_string(),
+            head: RequestHead {
+                corr_id: "test".to_string(),
+                version: PROTOCOL_VERSION.to_string(),
+                auth: None,
+                debug_time: None,
+            },
+            data,
+        }
+    }
+
+    async fn promise_state(server: &Arc<Server>, id: &str) -> (PromiseState, Option<String>) {
+        let resp = server
+            .dispatch(&envelope("promise.get", json!({ "id": id })), 1_000)
+            .await;
+        assert_eq!(resp.head.status, 200, "promise.get: {:?}", resp.data);
+        let promise = &resp.data["promise"];
+        let state = serde_json::from_value(promise["state"].clone()).unwrap();
+        let data = promise["value"]["data"].as_str().map(|s| s.to_string());
+        (state, data)
+    }
+
+    /// Poll until the promise leaves `pending`, or give up.
+    async fn await_settled(server: &Arc<Server>, id: &str) -> (PromiseState, Option<String>) {
+        for _ in 0..100 {
+            let (state, data) = promise_state(server, id).await;
+            if state != PromiseState::Pending {
+                return (state, data);
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("promise {id} never settled");
+    }
+
+    async fn run_one_task(
+        server: &Arc<Server>,
+        id: &str,
+        script: &str,
+    ) -> (PromiseState, Option<String>) {
+        queue_bash_task(server, id, script, "bash://").await;
+
+        let mut workers: HashMap<String, Arc<dyn ResonateWorker>> = HashMap::new();
+        workers.insert(
+            "bash".to_string(),
+            Arc::new(BashExecTransport::new(server.clone(), 60_000)),
+        );
+        let router = TransportDispatcher::new(workers);
+
+        process_batch(
+            &server.storage,
+            &router as &dyn ResonateRouter,
+            100,
+            "http://localhost:8001",
+        )
+        .await;
+        await_settled(server, id).await
+    }
+
+    /// The heartbeat loop hand-builds a `task.heartbeat` envelope and ignores
+    /// the result, so a malformed one would fail silently: the lease would
+    /// expire mid-script and the task be redispatched while still running.
+    /// Scripts in the other tests finish before the first beat, so this checks
+    /// the envelope shape directly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn heartbeat_envelope_is_accepted_by_the_server() {
+        let server = test_server();
+        queue_bash_task(&server, "bash-beat", "echo hi", "bash://").await;
+
+        // Acquire exactly as run_task does, so the pid/version match.
+        let pid = "bash-exec-test";
+        let resp = server
+            .dispatch(
+                &envelope(
+                    "task.acquire",
+                    json!({ "id": "bash-beat", "version": 1, "pid": pid, "ttl": 60_000 }),
+                ),
+                1_000,
+            )
+            .await;
+        assert_eq!(resp.head.status, 200, "task.acquire: {:?}", resp.data);
+        let acquired: TaskAcquireResponseData = serde_json::from_value(resp.data).unwrap();
+
+        // The exact envelope the heartbeat loop sends.
+        let resp = server
+            .dispatch(
+                &envelope(
+                    "task.heartbeat",
+                    json!({
+                        "pid": pid,
+                        "tasks": [{ "id": "bash-beat", "version": acquired.task.version }]
+                    }),
+                ),
+                2_000,
+            )
+            .await;
+        assert_eq!(resp.head.status, 200, "task.heartbeat: {:?}", resp.data);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn successful_script_resolves_the_promise_with_stdout() {
+        let server = test_server();
+        let (state, data) = run_one_task(&server, "bash-ok", "echo hello").await;
+        assert_eq!(state, PromiseState::Resolved);
+        assert_eq!(data.as_deref(), Some("hello"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failing_script_rejects_the_promise_with_stderr() {
+        let server = test_server();
+        let (state, data) = run_one_task(&server, "bash-fail", "echo boom >&2; exit 3").await;
+        assert_eq!(state, PromiseState::Rejected);
+        assert_eq!(data.as_deref(), Some("boom"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failing_script_without_stderr_rejects_with_the_exit_code() {
+        let server = test_server();
+        let (state, data) = run_one_task(&server, "bash-code", "exit 7").await;
+        assert_eq!(state, PromiseState::Rejected);
+        assert_eq!(data.as_deref(), Some("exit code 7"));
+    }
 
     #[test]
     fn parse_local_empty() {

--- a/src/transport/transport_exec_bash.rs
+++ b/src/transport/transport_exec_bash.rs
@@ -5,6 +5,8 @@ use async_trait::async_trait;
 use serde_json::json;
 use tokio::process::Command;
 
+use crate::core::types::Message;
+use crate::core::{ResonateWorker, Unavailable};
 use crate::persistence::{Storage, TaskAcquireParams, TaskFulfillParams};
 use crate::server::Server;
 use crate::util::system_time_ms;
@@ -124,18 +126,15 @@ impl BashExecTransport {
         }
     }
 
-    pub async fn send(&self, address: &str, payload: &serde_json::Value) {
-        let task_id = match payload.pointer("/data/task/id").and_then(|v| v.as_str()) {
-            Some(id) => id.to_string(),
-            None => {
-                tracing::warn!("bash-exec: missing task.id in execute payload");
-                return;
-            }
+    pub async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
+        // Only `execute` gives this worker something to run; an `unblock` is a
+        // notification for a waiting worker and has no local counterpart.
+        let task = match msg {
+            Message::Execute(e) => &e.data.task,
+            Message::Unblock(_) => return Ok(()),
         };
-        let task_version = payload
-            .pointer("/data/task/version")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0);
+        let task_id = task.id.clone();
+        let task_version = task.version;
 
         let (backend, target): (Arc<dyn ExecBackend>, Option<String>) = match parse_backend(address)
         {
@@ -143,8 +142,9 @@ impl BashExecTransport {
             Ok(BackendChoice::Docker { image }) => (self.docker.clone(), Some(image)),
             Ok(BackendChoice::Tensorlake { image }) => (self.tensorlake.clone(), Some(image)),
             Err(e) => {
-                tracing::warn!(address, error = %e, "bash-exec: cannot parse address");
-                return;
+                return Err(Unavailable::new(format!(
+                    "bash-exec: cannot parse address {address}: {e}"
+                )))
             }
         };
 
@@ -152,6 +152,14 @@ impl BashExecTransport {
         tokio::spawn(async move {
             run_task(server, task_id, task_version, backend, target).await;
         });
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ResonateWorker for BashExecTransport {
+    async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
+        BashExecTransport::send(self, address, msg).await
     }
 }
 

--- a/src/transport/transport_gcps.rs
+++ b/src/transport/transport_gcps.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use google_cloud_pubsub::client::Publisher;
 use tokio::sync::{mpsc, Mutex, Semaphore};
 
-use super::GcpsAddress;
+use crate::core::address::GcpsAddress;
 use crate::metrics;
 
 /// Google Cloud Pub/Sub transport — publishes messages to topics.

--- a/src/transport/transport_gcps.rs
+++ b/src/transport/transport_gcps.rs
@@ -9,8 +9,36 @@ use std::time::Duration;
 use google_cloud_pubsub::client::Publisher;
 use tokio::sync::{mpsc, Mutex, Semaphore};
 
-use crate::core::address::GcpsAddress;
 use crate::metrics;
+
+use crate::core::types::Message;
+use crate::core::{ResonateServer, ResonateWorker, Unavailable};
+
+/// A `gcps://` destination: `gcps://<project>/<topic>`.
+#[derive(Debug, Clone)]
+pub struct GcpsAddress {
+    pub project: String,
+    pub topic: String,
+}
+
+impl GcpsAddress {
+    /// Parse a `gcps://` address. This worker owns the syntax; the router has
+    /// only checked the scheme.
+    pub fn parse(address: &str) -> Result<Self, Unavailable> {
+        let bad = || Unavailable::new(format!("malformed gcps address: {address}"));
+        let parsed = url::Url::parse(address).map_err(|_| bad())?;
+        let project = parsed.host_str().ok_or_else(bad)?.to_string();
+        let path = parsed.path();
+        if path.len() <= 1 {
+            return Err(bad());
+        }
+        let topic = path[1..].to_string();
+        if topic.is_empty() {
+            return Err(bad());
+        }
+        Ok(GcpsAddress { project, topic })
+    }
+}
 
 /// Google Cloud Pub/Sub transport — publishes messages to topics.
 ///
@@ -20,6 +48,10 @@ use crate::metrics;
 /// only blocks if the queue is full, never on the publish RPC.
 pub struct GcpsPubSubTransport {
     tx: mpsc::Sender<PublishJob>,
+    /// Held so a delivery failure can be reported back to the server (e.g.
+    /// releasing the task instead of dropping it). Not used yet.
+    #[allow(dead_code)]
+    server: Arc<dyn ResonateServer>,
 }
 
 struct PublishJob {
@@ -28,7 +60,7 @@ struct PublishJob {
 }
 
 impl GcpsPubSubTransport {
-    pub fn new(concurrency: usize, timeout: Duration) -> Self {
+    pub fn new(server: Arc<dyn ResonateServer>, concurrency: usize, timeout: Duration) -> Self {
         let publishers = Arc::new(Mutex::new(HashMap::<String, Publisher>::new()));
         let semaphore = Arc::new(Semaphore::new(concurrency));
         // Queue capacity larger than concurrency so short bursts smooth out;
@@ -39,7 +71,7 @@ impl GcpsPubSubTransport {
 
         tokio::spawn(dispatcher(publishers, semaphore, timeout, rx));
 
-        Self { tx }
+        Self { tx, server }
     }
 
     /// Enqueue a publish. Returns once the job is on the in-memory queue.
@@ -150,5 +182,16 @@ async fn deliver(
                 .with_label_values(&["error"])
                 .inc();
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl ResonateWorker for GcpsPubSubTransport {
+    async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
+        let addr = GcpsAddress::parse(address)?;
+        let payload = serde_json::to_value(msg)
+            .map_err(|e| Unavailable::new(format!("cannot serialize message: {e}")))?;
+        GcpsPubSubTransport::send(self, &addr, &payload).await;
+        Ok(())
     }
 }

--- a/src/transport/transport_http_poll.rs
+++ b/src/transport/transport_http_poll.rs
@@ -212,7 +212,12 @@ impl PollRegistry {
 impl ResonateWorker for PollRegistry {
     async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
         let addr = PollAddress::parse(address)?;
-        let body = serde_json::to_string(msg)
+        // Serialize via `Value` rather than straight from the struct. serde_json
+        // has no `preserve_order`, so a `Value` map is a BTreeMap and emits keys
+        // alphabetically — which is what SSE consumers have always received.
+        // Going direct would emit declaration order instead and change the bytes.
+        let body = serde_json::to_value(msg)
+            .and_then(|v| serde_json::to_string(&v))
             .map_err(|e| Unavailable::new(format!("cannot serialize message: {e}")))?;
         if PollRegistry::send_poll(self, &addr, &body).await {
             Ok(())

--- a/src/transport/transport_http_poll.rs
+++ b/src/transport/transport_http_poll.rs
@@ -9,7 +9,44 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 
-use crate::core::address::{PollAddress, PollCast};
+use crate::core::types::Message;
+use crate::core::{ResonateServer, ResonateWorker, Unavailable};
+
+/// A `poll://` destination: `poll://<cast>@<group>[/<id>]`.
+#[derive(Debug, Clone)]
+pub struct PollAddress {
+    pub cast: PollCast,
+    pub group: String,
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PollCast {
+    Uni,
+    Any,
+}
+
+impl PollAddress {
+    /// Parse a `poll://` address. This worker owns the syntax; the router has
+    /// only checked the scheme.
+    pub fn parse(address: &str) -> Result<Self, Unavailable> {
+        let bad = || Unavailable::new(format!("malformed poll address: {address}"));
+        let parsed = url::Url::parse(address).map_err(|_| bad())?;
+        let cast = match parsed.username() {
+            "uni" => PollCast::Uni,
+            "any" => PollCast::Any,
+            _ => return Err(bad()),
+        };
+        let group = parsed.host_str().ok_or_else(bad)?.to_string();
+        let path = parsed.path();
+        let id = if path.len() > 1 {
+            Some(path[1..].to_string())
+        } else {
+            None
+        };
+        Ok(PollAddress { cast, group, id })
+    }
+}
 
 /// A single SSE connection to a worker.
 pub struct PollConnection {
@@ -27,15 +64,24 @@ pub struct PollRegistry {
     next_conn_id: AtomicU64,
     pub max_connections: usize,
     pub buffer_size: usize,
+    /// Held so a delivery failure can be reported back to the server (e.g.
+    /// releasing the task instead of dropping it). Not used yet.
+    #[allow(dead_code)]
+    server: Arc<dyn ResonateServer>,
 }
 
 impl PollRegistry {
-    pub fn new(max_connections: usize, buffer_size: usize) -> Self {
+    pub fn new(
+        server: Arc<dyn ResonateServer>,
+        max_connections: usize,
+        buffer_size: usize,
+    ) -> Self {
         Self {
             connections: Mutex::new(HashMap::new()),
             next_conn_id: AtomicU64::new(1),
             max_connections,
             buffer_size,
+            server,
         }
     }
 
@@ -159,5 +205,21 @@ impl PollRegistry {
             );
         }
         delivered
+    }
+}
+
+#[async_trait::async_trait]
+impl ResonateWorker for PollRegistry {
+    async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
+        let addr = PollAddress::parse(address)?;
+        let body = serde_json::to_string(msg)
+            .map_err(|e| Unavailable::new(format!("cannot serialize message: {e}")))?;
+        if PollRegistry::send_poll(self, &addr, &body).await {
+            Ok(())
+        } else {
+            Err(Unavailable::new(format!(
+                "no poll connection accepted delivery for {address}"
+            )))
+        }
     }
 }

--- a/src/transport/transport_http_poll.rs
+++ b/src/transport/transport_http_poll.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 
-use super::{PollAddress, PollCast};
+use crate::core::address::{PollAddress, PollCast};
 
 /// A single SSE connection to a worker.
 pub struct PollConnection {

--- a/src/transport/transport_http_push.rs
+++ b/src/transport/transport_http_push.rs
@@ -8,8 +8,18 @@ use reqwest::Client;
 use tokio::sync::{mpsc, Semaphore};
 
 use crate::config::{HttpPushAuthConfig, HttpPushAuthMode};
-use crate::core::address::HttpAddress;
+use async_trait::async_trait;
+
+use crate::core::types::Message;
+use crate::core::{ResonateServer, ResonateWorker, Unavailable};
 use crate::metrics;
+
+/// An `http://` or `https://` destination. The whole address is the URL, so
+/// parsing is the identity — the type exists to keep the delivery queue typed.
+#[derive(Debug, Clone)]
+pub struct HttpAddress {
+    pub url: String,
+}
 
 // ---------------------------------------------------------------------------
 // Token provider abstraction
@@ -126,10 +136,15 @@ struct DeliveryJob {
 
 pub struct HttpPushTransport {
     tx: mpsc::Sender<DeliveryJob>,
+    /// Held so a delivery failure can be reported back to the server (e.g.
+    /// releasing the task instead of dropping it). Not used yet.
+    #[allow(dead_code)]
+    server: Arc<dyn ResonateServer>,
 }
 
 impl HttpPushTransport {
     pub fn new(
+        server: Arc<dyn ResonateServer>,
         connect_timeout: Duration,
         request_timeout: Duration,
         auth: Auth,
@@ -150,7 +165,7 @@ impl HttpPushTransport {
 
         tokio::spawn(dispatcher(client, auth, semaphore, rx));
 
-        Self { tx }
+        Self { tx, server }
     }
 
     /// Enqueue a delivery. Returns once the job is on the in-memory queue.
@@ -173,6 +188,25 @@ impl HttpPushTransport {
                 .with_label_values(&["dropped"])
                 .inc();
         }
+    }
+}
+
+#[async_trait]
+impl ResonateWorker for HttpPushTransport {
+    /// The address is the URL verbatim; the router has already guaranteed the
+    /// scheme is `http` or `https`.
+    async fn send(&self, address: &str, msg: &Message) -> Result<(), Unavailable> {
+        let payload = serde_json::to_value(msg)
+            .map_err(|e| Unavailable::new(format!("cannot serialize message: {e}")))?;
+        HttpPushTransport::send(
+            self,
+            &HttpAddress {
+                url: address.to_string(),
+            },
+            &payload,
+        )
+        .await;
+        Ok(())
     }
 }
 
@@ -248,7 +282,6 @@ async fn deliver(client: Client, auth: Arc<Auth>, job: DeliveryJob) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::address::HttpAddress;
     use axum::{extract::State, routing::post, Router};
     use std::sync::Arc;
     use std::time::Duration;
@@ -319,7 +352,13 @@ mod tests {
     }
 
     fn make_transport(auth: Auth) -> HttpPushTransport {
-        HttpPushTransport::new(Duration::from_secs(5), Duration::from_secs(5), auth, 16)
+        HttpPushTransport::new(
+            Arc::new(crate::transport::stubs::NoopServer),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            auth,
+            16,
+        )
     }
 
     #[tokio::test]

--- a/src/transport/transport_http_push.rs
+++ b/src/transport/transport_http_push.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use reqwest::Client;
 use tokio::sync::{mpsc, Semaphore};
 
-use super::HttpAddress;
 use crate::config::{HttpPushAuthConfig, HttpPushAuthMode};
+use crate::core::address::HttpAddress;
 use crate::metrics;
 
 // ---------------------------------------------------------------------------
@@ -248,7 +248,7 @@ async fn deliver(client: Client, auth: Arc<Auth>, job: DeliveryJob) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::transport::HttpAddress;
+    use crate::core::address::HttpAddress;
     use axum::{extract::State, routing::post, Router};
     use std::sync::Arc;
     use std::time::Duration;


### PR DESCRIPTION
## What

Introduces a dependency-free `src/core/` module defining the system's ports, then reshapes everything else into adapters of those ports:

- **`ResonateServer`** — the inbound port: `process(&RequestEnvelope) -> Result<ResponseEnvelope, Unavailable>`. Implemented by the in-process `Server` and by `Mutex<Oracle>` (the reference model), so the CLI, workers, and the differential test can be written once and pointed at either. Non-2xx outcomes are in-band; `Err(Unavailable)` means the exchange did not complete, with an explicit idempotent-retry contract.
- **`ResonateWorker`** — the outbound dual: `send(address, &Message)`, meaning *accepted for delivery*, not *executed*. All four transports (HTTP push, poll/SSE, GCP Pub/Sub, bash exec) implement it; the four bespoke per-transport traits are deleted.
- **`ResonateRouter`** — maps an address's URI scheme to a registered worker and hands over the untouched address. Adding a transport is now a registration in `main.rs`, never a change to `core`.
- `src/types.rs` moves to `src/core/types.rs` and gains a typed `Message` enum (`Execute`/`Unblock`, untagged serde) replacing hand-built JSON.
- The `dispatch` free function and the 25 `op_*` functions become methods on `Server`.
- The bash exec worker becomes a protocol client: it acquires tasks through `ResonateServer` like any external worker, instead of poking storage directly. Its lease falls back to `tasks.lease_timeout`, overridable via the new optional `transports.bash_exec.lease_timeout`.
- The differential test's `enum Backend` is deleted — both implementations are driven through the same trait.

## Behavior changes

- **Address admission is looser.** `is_valid_address` is now "parses as a URI with a scheme" — deliberately deployment-independent, because the reference model has no workers and enabled transports must never change which requests a server accepts. Addresses that used to 400 at admission (`poll://group`, `gcps://project`, unknown schemes) are now accepted and fail at delivery, surfacing as a retry loop ending in promise timeout. Anything previously accepted is still accepted.
- **Startup is stricter.** `tasks.lease_timeout < 1` now fails config validation instead of silently 400ing every `task.acquire`.
- **Wire formats are unchanged and pinned by tests**, including the poll/SSE path's alphabetical key ordering (the struct→`Value`→string hop is kept, with a string-level test that `Value`-comparing tests cannot provide). Storage schemas untouched.

The last pre-merge commit fixes three defects found by adversarial review (SSE key ordering, the `lease_timeout` validation gap, and an overclaiming `ResonateServer` doc — envelope validation still lives in the HTTP adapter and is named as remaining work). It also adds a test refuting a review claim: undeliverable messages are not lost; `process_timeouts` re-inserts them until the promise times out.

## Known follow-ups

- Envelope validation (empty `kind`, non-object `data`, unsupported version) still lives in the HTTP adapter, so in-process and HTTP callers are not yet interchangeable for malformed input. Documented on the trait.
- Main's schedule-create `resonate:target` check (merged from #1128/#1129) exists in the server but not the oracle — an asymmetry inherited from main, worth reconciling given this PR's interchangeability goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)