### PR TITLE
One judgment on a promise: internal, external, runnable

### DIFF
--- a/crates/resonate-core/src/types.rs
+++ b/crates/resonate-core/src/types.rs
@@ -548,43 +548,53 @@ fn validate_task_suspend_data(data: &TaskSuspendData) -> Result<(), validator::V
     Ok(())
 }
 
-/// Who may be blocked on a promise. Derived from its tags, never stored.
+/// One judgment on a promise, three consequences: who may block on it, what
+/// runs it, and whether the machine owes its deadline as a write. Derived
+/// from its tags, never stored.
 ///
-/// `External` if any one of four things is true, and they are alternatives
-/// rather than a hierarchy:
+/// - `Internal` — nobody outside its own call graph; nothing runs it; NO
+///   armed timeout. Its deadline is a projection every read applies, never
+///   a write the machine owes.
+/// - `External` — anyone may await it; nothing runs it — a person, a
+///   webhook or the clock settles it; armed timeout. Reached by any of
+///   three tags, alternatives rather than a hierarchy:
+///   `resonate:scope = global` (the form the wire actually carries),
+///   `resonate:external = true` (the open-ended escape hatch), or
+///   `resonate:timer = true` (a sleep settles at its deadline, so there is
+///   something to await).
+/// - `Runnable` — anyone may await it, AND a worker is handed the
+///   execution. `resonate:target` present, which is the same condition as
+///   carrying a task — both directions hold, and the storage invariant
+///   `consistent_task_iff_targeted_promise` is the other half of it.
 ///
-/// - `resonate:scope = global` — the form the wire actually carries, and what
-///   makes a promise a caller wrote awaitable;
-/// - `resonate:external = true` — the open-ended escape hatch, for a kind
-///   nobody enumerated;
-/// - `resonate:target` present — a dispatch target implies anyone may await
-///   the result;
-/// - `resonate:timer = true` — a sleep, which settles at its deadline, so
-///   there is something to await.
+/// This was two axes for a while — `otype` of external or internal crossed
+/// with an `okind` of task or idle — and the pair carried a proof that
+/// their 2x2 was really a chain: target was a disjunct of external, so
+/// internal-plus-task named a cell no tag list could produce. Three values
+/// say that instead of proving it; the chain is the type, and the dead cell
+/// has nowhere to be written.
 ///
-/// Two things follow, and the second follows from the first: an external
-/// promise may be awaited, and an external promise is armed. The server owes
-/// an observation exactly where someone can be blocked, so this is one rule,
-/// not two. An internal promise is neither awaitable nor armed, and costs
-/// nothing.
+/// Doors ask [`OType::awaitable`], never name a constructor. A door written
+/// `otype == External` compiles and silently refuses every runnable promise
+/// — the ordinary case, a parent awaiting the child a worker runs.
 ///
 /// Nothing here gates settling, and nothing here decides the verdict a
 /// deadline produces — that is `is_timer` alone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OType {
-    External,
     Internal,
+    External,
+    Runnable,
 }
 
-/// What causes a promise to run. Derived from its tags, never stored.
-///
-/// `Task` exactly when a dispatch target is present, which is the same
-/// condition as carrying a task — both directions hold, and the storage
-/// invariant `consistent_task_iff_targeted_promise` is the other half of it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OKind {
-    Task,
-    Idle,
+impl OType {
+    /// Every value but `Internal`: who may register a callback or listener,
+    /// and equally whose deadline is armed. The server owes an observation
+    /// exactly where someone can be blocked, so awaitable-and-armed is one
+    /// rule, not two — an internal promise is neither, and costs nothing.
+    pub fn awaitable(self) -> bool {
+        self != OType::Internal
+    }
 }
 
 type Tags = std::collections::HashMap<String, String>;
@@ -600,9 +610,10 @@ pub fn is_timer(tags: &Tags) -> bool {
 }
 
 pub fn otype(tags: &Tags) -> OType {
-    if tag_is(tags, "resonate:scope", "global")
+    if tags.contains_key("resonate:target") {
+        OType::Runnable
+    } else if tag_is(tags, "resonate:scope", "global")
         || tag_is(tags, "resonate:external", "true")
-        || tags.contains_key("resonate:target")
         || is_timer(tags)
     {
         OType::External
@@ -611,17 +622,9 @@ pub fn otype(tags: &Tags) -> OType {
     }
 }
 
-pub fn okind(tags: &Tags) -> OKind {
-    if tags.contains_key("resonate:target") {
-        OKind::Task
-    } else {
-        OKind::Idle
-    }
-}
-
-/// `otype(tags) == External`, as a predicate — the awaitable-and-armed test.
-pub fn is_external(tags: &Tags) -> bool {
-    otype(tags) == OType::External
+/// `otype(tags).awaitable()`, as a predicate — the awaitable-and-armed test.
+pub fn is_awaitable(tags: &Tags) -> bool {
+    otype(tags).awaitable()
 }
 
 #[derive(Debug, Deserialize, Serialize, Validate)]
@@ -1145,15 +1148,18 @@ mod tests {
     }
 
     #[test]
-    fn a_promise_is_external_when_any_of_four_tags_says_something_else_settles_it() {
-        // `scope = global` is the form real SDK traffic carries; the other
-        // three are the escape hatch, a dispatch target, and a sleep.
-        assert_eq!(otype(&tag("resonate:scope", "global")), OType::External);
-        assert_eq!(otype(&tag("resonate:external", "true")), OType::External);
+    fn one_judgment_on_a_promise_internal_external_or_runnable() {
+        // Runnable exactly when a target is present — the same condition as
+        // carrying a task.
         assert_eq!(
             otype(&tag("resonate:target", "poll://any@w")),
-            OType::External
+            OType::Runnable
         );
+
+        // External by any of three tags: `scope = global` is the form real
+        // SDK traffic carries; the others are the escape hatch and a sleep.
+        assert_eq!(otype(&tag("resonate:scope", "global")), OType::External);
+        assert_eq!(otype(&tag("resonate:external", "true")), OType::External);
         assert_eq!(otype(&tag("resonate:timer", "true")), OType::External);
 
         assert_eq!(otype(&Tags::new()), OType::Internal);
@@ -1165,11 +1171,18 @@ mod tests {
     }
 
     #[test]
-    fn a_promise_runs_as_a_task_exactly_when_it_names_a_target() {
-        assert_eq!(okind(&tag("resonate:target", "poll://any@w")), OKind::Task);
-        assert_eq!(okind(&tag("resonate:scope", "global")), OKind::Idle);
-        assert_eq!(okind(&tag("resonate:timer", "true")), OKind::Idle);
-        assert_eq!(okind(&Tags::new()), OKind::Idle);
+    fn awaitable_and_armed_is_every_value_but_internal() {
+        // The door trap the axis exists to close: a door asking
+        // `otype == External` would refuse every runnable promise — the
+        // ordinary case, a parent awaiting the child a worker runs. Doors
+        // ask `awaitable`, and this is its whole truth table.
+        assert!(OType::Runnable.awaitable());
+        assert!(OType::External.awaitable());
+        assert!(!OType::Internal.awaitable());
+
+        assert!(is_awaitable(&tag("resonate:target", "poll://any@w")));
+        assert!(is_awaitable(&tag("resonate:timer", "true")));
+        assert!(!is_awaitable(&Tags::new()));
     }
 
     #[test]

--- a/crates/resonate-server-dbms/migrations/mysql/0001_initial.sql
+++ b/crates/resonate-server-dbms/migrations/mysql/0001_initial.sql
@@ -29,6 +29,14 @@ CREATE TABLE IF NOT EXISTS promises (
   parent_id VARCHAR(255) GENERATED ALWAYS AS (tags->>'$."resonate:parent"') STORED,
   branch_id VARCHAR(255) GENERATED ALWAYS AS (tags->>'$."resonate:branch"') STORED,
   is_timer BOOLEAN GENERATED ALWAYS AS (COALESCE(tags->>'$."resonate:timer"', '') = 'true') STORED NOT NULL,
+  -- `resonate_core::types::is_awaitable`, in SQL: every otype but internal.
+  -- Doors ask this, and the eager sweep is exactly this — awaitable and
+  -- armed are one rule, so an internal promise costs no timer.
+  awaitable BOOLEAN GENERATED ALWAYS AS (
+    COALESCE(tags->>'$."resonate:scope"', '') = 'global'
+    OR COALESCE(tags->>'$."resonate:external"', '') = 'true'
+    OR tags->>'$."resonate:target"' IS NOT NULL
+    OR COALESCE(tags->>'$."resonate:timer"', '') = 'true') STORED NOT NULL,
   timeout_at BIGINT NOT NULL,
   created_at BIGINT NOT NULL,
   settled_at BIGINT,

--- a/crates/resonate-server-dbms/migrations/postgres/0001_initial.sql
+++ b/crates/resonate-server-dbms/migrations/postgres/0001_initial.sql
@@ -76,10 +76,12 @@ CREATE TABLE IF NOT EXISTS promises (
   target        TEXT    GENERATED ALWAYS AS (tags->>'resonate:target') STORED,
   is_timer      BOOLEAN NOT NULL GENERATED ALWAYS AS (
                   COALESCE(tags->>'resonate:timer', '') = 'true') STORED,
-  -- `resonate_core::types::otype`, in SQL: who may be blocked on this. Four
-  -- alternatives, not a hierarchy — `scope = global` is the one the wire
-  -- actually carries, and the one that makes a caller's promise awaitable.
-  external      BOOLEAN NOT NULL GENERATED ALWAYS AS (
+  -- `resonate_core::types::is_awaitable`, in SQL: every otype but internal —
+  -- external by any of `scope = global` (the form the wire actually carries),
+  -- the escape hatch, or a timer; runnable by a target. Doors ask this, and
+  -- the eager sweep is exactly this: awaitable and armed are one rule, so an
+  -- internal promise costs no timer.
+  awaitable     BOOLEAN NOT NULL GENERATED ALWAYS AS (
                   COALESCE(tags->>'resonate:scope', '')       = 'global'
                   OR COALESCE(tags->>'resonate:external', '') = 'true'
                   OR tags->>'resonate:target' IS NOT NULL
@@ -129,9 +131,9 @@ CREATE TABLE IF NOT EXISTS promises (
 );
 
 -- The promise timeout sweep queue is NOT a column: promise_timeouts membership
--- is exactly (state = 'pending' AND target IS NOT NULL), given
--- `consistent_task_iff_targeted_promise`. A targetless promise has no task and
--- is never swept eagerly; it times out lazily on first touch (try_timeout).
+-- is exactly (state = 'pending' AND awaitable). An internal promise is never
+-- swept eagerly — its deadline is a projection every read applies
+-- (try_timeout), never a write the machine owes.
 CREATE INDEX IF NOT EXISTS idx_promises_timeout_at
   ON promises (timeout_at) WHERE state = 'pending';
 
@@ -311,8 +313,9 @@ ALTER TABLE promises ADD CONSTRAINT well_formed_promise_timer_not_targeted
   CHECK ((NOT (is_timer AND (target IS NOT NULL))));
 
 ALTER TABLE promises DROP CONSTRAINT IF EXISTS well_formed_promise_obligations_require_external;
-ALTER TABLE promises ADD CONSTRAINT well_formed_promise_obligations_require_external
-  CHECK ((external OR ((callbacks = '{}'::text[]) AND (listeners =
+ALTER TABLE promises DROP CONSTRAINT IF EXISTS well_formed_promise_obligations_require_awaitable;
+ALTER TABLE promises ADD CONSTRAINT well_formed_promise_obligations_require_awaitable
+  CHECK ((awaitable OR ((callbacks = '{}'::text[]) AND (listeners =
   '{}'::text[]))));
 
 ALTER TABLE promises DROP CONSTRAINT IF EXISTS well_formed_promise_awaiter_is_not_self;

--- a/crates/resonate-server-dbms/migrations/sqlite/0001_initial.sql
+++ b/crates/resonate-server-dbms/migrations/sqlite/0001_initial.sql
@@ -31,6 +31,14 @@ CREATE TABLE IF NOT EXISTS promises (
   parent_id TEXT GENERATED ALWAYS AS (json_extract(tags, '$.resonate:parent')) STORED,
   branch_id TEXT GENERATED ALWAYS AS (json_extract(tags, '$.resonate:branch')) STORED,
   is_timer BOOLEAN NOT NULL GENERATED ALWAYS AS (COALESCE(json_extract(tags, '$.resonate:timer'), '') = 'true') STORED,
+  -- `resonate_core::types::is_awaitable`, in SQL: every otype but internal.
+  -- Doors ask this, and the eager sweep is exactly this — awaitable and
+  -- armed are one rule, so an internal promise costs no timer.
+  awaitable BOOLEAN NOT NULL GENERATED ALWAYS AS (
+    COALESCE(json_extract(tags, '$.resonate:scope'), '') = 'global'
+    OR COALESCE(json_extract(tags, '$.resonate:external'), '') = 'true'
+    OR json_extract(tags, '$.resonate:target') IS NOT NULL
+    OR COALESCE(json_extract(tags, '$.resonate:timer'), '') = 'true') STORED,
   timeout_at BIGINT NOT NULL,
   created_at BIGINT NOT NULL,
   settled_at BIGINT,
@@ -52,9 +60,11 @@ CREATE INDEX IF NOT EXISTS idx_promises_timeout_at ON promises (timeout_at) WHER
 CREATE INDEX IF NOT EXISTS idx_promises_target ON promises (target) WHERE target IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_promises_branch_id ON promises (branch_id) WHERE branch_id IS NOT NULL;
 
--- `promise_timeouts` is gone: a pending promise past its timeout_at is
--- exactly the queue, and the partial index above is the same index the
--- table carried.
+-- `promise_timeouts` is gone: a pending, awaitable promise past its
+-- timeout_at is exactly the queue, and the partial index above is the same
+-- index the table carried. Internal promises never join it — their deadline
+-- is a projection every read applies (try_timeout), never a write the
+-- machine owes.
 CREATE INDEX IF NOT EXISTS idx_promises_retry_timeout_at ON promises (retry_timeout_at ASC, id ASC) WHERE retry_timeout_at IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_promises_lease_timeout_at ON promises (lease_timeout_at ASC, id ASC) WHERE lease_timeout_at IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_promises_pid ON promises (pid) WHERE pid IS NOT NULL;

--- a/crates/resonate-server-dbms/src/engine_mysql.rs
+++ b/crates/resonate-server-dbms/src/engine_mysql.rs
@@ -434,6 +434,7 @@ impl MysqlEngine {
                     settled_at,
                     already_timedout,
                     address,
+                    awaitable: resonate_core::types::is_awaitable(&r.tags),
                 })?;
                 if result.was_created {
                     tracing::info!(
@@ -597,7 +598,7 @@ impl MysqlEngine {
                         "Awaiter promise has no resonate:target tag",
                     ));
                 }
-                if !resonate_core::types::is_external(&p_awaited.tags) {
+                if !resonate_core::types::is_awaitable(&p_awaited.tags) {
                     tracing::debug!(awaited = %r.awaited, "Callback registration rejected: awaited is not awaitable");
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
@@ -661,7 +662,7 @@ impl MysqlEngine {
                 db.try_timeout(&[&r.awaited], now)?;
                 match db.promise_register_listener(&r.awaited, &r.address)? {
                     Some(promise) => {
-                        if !resonate_core::types::is_external(&promise.tags) {
+                        if !resonate_core::types::is_awaitable(&promise.tags) {
                             tracing::debug!(awaited = %r.awaited, "Listener registration rejected: awaited is not awaitable");
                             return Ok(ResponseEnvelope::error(
                                 kind_str.clone(),
@@ -1548,6 +1549,7 @@ impl MysqlEngine {
                             settled_at,
                             already_timedout,
                             address,
+                            awaitable: resonate_core::types::is_awaitable(&create_data.tags),
                         })?;
                         if !result.task_exists {
                             tracing::debug!(task_id = %r.id, fenced_action = "promise.create", "Task fence rejected: task not found");
@@ -2293,8 +2295,8 @@ impl<'a> MysqlDb<'a> {
         self.armed.borrow_mut().push(Scheduled { at, timeout });
     }
 
-    fn arm_promise_timeout(&self, promise_id: &str, timeout_at: i64, targeted: bool) {
-        if targeted {
+    fn arm_promise_timeout(&self, promise_id: &str, timeout_at: i64, awaitable: bool) {
+        if awaitable {
             self.arm(
                 timeout_at,
                 Timeout::PromiseTimeout {
@@ -2775,6 +2777,7 @@ impl MysqlDb<'_> {
             settled_at,
             already_timedout,
             address,
+            awaitable,
         } = *params;
         if id.len() > 255 {
             return Err(StorageError::InvalidInput(
@@ -2801,11 +2804,14 @@ impl MysqlDb<'_> {
 
         let was_created = res.rows_affected() > 0;
         if was_created {
-            // No promise timeout to write: `state = 'pending' AND target IS NOT
-            // NULL` is the queue, and the INSERT above already put the row in
+            // No promise timeout to write: `state = 'pending' AND awaitable`
+            // is the queue, and the INSERT above already put the row in
             // it. Creating the task is an UPDATE of that same row, and
             // `task_state IS NULL` is the guard `INSERT IGNORE INTO tasks`
             // used to be — a promise carries at most one task.
+            if !already_timedout {
+                self.arm_promise_timeout(id, timeout_at, awaitable);
+            }
             if let Some(addr) = address {
                 let task_state = if already_timedout {
                     "fulfilled"
@@ -2826,7 +2832,6 @@ impl MysqlDb<'_> {
                 )?;
 
                 if task_res.rows_affected() > 0 && !already_timedout {
-                    self.arm_promise_timeout(id, timeout_at, true);
                     self.arm_retry(id, created_at + trt);
                     self.emit(Outgoing::Execute {
                         address: addr.to_string(),
@@ -2928,7 +2933,7 @@ impl MysqlDb<'_> {
                 let tags: String = row.get("tags");
                 awaited_awaitable =
                     serde_json::from_str::<std::collections::HashMap<String, String>>(&tags)
-                        .map(|t| resonate_core::types::is_external(&t))
+                        .map(|t| resonate_core::types::is_awaitable(&t))
                         .unwrap_or(false);
             } else {
                 awaiter_state = Some(rstate);
@@ -3018,7 +3023,7 @@ impl MysqlDb<'_> {
             serde_json::from_str::<std::collections::HashMap<String, String>>(
                 &r.get::<String, _>("tags"),
             )
-            .map(|t| resonate_core::types::is_external(&t))
+            .map(|t| resonate_core::types::is_awaitable(&t))
             .unwrap_or(false)
         });
 
@@ -3167,7 +3172,7 @@ impl MysqlDb<'_> {
                 self.arm_promise_timeout(
                     promise_id,
                     timeout_at,
-                    promise.tags.contains_key("resonate:target"),
+                    resonate_core::types::is_awaitable(&promise.tags),
                 );
                 self.arm_lease(promise_id, pid, created_at + ttl);
             }
@@ -3275,6 +3280,7 @@ impl MysqlDb<'_> {
             settled_at,
             already_timedout,
             address,
+            awaitable,
         } = *params;
         let trt = self.task_retry_timeout;
 
@@ -3304,6 +3310,9 @@ impl MysqlDb<'_> {
             )?;
 
             if res.rows_affected() > 0 {
+                if !already_timedout {
+                    self.arm_promise_timeout(promise_id, timeout_at, awaitable);
+                }
                 if let Some(addr) = address {
                     let task_state = if already_timedout {
                         "fulfilled"
@@ -3323,7 +3332,6 @@ impl MysqlDb<'_> {
                         .execute(self.tx().as_mut()),
                     )?;
                     if task_res.rows_affected() > 0 && !already_timedout {
-                        self.arm_promise_timeout(promise_id, timeout_at, true);
                         self.arm_retry(promise_id, created_at + trt);
                         self.emit(Outgoing::Execute {
                             address: addr.to_string(),
@@ -3524,9 +3532,9 @@ impl MysqlDb<'_> {
             });
         }
 
-        // 4b. Count awaited promises that may not be awaited — the three tags
-        // of `resonate_core::types::is_external`, two of them already stored
-        // as generated columns.
+        // 4b. Count awaited promises that may not be awaited —
+        // `resonate_core::types::is_awaitable`, stored as the `awaitable`
+        // generated column.
         let non_awaitable_count = if awaited_ids.is_empty() {
             0i32
         } else {
@@ -3537,9 +3545,7 @@ impl MysqlDb<'_> {
                 .join(", ");
             let sql = format!(
                 "SELECT COUNT(*) AS cnt FROM promises WHERE id IN ({}) \
-                 AND NOT (COALESCE(tags->>'$.\"resonate:scope\"', '') = 'global' \
-                          OR COALESCE(tags->>'$.\"resonate:external\"', '') = 'true' \
-                          OR target IS NOT NULL OR is_timer)",
+                 AND NOT awaitable",
                 placeholders
             );
             let mut q = sqlx::query(&sql);
@@ -4000,7 +4006,7 @@ impl MysqlDb<'_> {
                 // untyped NULL takes the one the third branch supplies.
                 "SELECT deadline, kind, id, pid FROM (
                      SELECT timeout_at AS deadline, 0 AS kind, id AS id, NULL AS pid
-                       FROM promises WHERE state = 'pending' AND target IS NOT NULL
+                       FROM promises WHERE state = 'pending' AND awaitable
                      UNION ALL
                      SELECT retry_timeout_at, 1, id, NULL
                        FROM promises WHERE task_state = 'pending' AND retry_timeout_at IS NOT NULL
@@ -4139,7 +4145,14 @@ impl MysqlDb<'_> {
 
         if promise_res.rows_affected() > 0 {
             // 6a is gone with `promise_timeouts`: the INSERT above already put
-            // a pending, targeted promise on the queue.
+            // a pending, awaitable promise on the queue.
+            if !already_timedout {
+                self.arm_promise_timeout(
+                    &computed_promise_id,
+                    computed_timeout_at,
+                    resonate_core::types::is_awaitable(promise_tags),
+                );
+            }
             if already_timedout {
                 // Promise is immediately settled — create fulfilled task if resonate:target is set
                 if address.is_some() {
@@ -4164,7 +4177,6 @@ impl MysqlDb<'_> {
                     .execute(self.tx().as_mut()),
                 )?;
                 if task_res.rows_affected() > 0 {
-                    self.arm_promise_timeout(&computed_promise_id, computed_timeout_at, true);
                     self.arm_retry(&computed_promise_id, time + trt);
                     self.emit(Outgoing::Execute {
                         address: addr.to_string(),
@@ -4212,19 +4224,20 @@ impl MysqlDb<'_> {
             Some(_) => None,
         };
 
-        // Statement 1: Expire all pending promises with timeout_at <= time
-        // (with resonate:target).
+        // Statement 1: Expire all awaitable pending promises with
+        // timeout_at <= time.
         //
-        // `state = 'pending' AND target IS NOT NULL` is the whole of what
+        // `state = 'pending' AND awaitable` is the whole of what
         // `promise_timeouts` held: rows entered on create and left on settle,
-        // and only a targeted promise was ever swept eagerly. Untargeted ones
-        // still time out lazily, through `try_timeout`.
+        // and only an awaitable promise is ever swept eagerly — a deadline is
+        // owed as a write exactly where someone can be waiting to observe it.
+        // Internal promises still time out lazily, through `try_timeout`.
         let expired_rows = match selected("promise") {
             None => Vec::new(),
             Some(id) => rt_block_on(
                 sqlx::query(
                     "SELECT id FROM promises
-                     WHERE state = 'pending' AND target IS NOT NULL AND timeout_at <= ?
+                     WHERE state = 'pending' AND awaitable AND timeout_at <= ?
                        AND (? IS NULL OR id = ?)
                      ORDER BY id",
                 )
@@ -4385,7 +4398,7 @@ impl MysqlDb<'_> {
         let pt_rows = rt_block_on(
             sqlx::query(
                 "SELECT id, timeout_at FROM promises
-                 WHERE state = 'pending' AND target IS NOT NULL ORDER BY id",
+                 WHERE state = 'pending' AND awaitable ORDER BY id",
             )
             .fetch_all(self.tx().as_mut()),
         )?;

--- a/crates/resonate-server-dbms/src/engine_postgres.rs
+++ b/crates/resonate-server-dbms/src/engine_postgres.rs
@@ -500,6 +500,7 @@ impl PostgresEngine {
                     settled_at,
                     already_timedout,
                     address,
+                    awaitable: resonate_core::types::is_awaitable(&r.tags),
                 })?;
                 if result.was_created {
                     tracing::info!(
@@ -663,7 +664,7 @@ impl PostgresEngine {
                         "Awaiter promise has no resonate:target tag",
                     ));
                 }
-                if !resonate_core::types::is_external(&p_awaited.tags) {
+                if !resonate_core::types::is_awaitable(&p_awaited.tags) {
                     tracing::debug!(awaited = %r.awaited, "Callback registration rejected: awaited is not awaitable");
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
@@ -727,7 +728,7 @@ impl PostgresEngine {
                 db.try_timeout(&[&r.awaited], now)?;
                 match db.promise_register_listener(&r.awaited, &r.address)? {
                     Some(promise) => {
-                        if !resonate_core::types::is_external(&promise.tags) {
+                        if !resonate_core::types::is_awaitable(&promise.tags) {
                             tracing::debug!(awaited = %r.awaited, "Listener registration rejected: awaited is not awaitable");
                             return Ok(ResponseEnvelope::error(
                                 kind_str.clone(),
@@ -1614,6 +1615,7 @@ impl PostgresEngine {
                             settled_at,
                             already_timedout,
                             address,
+                            awaitable: resonate_core::types::is_awaitable(&create_data.tags),
                         })?;
                         if !result.task_exists {
                             tracing::debug!(task_id = %r.id, fenced_action = "promise.create", "Task fence rejected: task not found");
@@ -2345,8 +2347,8 @@ impl<'a> PostgresDb<'a> {
         self.armed.borrow_mut().push(Scheduled { at, timeout });
     }
 
-    fn arm_promise_timeout(&self, promise_id: &str, timeout_at: i64, targeted: bool) {
-        if targeted {
+    fn arm_promise_timeout(&self, promise_id: &str, timeout_at: i64, awaitable: bool) {
+        if awaitable {
             self.arm(
                 timeout_at,
                 Timeout::PromiseTimeout {
@@ -2845,6 +2847,7 @@ impl PostgresDb<'_> {
             settled_at,
             already_timedout,
             address,
+            awaitable,
         } = *params;
         let trt = self.task_retry_timeout;
 
@@ -2887,7 +2890,7 @@ impl PostgresDb<'_> {
         self.absorb_and_arm_retries(&rows[0], created_at + trt);
         let was_created: bool = rows[0].get("was_created");
         if was_created && !already_timedout {
-            self.arm_promise_timeout(id, timeout_at, address.is_some());
+            self.arm_promise_timeout(id, timeout_at, awaitable);
         }
         Ok(PromiseCreateResult {
             was_created,
@@ -2984,7 +2987,7 @@ impl PostgresDb<'_> {
             -- the direct resume, which would wake the awaiter for a
             -- registration that never happened.
             awaitable AS (
-              SELECT EXISTS (SELECT 1 FROM awaited WHERE external) AS ok
+              SELECT EXISTS (SELECT 1 FROM awaited WHERE awaitable) AS ok
             ),
             -- link: awaited still pending and awaitable, awaiter targeted and pending
             linked AS (
@@ -3078,14 +3081,14 @@ impl PostgresDb<'_> {
             WITH locked_promise AS (
               SELECT * FROM promises WHERE id = $1 FOR UPDATE
             ),
-            -- A listener is an obligation, and `external` is where the server
+            -- A listener is an obligation, and `awaitable` is where the server
             -- owes an observation. Refused by the caller with a 422, so nothing
             -- is written for a promise that may not be awaited.
             linked AS (
               UPDATE promises p SET listeners = p.listeners || $2
               WHERE p.id = $1
                 AND NOT (p.listeners @> ARRAY[$2])
-                AND EXISTS (SELECT 1 FROM locked_promise WHERE state = 'pending' AND external)
+                AND EXISTS (SELECT 1 FROM locked_promise WHERE state = 'pending' AND awaitable)
               RETURNING p.id
             )
             SELECT {cols} FROM locked_promise",
@@ -3200,7 +3203,7 @@ impl PostgresDb<'_> {
                 self.arm_promise_timeout(
                     promise_id,
                     timeout_at,
-                    promise.tags.contains_key("resonate:target"),
+                    resonate_core::types::is_awaitable(&promise.tags),
                 );
                 self.arm_lease(promise_id, pid, created_at + ttl);
             }
@@ -3296,6 +3299,7 @@ impl PostgresDb<'_> {
             settled_at,
             already_timedout,
             address,
+            awaitable,
         } = *params;
         let trt = self.task_retry_timeout;
 
@@ -3333,6 +3337,8 @@ impl PostgresDb<'_> {
             SELECT
               EXISTS (SELECT 1 FROM fence_check) AS task_exists,
               (SELECT ok FROM fence_ok) AS fence_ok,
+              EXISTS (SELECT 1 FROM inserted_or_skipped_promise p
+                      WHERE p.state = 'pending') AS promise_pending_created,
               {cols}, {messages}
             FROM (SELECT 1) AS dummy
             LEFT JOIN result r ON true
@@ -3347,14 +3353,15 @@ impl PostgresDb<'_> {
             return Err(StorageError::Serialization);
         }
         let row = &rows[0];
-        let armed = self.absorb_and_arm_retries(row, created_at + trt);
+        self.absorb_and_arm_retries(row, created_at + trt);
         let promise_id_val: Option<String> = row.get("id");
-        // A promise joins the eager sweep under exactly the condition its task
-        // gets a retry deadline: newly created, targeted, not already timed
-        // out. So the retries this statement armed name the promises too, and
-        // there is no separate `was_created` to read.
-        for id in &armed {
-            self.arm_promise_timeout(id, timeout_at, true);
+        // A promise joins the eager sweep when this statement created it
+        // still pending — the CTE says so directly, because "got a retry
+        // deadline" no longer names the same set: an awaitable, untargeted
+        // promise is armed with no retry to ride on.
+        let promise_pending_created: bool = row.get("promise_pending_created");
+        if promise_pending_created {
+            self.arm_promise_timeout(promise_id, timeout_at, awaitable);
         }
         Ok(TaskFenceResult {
             task_exists: row.get("task_exists"),
@@ -3515,17 +3522,17 @@ impl PostgresDb<'_> {
               SELECT EXISTS (SELECT 1 FROM me WHERE task_version = $2 AND task_state = 'acquired') AS ok
             ),
             awaited AS (
-              SELECT id, state, external
+              SELECT id, state, awaitable
               FROM promises WHERE id = ANY($3) AND (SELECT ok FROM matched)
             ),
             missing AS (
               SELECT (COALESCE(array_length($3::text[], 1), 0) - COUNT(*)::INT) AS cnt FROM awaited
             ),
-            -- `external` is the generated column of the same three tags as
-            -- `resonate_core::types::is_external`. A promise nothing outside
+            -- `awaitable` is the generated column of the same four tags as
+            -- `resonate_core::types::is_awaitable`. A promise nothing outside
             -- its own execution can settle may not be awaited.
             non_awaitable AS (
-              SELECT COUNT(*)::INT AS cnt FROM awaited WHERE NOT external
+              SELECT COUNT(*)::INT AS cnt FROM awaited WHERE NOT awaitable
             ),
             can_suspend AS (
               SELECT 1 WHERE (SELECT ok FROM matched)
@@ -3925,7 +3932,7 @@ impl PostgresDb<'_> {
             sqlx::query(
                 "SELECT deadline, kind, id, pid FROM (
                      SELECT timeout_at AS deadline, 'promise' AS kind, id AS id, NULL::text AS pid
-                       FROM promises WHERE state = 'pending' AND target IS NOT NULL
+                       FROM promises WHERE state = 'pending' AND awaitable
                      UNION ALL
                      SELECT retry_timeout_at, 'retry', id, NULL
                        FROM promises WHERE task_state = 'pending' AND retry_timeout_at IS NOT NULL
@@ -4026,6 +4033,8 @@ impl PostgresDb<'_> {
             )
             SELECT id, cron, promise_id, promise_timeout, NULLIF(promise_param_headers, '{{}}'::jsonb)::text AS promise_param_headers,
                    promise_param_data, promise_tags::text, created_at, next_run_at, last_run_at,
+                   EXISTS (SELECT 1 FROM inserted_or_skipped_promise p
+                           WHERE p.state = 'pending') AS promise_pending_created,
                    {messages}
             FROM updated_schedule
         ", messages = emitted_json(&["emit_new"])))
@@ -4035,13 +4044,24 @@ impl PostgresDb<'_> {
         if rows.is_empty() {
             return Ok(None);
         }
-        let armed = self.absorb_and_arm_retries(&rows[0], time + trt);
+        self.absorb_and_arm_retries(&rows[0], time + trt);
         // The schedule advanced, so its own deadline moved. The promise this
-        // firing created has one too, if it is still pending and targeted —
-        // which is exactly when a retry deadline was armed for it.
+        // firing created has one too, if it is still pending and awaitable —
+        // asked of the CTE directly, because "got a retry deadline" no longer
+        // names the same set: a cron that mints timers arms with no retry to
+        // ride on.
         let schedule = row_to_schedule(&rows[0]);
-        for id in &armed {
-            self.arm_promise_timeout(id, fired_at + schedule.promise_timeout, true);
+        let promise_pending_created: bool = rows[0].get("promise_pending_created");
+        if promise_pending_created {
+            let computed_promise_id = schedule
+                .promise_id
+                .replace("{{.id}}", schedule_id)
+                .replace("{{.timestamp}}", &fired_at.to_string());
+            self.arm_promise_timeout(
+                &computed_promise_id,
+                fired_at + schedule.promise_timeout,
+                resonate_core::types::is_awaitable(promise_tags),
+            );
         }
         self.arm(
             schedule.next_run_at,
@@ -4090,12 +4110,14 @@ impl PostgresDb<'_> {
 
         // Statement 1: expired promises.
         //
-        // `state = 'pending' AND target IS NOT NULL` is the whole of what
+        // `state = 'pending' AND awaitable` is the whole of what
         // promise_timeouts held: rows enter on create and leave on settle, and
-        // only targeted promises are ever swept eagerly.
+        // only awaitable promises are ever swept eagerly — a deadline is owed
+        // as a write exactly where someone can be waiting to observe it.
+        // Internal promises still time out lazily, through `try_timeout`.
         if let Some(id) = selected("promise") {
             let sql = expire_batch_sql(
-                "state = 'pending' AND target IS NOT NULL AND timeout_at <= $1
+                "state = 'pending' AND awaitable AND timeout_at <= $1
                  AND ($2::text IS NULL OR id = $2)",
                 "$1",
                 trt,
@@ -4196,7 +4218,7 @@ impl PostgresDb<'_> {
         let pt_rows = rt_block_on(
             sqlx::query(
                 "SELECT id, timeout_at FROM promises
-                 WHERE state = 'pending' AND target IS NOT NULL ORDER BY id",
+                 WHERE state = 'pending' AND awaitable ORDER BY id",
             )
             .fetch_all(self.tx().as_mut()),
         )?;

--- a/crates/resonate-server-dbms/src/engine_sqlite.rs
+++ b/crates/resonate-server-dbms/src/engine_sqlite.rs
@@ -396,6 +396,7 @@ impl SqliteEngine {
                     settled_at,
                     already_timedout,
                     address,
+                    awaitable: resonate_core::types::is_awaitable(&r.tags),
                 })?;
                 if result.was_created {
                     tracing::info!(
@@ -559,7 +560,7 @@ impl SqliteEngine {
                         "Awaiter promise has no resonate:target tag",
                     ));
                 }
-                if !resonate_core::types::is_external(&p_awaited.tags) {
+                if !resonate_core::types::is_awaitable(&p_awaited.tags) {
                     tracing::debug!(awaited = %r.awaited, "Callback registration rejected: awaited is not awaitable");
                     return Ok(ResponseEnvelope::error(
                         kind_str.clone(),
@@ -623,7 +624,7 @@ impl SqliteEngine {
                 db.try_timeout(&[&r.awaited], now)?;
                 match db.promise_register_listener(&r.awaited, &r.address)? {
                     Some(promise) => {
-                        if !resonate_core::types::is_external(&promise.tags) {
+                        if !resonate_core::types::is_awaitable(&promise.tags) {
                             tracing::debug!(awaited = %r.awaited, "Listener registration rejected: awaited is not awaitable");
                             return Ok(ResponseEnvelope::error(
                                 kind_str.clone(),
@@ -1510,6 +1511,7 @@ impl SqliteEngine {
                             settled_at,
                             already_timedout,
                             address,
+                            awaitable: resonate_core::types::is_awaitable(&create_data.tags),
                         })?;
                         if !result.task_exists {
                             tracing::debug!(task_id = %r.id, fenced_action = "promise.create", "Task fence rejected: task not found");
@@ -2252,11 +2254,13 @@ impl SqliteDb<'_> {
         self.armed.borrow_mut().push(Scheduled { at, timeout });
     }
 
-    /// A promise joins the eager sweep only when it is targeted — the queue is
-    /// `state = 'pending' AND target IS NOT NULL`, so an untargeted promise
-    /// times out lazily through `try_timeout` and has no deadline to announce.
-    fn arm_promise_timeout(&self, promise_id: &str, timeout_at: i64, targeted: bool) {
-        if targeted {
+    /// A promise joins the eager sweep only when it is awaitable — the queue
+    /// is `state = 'pending' AND awaitable`, because a deadline is owed as a
+    /// write exactly where someone can be waiting to observe it. An internal
+    /// promise times out lazily through `try_timeout` and has no deadline to
+    /// announce.
+    fn arm_promise_timeout(&self, promise_id: &str, timeout_at: i64, awaitable: bool) {
+        if awaitable {
             self.arm(
                 timeout_at,
                 Timeout::PromiseTimeout {
@@ -2578,6 +2582,7 @@ impl<'a> SqliteDb<'a> {
             settled_at,
             already_timedout,
             address,
+            awaitable,
         } = *params;
         // Idempotent insert
         let inserted = self.conn.execute(
@@ -2592,7 +2597,7 @@ impl<'a> SqliteDb<'a> {
             // inserted, and `task_state IS NULL` is the guard that used to be
             // `INSERT OR IGNORE INTO tasks`: a promise carries at most one task,
             // and only the first writer gets to install it. No promise timeout
-            // is written either way — `state = 'pending' AND target IS NOT NULL`
+            // is written either way — `state = 'pending' AND awaitable`
             // is the queue, and the INSERT above already put the row in it.
             if already_timedout {
                 // Already timed out — create fulfilled task if resonate:target
@@ -2603,21 +2608,23 @@ impl<'a> SqliteDb<'a> {
                         params![id],
                     )?;
                 }
-            } else if let Some(addr) = address {
-                self.arm_promise_timeout(id, timeout_at, true);
-                // TaskInfraCreated
-                let created = self.conn.execute(
-                    "UPDATE promises SET task_state = 'pending', task_version = 0, retry_timeout_at = ?2
-                     WHERE id = ?1 AND task_state IS NULL",
-                    params![id, created_at + self.task_retry_timeout],
-                )? > 0;
-                if created {
-                    self.arm_retry(id, created_at + self.task_retry_timeout);
-                    self.emit(Outgoing::Execute {
-                        address: addr.to_string(),
-                        task_id: id.to_string(),
-                        version: 0,
-                    });
+            } else {
+                self.arm_promise_timeout(id, timeout_at, awaitable);
+                if let Some(addr) = address {
+                    // TaskInfraCreated
+                    let created = self.conn.execute(
+                        "UPDATE promises SET task_state = 'pending', task_version = 0, retry_timeout_at = ?2
+                         WHERE id = ?1 AND task_state IS NULL",
+                        params![id, created_at + self.task_retry_timeout],
+                    )? > 0;
+                    if created {
+                        self.arm_retry(id, created_at + self.task_retry_timeout);
+                        self.emit(Outgoing::Execute {
+                            address: addr.to_string(),
+                            task_id: id.to_string(),
+                            version: 0,
+                        });
+                    }
                 }
             }
         }
@@ -2667,7 +2674,7 @@ impl<'a> SqliteDb<'a> {
         // resume, which would otherwise wake the awaiter for a registration
         // that never happened.
         if let Some(ref pa) = awaited {
-            if !resonate_core::types::is_external(&pa.tags) {
+            if !resonate_core::types::is_awaitable(&pa.tags) {
                 return Ok(RegisterCallbackResult { awaited, awaiter });
             }
         }
@@ -2725,7 +2732,7 @@ impl<'a> SqliteDb<'a> {
             // A listener is an obligation, and the server owes an observation
             // only where someone can be blocked. Refused by the caller with a
             // 422, so nothing is written here.
-            if p.state == PromiseState::Pending && resonate_core::types::is_external(&p.tags) {
+            if p.state == PromiseState::Pending && resonate_core::types::is_awaitable(&p.tags) {
                 self.conn.execute(
                     "INSERT OR IGNORE INTO listeners (promise_id, address) VALUES (?1, ?2)",
                     params![awaited_id, address],
@@ -2844,7 +2851,7 @@ impl<'a> SqliteDb<'a> {
                     self.arm_promise_timeout(
                         promise_id,
                         timeout_at,
-                        promise.tags.contains_key("resonate:target"),
+                        resonate_core::types::is_awaitable(&promise.tags),
                     );
                     self.arm_lease(promise_id, pid, created_at + ttl);
                 }
@@ -2931,6 +2938,7 @@ impl<'a> SqliteDb<'a> {
             settled_at,
             already_timedout,
             address,
+            awaitable,
         } = *params;
         // Fence check
         let task = self.task_get(task_id)?;
@@ -2957,6 +2965,7 @@ impl<'a> SqliteDb<'a> {
             settled_at,
             already_timedout,
             address,
+            awaitable,
         })?;
 
         Ok(TaskFenceResult {
@@ -3067,7 +3076,7 @@ impl<'a> SqliteDb<'a> {
         for aid in awaited_ids {
             if let Some(p) = self.promise_get(aid)? {
                 found_count += 1;
-                if !resonate_core::types::is_external(&p.tags) {
+                if !resonate_core::types::is_awaitable(&p.tags) {
                     non_awaitable_count += 1;
                 }
                 if p.state != PromiseState::Pending {
@@ -3404,7 +3413,7 @@ impl<'a> SqliteDb<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT deadline, kind, id, pid FROM (
                  SELECT timeout_at AS deadline, 'promise' AS kind, id AS id, NULL AS pid
-                   FROM promises WHERE state = 'pending' AND target IS NOT NULL
+                   FROM promises WHERE state = 'pending' AND awaitable
                  UNION ALL
                  SELECT retry_timeout_at, 'retry', id, NULL
                    FROM promises WHERE task_state = 'pending' AND retry_timeout_at IS NOT NULL
@@ -3515,7 +3524,7 @@ impl<'a> SqliteDb<'a> {
 
         if promise_inserted {
             // Step 6 is gone with `promise_timeouts`; the INSERT above already
-            // put a pending, targeted promise on the queue.
+            // put a pending, awaitable promise on the queue.
             if already_timedout {
                 // Promise is immediately settled — create fulfilled task if resonate:target is set
                 if address.is_some() {
@@ -3525,21 +3534,27 @@ impl<'a> SqliteDb<'a> {
                         params![promise_id],
                     )?;
                 }
-            } else if let Some(addr) = &address {
-                // Step 7: Create task infrastructure if resonate:target is set
-                self.arm_promise_timeout(&promise_id, promise_timeout_at, true);
-                let created = self.conn.execute(
-                    "UPDATE promises SET task_state = 'pending', task_version = 0, retry_timeout_at = ?2
-                     WHERE id = ?1 AND task_state IS NULL",
-                    params![promise_id, time + self.task_retry_timeout],
-                )? > 0;
-                if created {
-                    self.arm_retry(&promise_id, time + self.task_retry_timeout);
-                    self.emit(Outgoing::Execute {
-                        address: addr.clone(),
-                        task_id: promise_id.clone(),
-                        version: 0,
-                    });
+            } else {
+                self.arm_promise_timeout(
+                    &promise_id,
+                    promise_timeout_at,
+                    resonate_core::types::is_awaitable(promise_tags),
+                );
+                if let Some(addr) = &address {
+                    // Step 7: Create task infrastructure if resonate:target is set
+                    let created = self.conn.execute(
+                        "UPDATE promises SET task_state = 'pending', task_version = 0, retry_timeout_at = ?2
+                         WHERE id = ?1 AND task_state IS NULL",
+                        params![promise_id, time + self.task_retry_timeout],
+                    )? > 0;
+                    if created {
+                        self.arm_retry(&promise_id, time + self.task_retry_timeout);
+                        self.emit(Outgoing::Execute {
+                            address: addr.clone(),
+                            task_id: promise_id.clone(),
+                            version: 0,
+                        });
+                    }
                 }
             }
         }
@@ -3597,16 +3612,17 @@ impl<'a> SqliteDb<'a> {
 
         // Statement 1: Process expired promise timeouts.
         //
-        // `state = 'pending' AND target IS NOT NULL` is the whole of what
+        // `state = 'pending' AND awaitable` is the whole of what
         // `promise_timeouts` held: rows entered on create and left on settle,
-        // and only a targeted promise was ever swept eagerly. Untargeted ones
-        // still time out lazily, through `try_timeout`.
+        // and only an awaitable promise is ever swept eagerly — a deadline is
+        // owed as a write exactly where someone can be waiting to observe it.
+        // Internal promises still time out lazily, through `try_timeout`.
         let expired_ids: Vec<String> = match selected("promise") {
             None => Vec::new(),
             Some(id) => {
                 let mut stmt = self.conn.prepare(
                     "SELECT id FROM promises
-                     WHERE state = 'pending' AND target IS NOT NULL AND timeout_at <= ?1
+                     WHERE state = 'pending' AND awaitable AND timeout_at <= ?1
                        AND (?2 IS NULL OR id = ?2)
                      ORDER BY id",
                 )?;
@@ -3728,7 +3744,7 @@ impl<'a> SqliteDb<'a> {
         // predicates are the membership rules the deleted tables carried.
         let mut stmt = conn.prepare(
             "SELECT id, timeout_at FROM promises
-             WHERE state = 'pending' AND target IS NOT NULL ORDER BY id",
+             WHERE state = 'pending' AND awaitable ORDER BY id",
         )?;
         let promise_timeouts: Vec<SnapshotPromiseTimeout> = {
             let mut rows = stmt.query([])?;
@@ -3916,12 +3932,12 @@ fn row_to_schedule(row: &rusqlite::Row) -> rusqlite::Result<ScheduleRecord> {
 //                     other — which is why fulfilling a task, dropping its
 //                     timeout and clearing its lease are one UPDATE here.
 //
-//   promise_timeouts  Gone. The queue is `state = 'pending' AND target IS NOT
-//                     NULL`, which is what rows entering on create and leaving
+//   promise_timeouts  Gone. The queue is `state = 'pending' AND awaitable`,
+//                     which is what rows entering on create and leaving
 //                     on settle amounted to; idx_promises_timeout_at is the
-//                     index the table carried. Untargeted promises were never
-//                     swept eagerly and still are not — they time out lazily,
-//                     through try_timeout.
+//                     index the table carried. Internal promises are never
+//                     swept eagerly — their deadline is a projection every
+//                     read applies, through try_timeout.
 //
 //   schedule_timeouts Gone: `next_run_at` already is the queue, and
 //                     process_schedule_timeout's idempotency guard reads the

--- a/crates/resonate-server-dbms/src/lib.rs
+++ b/crates/resonate-server-dbms/src/lib.rs
@@ -116,7 +116,7 @@ pub struct TaskSuspendResult {
     pub was_suspended: bool,
     pub missing_count: i32,
     /// Awaited promises that exist but may not be awaited — see
-    /// `resonate_core::types::is_external`. Refused with the same 422 as a
+    /// `resonate_core::types::is_awaitable`. Refused with the same 422 as a
     /// missing one, and counted apart only so the message can say which.
     pub non_awaitable_count: i32,
 }
@@ -157,6 +157,10 @@ pub struct PromiseCreateParams<'a> {
     pub settled_at: Option<i64>,
     pub already_timedout: bool,
     pub address: Option<&'a str>,
+    /// `resonate_core::types::is_awaitable`, computed where the tags are
+    /// still typed. Decides whether the deadline is armed: awaitable and
+    /// armed are one rule, so an internal promise costs no timer.
+    pub awaitable: bool,
 }
 
 pub struct PromiseSettleParams<'a> {
@@ -202,6 +206,8 @@ pub struct TaskFenceCreateParams<'a> {
     pub settled_at: Option<i64>,
     pub already_timedout: bool,
     pub address: Option<&'a str>,
+    /// See [`PromiseCreateParams::awaitable`].
+    pub awaitable: bool,
 }
 
 pub struct TaskFenceSettleParams<'a> {

--- a/crates/resonate-server-dbms/src/oracle.rs
+++ b/crates/resonate-server-dbms/src/oracle.rs
@@ -213,7 +213,7 @@ impl Oracle {
 
         for pt in &self.p_timeouts {
             if self.promises.get(&pt.id).is_some_and(|p| {
-                p.state == PromiseState::Pending && p.tags.contains_key("resonate:target")
+                p.state == PromiseState::Pending && resonate_core::types::is_awaitable(&p.tags)
             }) {
                 out.push(Scheduled {
                     at: pt.timeout,
@@ -417,7 +417,7 @@ impl Oracle {
                 );
             }
         } else {
-            if addr.is_some() {
+            if resonate_core::types::is_awaitable(&r.tags) {
                 self.set_p_timeout(&r.id, r.timeout_at);
             }
             if let Some(ref addr) = addr {
@@ -548,7 +548,7 @@ impl Oracle {
                 "Awaiter promise has no resonate:target tag",
             );
         }
-        if !resonate_core::types::is_external(&awaited_record.tags) {
+        if !resonate_core::types::is_awaitable(&awaited_record.tags) {
             return ResponseEnvelope::error(
                 req.kind.clone(),
                 req.head.corr_id.clone(),
@@ -640,7 +640,7 @@ impl Oracle {
             Some(p) => {
                 // A listener is an obligation, and the server owes an
                 // observation only where someone can be blocked.
-                if !resonate_core::types::is_external(&p.tags) {
+                if !resonate_core::types::is_awaitable(&p.tags) {
                     return ResponseEnvelope::error(
                         req.kind.clone(),
                         req.head.corr_id.clone(),
@@ -1178,7 +1178,7 @@ impl Oracle {
             let awaitable = self
                 .promises
                 .get(&action.data.awaited)
-                .is_some_and(|p| resonate_core::types::is_external(&p.tags));
+                .is_some_and(|p| resonate_core::types::is_awaitable(&p.tags));
             if !awaitable {
                 return ResponseEnvelope::error(
                     req.kind.clone(),
@@ -1337,7 +1337,7 @@ impl Oracle {
                             );
                         }
                     } else {
-                        if addr.is_some() {
+                        if resonate_core::types::is_awaitable(&create_data.tags) {
                             self.set_p_timeout(&create_data.id, create_data.timeout_at);
                         }
                         if let Some(ref a) = addr {
@@ -1947,9 +1947,9 @@ impl Oracle {
             }
         }
 
-        // Collect expired promise timeouts — after fix 1, p_timeouts only contains
-        // promises with resonate:target, and del_p_timeout is always called on settlement
-        // so all entries here are guaranteed to be Pending with a target.
+        // Collect expired promise timeouts — p_timeouts only contains
+        // awaitable promises, and del_p_timeout is always called on settlement
+        // so all entries here are guaranteed to be Pending and awaitable.
         let expired_promise_ids: Vec<String> = self
             .p_timeouts
             .iter()
@@ -2129,7 +2129,7 @@ impl Oracle {
                             );
                         }
                     } else {
-                        if addr.is_some() {
+                        if resonate_core::types::is_awaitable(&tags) {
                             self.set_p_timeout(&promise_id, timeout_at);
                         }
                         if let Some(ref a) = addr {
@@ -2521,13 +2521,13 @@ impl Oracle {
     }
 
     /// Pending promises that may be awaited — see
-    /// `resonate_core::types::is_external`. The generator needs these apart
+    /// `resonate_core::types::is_awaitable`. The generator needs these apart
     /// from `pending_promise_ids`, or every callback it plans is refused.
-    pub fn external_pending_promise_ids(&self) -> Vec<String> {
+    pub fn awaitable_pending_promise_ids(&self) -> Vec<String> {
         self.promises
             .iter()
             .filter(|(_, p)| {
-                p.state == PromiseState::Pending && resonate_core::types::is_external(&p.tags)
+                p.state == PromiseState::Pending && resonate_core::types::is_awaitable(&p.tags)
             })
             .map(|(id, _)| id.clone())
             .collect()

--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -1075,10 +1075,10 @@ fn gen_promise_create(rng: &mut fastrand::Rng, oracle: &Oracle, now: i64) -> Req
 /// Mostly awaitable, so the registration paths are actually walked; one time
 /// in four whatever is pending, so the 422 stays covered too.
 fn pick_awaited(rng: &mut fastrand::Rng, oracle: &Oracle, awaiter: &str) -> String {
-    let prefer_external = rng.u32(0..4) != 0;
-    if prefer_external {
-        let external = oracle.external_pending_promise_ids();
-        if let Some(id) = external.iter().find(|p| p.as_str() != awaiter) {
+    let prefer_awaitable = rng.u32(0..4) != 0;
+    if prefer_awaitable {
+        let awaitable = oracle.awaitable_pending_promise_ids();
+        if let Some(id) = awaitable.iter().find(|p| p.as_str() != awaiter) {
             return id.clone();
         }
     }


### PR DESCRIPTION
## What

Replaces the two-axis classification (`OType::{External, Internal}` × `OKind::{Task, Idle}`) with the specification's single three-valued judgment, and moves the eager-timeout rule onto that axis:

| otype | who may await | who runs it | armed timeout |
|---|---|---|---|
| `internal` | nobody outside its own call graph | nothing | **no** — deadline is a projection every read applies (`try_timeout`) |
| `external` | anyone | nothing — a person, a webhook, or the clock | **yes** |
| `runnable` (`resonate:target` present) | anyone | a worker | **yes** |

Follows resonate-specification `ac6d9b8` ("One judgment on a promise: internal, external, runnable") and `a5f85e4` ("The axis decides the arming too, and that is checked").

## Why

The eager sweep was `state = 'pending' AND target IS NOT NULL` — runnable only. An external promise nobody touched never fired: a suspended awaiter sleeping on a timer had no eager wake path. The spec's arming theorems (`arms_a_runnable_deadline`, `arms_an_external_deadline`, `arms_no_internal_deadline`) pin the rule this PR implements: a deadline is owed as a write exactly where someone can be waiting to observe it.

This is also the prerequisite for the ScyllaDB engine: its `promise_timeouts` queue membership must be settled semantics (`pending ∧ awaitable`) before that engine's hard-gated first PR.

## How

- **resonate-core**: `OType::{Internal, External, Runnable}` with `awaitable()` (every value but internal); `okind`/`OKind` deleted (runnable subsumes Task); `is_external` → `is_awaitable`. Doors ask `awaitable`, never name a constructor — under three values, a door written `otype == External` would silently refuse every runnable promise.
- **Engines (sqlite/postgres/mysql)**: sweep, `upcoming`, and `snap` queue predicate → `state = 'pending' AND awaitable`; Postgres's `external` generated column renamed `awaitable`; SQLite and MySQL grow the same generated column; arming on create/fence/schedule-fire follows the axis, not the address (`PromiseCreateParams`/`TaskFenceCreateParams` carry `awaitable`, computed where tags are still typed).
- **Oracle**: `set_p_timeout` gated on `is_awaitable` at all three create paths; `upcoming` liveness test matches; `external_pending_promise_ids` → `awaitable_pending_promise_ids`.
- Schemas edited in place per the pre-release migration policy (0001 stays 0001).

## Verification

- `cargo test -p resonate-core` / `-p resonate-server-dbms`: green.
- Differential, all four backends (SQLite + Oracle + Postgres + MySQL): **zero divergences** over the full run (703s locally). The first run caught exactly one drift — the oracle's `upcoming` still filtered on `target` — which is the differential doing its job.
- Linearizability: `conctrace` (8 clients × 600 ops, max concurrency 27) against a debug-mode server, checked with the spec repo's `conccheck -partition=false`: no refutation.
- Clippy clean on both crates.

## Merge-order note

CI's linearizability job checks out `resonatehq/resonate-specification` at its default branch. The runnable-axis commits (which also touch `valid/porc/state.go` and `handlers.go`) are on `claude/resonate-accordant-start-8a1nqs`. The trace run is in debug mode (no background sweep), so the arming change should be invisible to the checker either way — the local run above used spec `main`'s checker and did not refute — but merging the spec branch first keeps model and server named the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)