### PR TITLE
Port resonate-on-scylladb: the eager engine joins the differential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [sqlite, postgres, mysql]
+        backend: [sqlite, postgres, mysql, scylladb]
 
     # Services cannot be selected per matrix leg, so both start everywhere
-    # and the step below picks the one this leg talks to.
+    # and the step below picks the one this leg talks to. ScyllaDB is not a
+    # service because services cannot pass container arguments, and it needs
+    # several; the scylladb leg starts it in a step instead.
     services:
       postgres:
         image: postgres:16
@@ -87,6 +89,23 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      # The flags are the ones LWT needs: single shard for a CI runner, and
+      # 127.0.0.1 broadcast so the driver follows the mapped port rather
+      # than the container's internal address. The keyspace opts out of
+      # tablets in the engine itself.
+      - name: Start ScyllaDB
+        if: matrix.backend == 'scylladb'
+        run: |
+          docker run -d --rm --name scylla -p 9042:9042 scylladb/scylla:6.2 \
+            --smp 1 --developer-mode 1 --overprovisioned 1 \
+            --broadcast-rpc-address 127.0.0.1
+          for _ in $(seq 1 90); do
+            docker exec scylla sh -c 'cqlsh $(hostname -i) -e "SELECT release_version FROM system.local"' >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "ScyllaDB did not become ready" >&2
+          exit 1
+
       # --release: the run walks to a coverage plateau or 200k steps, which
       # a debug build turns from minutes into an afternoon.
       - name: Differential
@@ -99,6 +118,9 @@ jobs:
               ;;
             mysql)
               export TEST_MYSQL_URL=mysql://resonate:resonate@localhost:3306/resonate
+              ;;
+            scylladb)
+              export TEST_SCYLLADB_HOSTS=127.0.0.1:9042
               ;;
           esac
           cargo test --release --test differential --all-features -- --nocapture
@@ -129,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [sqlite, postgres, mysql]
+        backend: [sqlite, postgres, mysql, scylladb]
 
     services:
       postgres:
@@ -183,6 +205,19 @@ jobs:
       - name: Build
         run: cargo build --release --bin resonate --example conctrace
 
+      - name: Start ScyllaDB
+        if: matrix.backend == 'scylladb'
+        run: |
+          docker run -d --rm --name scylla -p 9042:9042 scylladb/scylla:6.2 \
+            --smp 1 --developer-mode 1 --overprovisioned 1 \
+            --broadcast-rpc-address 127.0.0.1
+          for _ in $(seq 1 90); do
+            docker exec scylla sh -c 'cqlsh $(hostname -i) -e "SELECT release_version FROM system.local"' >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "ScyllaDB did not become ready" >&2
+          exit 1
+
       # Debug mode is what makes a history checkable: the clock belongs to the
       # caller, so every request carries the `resonate:debug_time` the model's
       # non-decreasing clock needs, and no background sweep settles anything
@@ -199,6 +234,12 @@ jobs:
             mysql)
               export RESONATE_STORAGE__TYPE=mysql
               export RESONATE_STORAGE__MYSQL__URL=mysql://resonate:resonate@localhost:3306/resonate
+              ;;
+            scylladb)
+              export RESONATE_STORAGE__TYPE=scylladb
+              # figment parses env values as TOML, so a list is spelled as one.
+              export RESONATE_STORAGE__SCYLLADB__HOSTS='["127.0.0.1:9042"]'
+              export RESONATE_STORAGE__SCYLLADB__MIGRATE=true
               ;;
             *)
               export RESONATE_STORAGE__TYPE=sqlite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +606,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +643,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +675,31 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -836,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +936,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -952,6 +1016,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1229,7 +1294,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1237,6 +1302,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1651,6 +1727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +1919,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "matchers"
@@ -2338,7 +2432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2513,6 +2607,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_pcg"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,6 +2781,7 @@ dependencies = [
  "resonate-core",
  "resonate-gateway-http",
  "resonate-server-dbms",
+ "resonate-server-scylladb",
  "resonate-timer-wheel",
  "resonate-transport-gcps",
  "resonate-transport-http-poll",
@@ -2750,6 +2854,24 @@ dependencies = [
  "sqlx",
  "tokio",
  "tracing",
+ "validator",
+]
+
+[[package]]
+name = "resonate-server-scylladb"
+version = "0.9.8"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "cron",
+ "resonate-core",
+ "resonate-server-dbms",
+ "scylla",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
  "validator",
 ]
 
@@ -3075,6 +3197,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "scylla"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1163ef6fae8e222c156962532de31aa1cd19a83782c4eb196aab7fc76aebdae"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "futures",
+ "hashbrown 0.17.1",
+ "itertools 0.15.0",
+ "rand 0.9.2",
+ "rand_pcg",
+ "scylla-cql",
+ "scylla-cql-core",
+ "smallvec",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "scylla-cql"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d9ae8618f958fedff008180f2237f6c9fe51a8e1e3496910fb3bb7f4b12816"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "chrono",
+ "itertools 0.15.0",
+ "lz4_flex",
+ "scylla-cql-core",
+ "snap",
+ "stable_deref_trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+ "yoke",
+]
+
+[[package]]
+name = "scylla-cql-core"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d98bb372cbdf09b575488a9493d2e5b3812c034353cb066e33ac0c386992eeb"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "chrono",
+ "itertools 0.15.0",
+ "scylla-macros",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "scylla-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc72604b7e5e759ca0e766f7324f0e1286e776fb154b6f8b658b89daf2e220ef"
+dependencies = [
+ "darling 0.24.1",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +3498,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -3582,6 +3783,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4046,6 +4258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4142,6 +4360,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,8 @@ dependencies = [
  "cron",
  "resonate-core",
  "resonate-server-dbms",
+ "rustls 0.23.40",
+ "rustls-pemfile 2.2.0",
  "scylla",
  "serde",
  "serde_json",
@@ -2873,6 +2875,7 @@ dependencies = [
  "tracing",
  "uuid",
  "validator",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3040,6 +3043,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.10",
  "subtle",
@@ -3065,6 +3069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3212,12 +3225,14 @@ dependencies = [
  "itertools 0.15.0",
  "rand 0.9.2",
  "rand_pcg",
+ "rustls 0.23.40",
  "scylla-cql",
  "scylla-cql-core",
  "smallvec",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "uuid",
 ]
@@ -3585,7 +3600,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3596,7 +3611,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -4649,6 +4664,24 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/resonate-core",
     "crates/resonate-gateway-http",
     "crates/resonate-server-dbms",
+    "crates/resonate-server-scylladb",
     "crates/resonate-timer-wheel",
     "crates/resonate-transport-gcps",
     "crates/resonate-transport-http-poll",
@@ -43,14 +44,16 @@ name = "differential"
 path = "diff/differential.rs"
 # It compares the engines against each other, so it needs all of them; with any
 # turned off cargo skips the target rather than failing to build it.
-required-features = ["sqlite", "postgres", "mysql"]
+required-features = ["sqlite", "postgres", "mysql", "scylladb"]
 
 [features]
-# All forwarded: the cfg'd code lives in resonate-server-dbms.
-default = ["sqlite", "postgres", "mysql"]
+# All forwarded: the cfg'd code lives in resonate-server-dbms, except the
+# ScyllaDB engine, which is its own crate.
+default = ["sqlite", "postgres", "mysql", "scylladb"]
 sqlite = ["resonate-server-dbms/sqlite"]
 postgres = ["resonate-server-dbms/postgres"]
 mysql = ["resonate-server-dbms/mysql"]
+scylladb = ["dep:resonate-server-scylladb"]
 concurrency-stress = ["resonate-server-dbms/concurrency-stress"]
 
 [dependencies]
@@ -58,6 +61,7 @@ resonate-auth = { path = "crates/resonate-auth" }
 resonate-core = { path = "crates/resonate-core" }
 resonate-gateway-http = { path = "crates/resonate-gateway-http" }
 resonate-server-dbms = { path = "crates/resonate-server-dbms", default-features = false }
+resonate-server-scylladb = { path = "crates/resonate-server-scylladb", optional = true }
 resonate-timer-wheel = { path = "crates/resonate-timer-wheel" }
 resonate-transport-gcps = { path = "crates/resonate-transport-gcps" }
 resonate-transport-http-poll = { path = "crates/resonate-transport-http-poll" }

--- a/README.md
+++ b/README.md
@@ -169,6 +169,38 @@ Or, you can run it as an executable using the following command:
 ./target/release/resonate serve
 ```
 
+## Storage backends
+
+The server stores its durable state in SQLite (the default), PostgreSQL,
+MySQL, or ScyllaDB, selected with `storage.type` in `resonate.toml` or
+`RESONATE_STORAGE__TYPE`. All four are held to the same behavior by a
+differential test that drives them in lock step against a reference model.
+
+ScyllaDB configuration, with its defaults:
+
+```toml
+[storage]
+type = "scylladb"
+
+[storage.scylladb]
+hosts = ["localhost"]      # seed hosts, bare or host:port
+port = 0                   # applied to bare hosts AND gossip-discovered peers (9142 for TLS clusters)
+username = ""
+password = ""
+keyspace = "resonate"
+replication = ""           # CREATE KEYSPACE clause; empty = NetworkTopologyStrategy, RF 1
+migrate = false            # apply the embedded schema (CREATE ... IF NOT EXISTS) on connect
+bucket_width = 3600000     # timeout-queue bucket width (ms)
+bucket_lookback = 1        # past buckets each sweep covers
+shards = 1                 # timeout-queue shard count, split among live server instances
+worker_ttl = 180000        # instance heartbeat TTL (ms); must exceed timeouts.poll_interval
+tls = { enabled = false, insecure = false }  # insecure = encrypt, skip verification (private CAs)
+# tls.ca_cert = "/path/to/ca.pem"            # or trust a specific CA, verified
+```
+
+The keyspace is created with tablets disabled — lightweight transactions,
+which this engine is built on, require it.
+
 ## Outbound authentication for HTTP push
 
 When the Resonate Server delivers execute messages to protected Cloud Functions or Cloud Run services, it can attach an outbound authentication header. Configure this under `[transports.http_push.auth]`.

--- a/crates/resonate-server-dbms/src/engine_mysql.rs
+++ b/crates/resonate-server-dbms/src/engine_mysql.rs
@@ -292,7 +292,7 @@ impl MysqlEngine {
                 ))
             }
             "debug.reset" => self.op_debug_reset(req).await,
-            "debug.snap" => self.op_debug_snap(req).await,
+            "debug.snap" => self.op_debug_snap(req, now).await,
             "debug.tick" => self.op_debug_tick(req).await,
 
             _ => {
@@ -697,7 +697,7 @@ impl MysqlEngine {
             .await
     }
 
-    async fn op_promise_search(&self, req: &RequestEnvelope, _now: i64) -> Output {
+    async fn op_promise_search(&self, req: &RequestEnvelope, now: i64) -> Output {
         let data = req.data.clone();
         let kind_str = req.kind.clone();
         let corr_id = req.head.corr_id.clone();
@@ -740,6 +740,7 @@ impl MysqlEngine {
                 tags_json.as_deref(),
                 r.cursor.as_deref(),
                 limit + 1,
+                now,
             )?;
             let has_more = results.len() as i64 > limit;
             let promises: Vec<_> = results.into_iter().take(limit as usize).collect();
@@ -2188,8 +2189,8 @@ impl MysqlEngine {
         })
     }
 
-    async fn op_debug_snap(&self, req: &RequestEnvelope) -> Output {
-        Output::response(match self.query(move |db| db.snap()).await {
+    async fn op_debug_snap(&self, req: &RequestEnvelope, now: i64) -> Output {
+        Output::response(match self.query(move |db| db.snap(now)).await {
             Ok(snapshot) => {
                 let data = serde_json::to_value(snapshot).unwrap_or(Value::Null);
                 ResponseEnvelope::new(req.kind.clone(), req.head.corr_id.clone(), 200, data)
@@ -3045,18 +3046,31 @@ impl MysqlDb<'_> {
         tags: Option<&str>,
         cursor: Option<&str>,
         limit: i64,
+        time: i64,
     ) -> StorageResult<Vec<PromiseRecord>> {
+        // The deadline is a projection every read applies, and search is a
+        // read: an expired pending promise reads as its timeout verdict.
+        // The state filter asks the projected state for the same reason.
         let rows = rt_block_on(
             sqlx::query(
-                "SELECT id, state, param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at, settled_at
+                "SELECT id,
+                        CASE WHEN state = 'pending' AND timeout_at <= ?
+                             THEN (CASE WHEN is_timer THEN 'resolved' ELSE 'rejected_timedout' END)
+                             ELSE state END AS state,
+                        param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at,
+                        CASE WHEN state = 'pending' AND timeout_at <= ?
+                             THEN timeout_at ELSE settled_at END AS settled_at
                  FROM promises
-                 WHERE (? IS NULL OR state = ?)
+                 WHERE (? IS NULL OR CASE WHEN state = 'pending' AND timeout_at <= ?
+                             THEN (CASE WHEN is_timer THEN 'resolved' ELSE 'rejected_timedout' END)
+                             ELSE state END = ?)
                    AND (? IS NULL OR JSON_CONTAINS(tags, ?))
                    AND (? IS NULL OR id > ?)
                  ORDER BY id ASC
                  LIMIT ?",
             )
-            .bind(state).bind(state)
+            .bind(time).bind(time)
+            .bind(state).bind(time).bind(state)
             .bind(tags).bind(tags)
             .bind(cursor).bind(cursor)
             .bind(limit)
@@ -4384,11 +4398,23 @@ impl MysqlDb<'_> {
         Ok(())
     }
 
-    fn snap(&self) -> StorageResult<Snapshot> {
+    fn snap(&self, now: i64) -> StorageResult<Snapshot> {
+        // The promise records project expiry, like every read; the queue
+        // sections stay physical — sweeps are tick-driven, so those agree
+        // across backends at every instant without projection.
         let promise_rows = rt_block_on(
             sqlx::query(
-                "SELECT id, state, param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at, settled_at FROM promises ORDER BY id",
+                "SELECT id,
+                        CASE WHEN state = 'pending' AND timeout_at <= ?
+                             THEN (CASE WHEN is_timer THEN 'resolved' ELSE 'rejected_timedout' END)
+                             ELSE state END AS state,
+                        param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at,
+                        CASE WHEN state = 'pending' AND timeout_at <= ?
+                             THEN timeout_at ELSE settled_at END AS settled_at
+                 FROM promises ORDER BY id",
             )
+            .bind(now)
+            .bind(now)
             .fetch_all(self.tx().as_mut()),
         )?;
         let promises: Vec<PromiseRecord> = promise_rows.iter().map(row_to_promise).collect();
@@ -4410,10 +4436,18 @@ impl MysqlDb<'_> {
             })
             .collect();
 
+        // The obligation sections report where someone can still be
+        // blocked: a holder whose projected state is settled reports none —
+        // the read-side twin of settle clearing them.
         let cb_rows = rt_block_on(
             sqlx::query(
-                "SELECT awaiter_id, awaited_id FROM callbacks WHERE NOT ready ORDER BY awaiter_id, awaited_id",
+                "SELECT awaiter_id, awaited_id FROM callbacks
+                 WHERE NOT ready AND EXISTS (
+                   SELECT 1 FROM promises p WHERE p.id = awaited_id
+                     AND p.state = 'pending' AND p.timeout_at > ?)
+                 ORDER BY awaiter_id, awaited_id",
             )
+            .bind(now)
             .fetch_all(self.tx().as_mut()),
         )?;
         let callbacks: Vec<SnapshotCallback> = cb_rows
@@ -4425,8 +4459,15 @@ impl MysqlDb<'_> {
             .collect();
 
         let li_rows = rt_block_on(
-            sqlx::query("SELECT promise_id, address FROM listeners ORDER BY promise_id, address")
-                .fetch_all(self.tx().as_mut()),
+            sqlx::query(
+                "SELECT promise_id, address FROM listeners
+                 WHERE EXISTS (
+                   SELECT 1 FROM promises p WHERE p.id = promise_id
+                     AND p.state = 'pending' AND p.timeout_at > ?)
+                 ORDER BY promise_id, address",
+            )
+            .bind(now)
+            .fetch_all(self.tx().as_mut()),
         )?;
         let listeners: Vec<SnapshotListener> = li_rows
             .iter()

--- a/crates/resonate-server-dbms/src/engine_postgres.rs
+++ b/crates/resonate-server-dbms/src/engine_postgres.rs
@@ -81,6 +81,32 @@ fn p_cols(alias: &str) -> String {
     )
 }
 
+/// The deadline projection, as an expression: an expired pending promise
+/// reads as its timeout verdict, whether or not anything has written that
+/// yet. `now` names the bind slot carrying the time.
+fn state_projected(now: &str) -> String {
+    format!(
+        "CASE WHEN state = 'pending' AND timeout_at <= {now} \
+              THEN (CASE WHEN is_timer THEN 'resolved' ELSE 'rejected_timedout' END) \
+              ELSE state END"
+    )
+}
+
+/// `P_COLS` with the deadline projection applied. The deadline is a
+/// projection every read applies, and search and snap are reads — which is
+/// what lets an engine that settles an expired promise eagerly and one that
+/// leaves the row pending until touched answer identically.
+fn p_cols_projected(now: &str) -> String {
+    format!(
+        "id, {state} AS state, \
+         NULLIF(param_headers, '{{}}'::jsonb)::text AS param_headers, param_data, \
+         NULLIF(value_headers, '{{}}'::jsonb)::text AS value_headers, value_data, \
+         tags::text, timeout_at, created_at, \
+         CASE WHEN state = 'pending' AND timeout_at <= {now} THEN timeout_at ELSE settled_at END AS settled_at",
+        state = state_projected(now)
+    )
+}
+
 /// The columns every emission CTE produces, so several can be `UNION ALL`ed
 /// into one list regardless of which kind they carry.
 const MSG_COLS: &str = "kind, address, task_id, version, promise";
@@ -358,7 +384,7 @@ impl PostgresEngine {
                 ))
             }
             "debug.reset" => self.op_debug_reset(req).await,
-            "debug.snap" => self.op_debug_snap(req).await,
+            "debug.snap" => self.op_debug_snap(req, now).await,
             "debug.tick" => self.op_debug_tick(req).await,
 
             _ => {
@@ -763,7 +789,7 @@ impl PostgresEngine {
             .await
     }
 
-    async fn op_promise_search(&self, req: &RequestEnvelope, _now: i64) -> Output {
+    async fn op_promise_search(&self, req: &RequestEnvelope, now: i64) -> Output {
         let data = req.data.clone();
         let kind_str = req.kind.clone();
         let corr_id = req.head.corr_id.clone();
@@ -806,6 +832,7 @@ impl PostgresEngine {
                 tags_json.as_deref(),
                 r.cursor.as_deref(),
                 limit + 1,
+                now,
             )?;
             let has_more = results.len() as i64 > limit;
             let promises: Vec<_> = results.into_iter().take(limit as usize).collect();
@@ -2254,8 +2281,8 @@ impl PostgresEngine {
         })
     }
 
-    async fn op_debug_snap(&self, req: &RequestEnvelope) -> Output {
-        Output::response(match self.query(move |db| db.snap()).await {
+    async fn op_debug_snap(&self, req: &RequestEnvelope, now: i64) -> Output {
+        Output::response(match self.query(move |db| db.snap(now)).await {
             Ok(snapshot) => {
                 let data = serde_json::to_value(snapshot).unwrap_or(Value::Null);
                 ResponseEnvelope::new(req.kind.clone(), req.head.corr_id.clone(), 200, data)
@@ -3112,19 +3139,25 @@ impl PostgresDb<'_> {
         tags: Option<&str>,
         cursor: Option<&str>,
         limit: i64,
+        time: i64,
     ) -> StorageResult<Vec<PromiseRecord>> {
+        // The state filter asks the projected state — a search for 'pending'
+        // must not surface what no reader may observe as pending.
         let rows = rt_block_on(
             sqlx::query(&format!(
-                "SELECT {P_COLS} FROM promises
-                 WHERE ($1::text IS NULL OR state = $1)
+                "SELECT {cols} FROM promises
+                 WHERE ($1::text IS NULL OR {st} = $1)
                    AND ($2::jsonb IS NULL OR tags @> $2::jsonb)
                    AND ($3::text IS NULL OR id > $3)
-                 ORDER BY id ASC LIMIT $4"
+                 ORDER BY id ASC LIMIT $4",
+                cols = p_cols_projected("$5"),
+                st = state_projected("$5"),
             ))
             .bind(state)
             .bind(tags)
             .bind(cursor)
             .bind(limit)
+            .bind(time)
             .fetch_all(self.tx().as_mut()),
         )?;
         Ok(rows.iter().map(row_to_promise).collect())
@@ -4208,10 +4241,17 @@ impl PostgresDb<'_> {
     }
 
     // D-04: debug.snap — every section is now a projection of the one table
-    fn snap(&self) -> StorageResult<Snapshot> {
+    fn snap(&self, now: i64) -> StorageResult<Snapshot> {
+        // The promise records project expiry, like every read; the queue
+        // sections stay physical — sweeps are tick-driven, so those agree
+        // across backends at every instant without projection.
         let promise_rows = rt_block_on(
-            sqlx::query(&format!("SELECT {P_COLS} FROM promises ORDER BY id"))
-                .fetch_all(self.tx().as_mut()),
+            sqlx::query(&format!(
+                "SELECT {} FROM promises ORDER BY id",
+                p_cols_projected("$1")
+            ))
+            .bind(now)
+            .fetch_all(self.tx().as_mut()),
         )?;
         let promises: Vec<PromiseRecord> = promise_rows.iter().map(row_to_promise).collect();
 
@@ -4230,13 +4270,18 @@ impl PostgresDb<'_> {
             })
             .collect();
 
-        // Non-ready callbacks only — the ready ones live in `resumes`.
+        // Non-ready callbacks only — the ready ones live in `resumes`. The
+        // obligation sections report where someone can still be blocked: a
+        // holder whose projected state is settled reports none — the
+        // read-side twin of settle clearing them.
         let cb_rows = rt_block_on(
             sqlx::query(
                 "SELECT aw AS awaiter_id, id AS awaited_id
                  FROM promises CROSS JOIN LATERAL unnest(callbacks) AS aw
+                 WHERE state = 'pending' AND timeout_at > $1
                  ORDER BY aw, id",
             )
+            .bind(now)
             .fetch_all(self.tx().as_mut()),
         )?;
         let callbacks: Vec<SnapshotCallback> = cb_rows
@@ -4251,8 +4296,10 @@ impl PostgresDb<'_> {
             sqlx::query(
                 "SELECT id AS promise_id, l AS address
                  FROM promises CROSS JOIN LATERAL unnest(listeners) AS l
+                 WHERE state = 'pending' AND timeout_at > $1
                  ORDER BY id, l",
             )
+            .bind(now)
             .fetch_all(self.tx().as_mut()),
         )?;
         let listeners: Vec<SnapshotListener> = li_rows

--- a/crates/resonate-server-dbms/src/engine_sqlite.rs
+++ b/crates/resonate-server-dbms/src/engine_sqlite.rs
@@ -254,7 +254,7 @@ impl SqliteEngine {
                 ))
             }
             "debug.reset" => self.op_debug_reset(req).await,
-            "debug.snap" => self.op_debug_snap(req).await,
+            "debug.snap" => self.op_debug_snap(req, now).await,
             "debug.tick" => self.op_debug_tick(req).await,
 
             _ => {
@@ -659,7 +659,7 @@ impl SqliteEngine {
             .await
     }
 
-    async fn op_promise_search(&self, req: &RequestEnvelope, _now: i64) -> Output {
+    async fn op_promise_search(&self, req: &RequestEnvelope, now: i64) -> Output {
         let data = req.data.clone();
         let kind_str = req.kind.clone();
         let corr_id = req.head.corr_id.clone();
@@ -702,6 +702,7 @@ impl SqliteEngine {
                 tags_json.as_deref(),
                 r.cursor.as_deref(),
                 limit + 1,
+                now,
             )?;
             let has_more = results.len() as i64 > limit;
             let promises: Vec<_> = results.into_iter().take(limit as usize).collect();
@@ -2150,8 +2151,8 @@ impl SqliteEngine {
         })
     }
 
-    async fn op_debug_snap(&self, req: &RequestEnvelope) -> Output {
-        Output::response(match self.query(move |db| db.snap()).await {
+    async fn op_debug_snap(&self, req: &RequestEnvelope, now: i64) -> Output {
+        Output::response(match self.query(move |db| db.snap(now)).await {
             Ok(snapshot) => {
                 let data = serde_json::to_value(snapshot).unwrap_or(Value::Null);
                 ResponseEnvelope::new(req.kind.clone(), req.head.corr_id.clone(), 200, data)
@@ -2748,18 +2749,32 @@ impl<'a> SqliteDb<'a> {
         tags: Option<&str>,
         cursor: Option<&str>,
         limit: i64,
+        time: i64,
     ) -> StorageResult<Vec<PromiseRecord>> {
+        // The deadline is a projection every read applies, and search is a
+        // read: an expired pending promise reads as its timeout verdict,
+        // whether or not anything has written that yet — which is what lets
+        // a lazy engine and one that settles eagerly answer identically.
+        // The state filter asks the projected state for the same reason.
         let mut stmt = self.conn.prepare(
-            "SELECT id, state, param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at, settled_at
+            "SELECT id,
+                    CASE WHEN state = 'pending' AND timeout_at <= ?5
+                         THEN (CASE WHEN is_timer THEN 'resolved' ELSE 'rejected_timedout' END)
+                         ELSE state END AS state,
+                    param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at,
+                    CASE WHEN state = 'pending' AND timeout_at <= ?5
+                         THEN timeout_at ELSE settled_at END AS settled_at
              FROM promises
-             WHERE (?1 IS NULL OR state = ?1)
+             WHERE (?1 IS NULL OR CASE WHEN state = 'pending' AND timeout_at <= ?5
+                         THEN (CASE WHEN is_timer THEN 'resolved' ELSE 'rejected_timedout' END)
+                         ELSE state END = ?1)
                AND (?2 IS NULL OR NOT EXISTS (
                  SELECT key, value FROM json_each(?2) EXCEPT SELECT key, value FROM json_each(tags)
                ))
                AND (?3 IS NULL OR id > ?3)
              ORDER BY id ASC LIMIT ?4",
         )?;
-        let mut rows = stmt.query(params![state, tags, cursor, limit])?;
+        let mut rows = stmt.query(params![state, tags, cursor, limit, time])?;
         let mut results = Vec::new();
         while let Some(row) = rows.next()? {
             results.push(row_to_promise(row)?);
@@ -3727,12 +3742,26 @@ impl<'a> SqliteDb<'a> {
         Ok(())
     }
 
-    fn snap(&self) -> StorageResult<Snapshot> {
+    fn snap(&self, now: i64) -> StorageResult<Snapshot> {
         let conn = self.conn;
 
-        let mut stmt = conn.prepare("SELECT id, state, param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at, settled_at FROM promises ORDER BY id")?;
+        // The promise records project expiry, like every read: what the
+        // snapshot compares is what an observer could learn, so an engine
+        // that settles an expired promise eagerly and one that leaves the
+        // row pending until touched snap identically. The queue sections
+        // stay physical — sweeps are tick-driven, so those agree across
+        // backends at every instant without projection.
+        let mut stmt = conn.prepare(
+            "SELECT id,
+                    CASE WHEN state = 'pending' AND timeout_at <= ?1
+                         THEN (CASE WHEN is_timer THEN 'resolved' ELSE 'rejected_timedout' END)
+                         ELSE state END AS state,
+                    param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at,
+                    CASE WHEN state = 'pending' AND timeout_at <= ?1
+                         THEN timeout_at ELSE settled_at END AS settled_at
+             FROM promises ORDER BY id")?;
         let promises: Vec<PromiseRecord> = {
-            let mut rows = stmt.query([])?;
+            let mut rows = stmt.query(params![now])?;
             let mut r = Vec::new();
             while let Some(row) = rows.next()? {
                 r.push(row_to_promise(row)?);
@@ -3758,9 +3787,18 @@ impl<'a> SqliteDb<'a> {
             r
         };
 
-        let mut stmt = conn.prepare("SELECT awaiter_id, awaited_id FROM callbacks WHERE NOT ready ORDER BY awaiter_id, awaited_id")?;
+        // Obligations report where someone can still be blocked: a holder
+        // whose projected state is settled reports none, whatever the rows
+        // physically hold — the read-side twin of settle clearing them.
+        let mut stmt = conn.prepare(
+            "SELECT awaiter_id, awaited_id FROM callbacks
+             WHERE NOT ready AND EXISTS (
+               SELECT 1 FROM promises p WHERE p.id = awaited_id
+                 AND p.state = 'pending' AND p.timeout_at > ?1)
+             ORDER BY awaiter_id, awaited_id",
+        )?;
         let callbacks: Vec<SnapshotCallback> = {
-            let mut rows = stmt.query([])?;
+            let mut rows = stmt.query(params![now])?;
             let mut r = Vec::new();
             while let Some(row) = rows.next()? {
                 r.push(SnapshotCallback {
@@ -3772,9 +3810,15 @@ impl<'a> SqliteDb<'a> {
         };
 
         let mut stmt =
-            conn.prepare("SELECT promise_id, address FROM listeners ORDER BY promise_id, address")?;
+            conn.prepare(
+                "SELECT promise_id, address FROM listeners
+                 WHERE EXISTS (
+                   SELECT 1 FROM promises p WHERE p.id = promise_id
+                     AND p.state = 'pending' AND p.timeout_at > ?1)
+                 ORDER BY promise_id, address",
+            )?;
         let listeners: Vec<SnapshotListener> = {
-            let mut rows = stmt.query([])?;
+            let mut rows = stmt.query(params![now])?;
             let mut r = Vec::new();
             while let Some(row) = rows.next()? {
                 r.push(SnapshotListener {

--- a/crates/resonate-server-dbms/src/engine_sqlite.rs
+++ b/crates/resonate-server-dbms/src/engine_sqlite.rs
@@ -3809,14 +3809,13 @@ impl<'a> SqliteDb<'a> {
             r
         };
 
-        let mut stmt =
-            conn.prepare(
-                "SELECT promise_id, address FROM listeners
+        let mut stmt = conn.prepare(
+            "SELECT promise_id, address FROM listeners
                  WHERE EXISTS (
                    SELECT 1 FROM promises p WHERE p.id = promise_id
                      AND p.state = 'pending' AND p.timeout_at > ?1)
                  ORDER BY promise_id, address",
-            )?;
+        )?;
         let listeners: Vec<SnapshotListener> = {
             let mut rows = stmt.query(params![now])?;
             let mut r = Vec::new();

--- a/crates/resonate-server-dbms/src/oracle.rs
+++ b/crates/resonate-server-dbms/src/oracle.rs
@@ -273,7 +273,7 @@ impl Oracle {
             "promise.settle" => self.op_promise_settle(req, now),
             "promise.register_callback" => self.op_promise_register_callback(req, now),
             "promise.register_listener" => self.op_promise_register_listener(req, now),
-            "promise.search" => self.op_promise_search(req),
+            "promise.search" => self.op_promise_search(req, now),
             "task.get" => self.op_task_get(req, now),
             "task.create" => self.op_task_create(req, now),
             "task.acquire" => self.op_task_acquire(req, now),
@@ -290,7 +290,7 @@ impl Oracle {
             "schedule.delete" => self.op_schedule_delete(req),
             "schedule.search" => self.op_schedule_search(req),
             "debug.reset" => self.op_debug_reset(req),
-            "debug.snap" => self.op_debug_snap(req),
+            "debug.snap" => self.op_debug_snap(req, now),
             "debug.tick" => self.op_debug_tick(req),
             _ => ResponseEnvelope::error(
                 req.kind.clone(),
@@ -668,7 +668,7 @@ impl Oracle {
         )
     }
 
-    fn op_promise_search(&self, req: &RequestEnvelope) -> ResponseEnvelope {
+    fn op_promise_search(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
         let r: PromiseSearchData = match serde_json::from_value(req.data.clone()) {
             Ok(r) => r,
             Err(e) => {
@@ -700,11 +700,17 @@ impl Oracle {
             Some(n) => n as usize,
             None => 100,
         };
+        // Records are built before the state filter so the filter sees the
+        // projected state — an expired pending promise is its timeout
+        // verdict to a reader, whether or not anything has written that
+        // yet. The deadline is a projection every read applies; search is
+        // a read.
         let mut promises: Vec<PromiseRecord> = self
             .promises
             .iter()
-            .filter(|(_, p)| {
-                r.state.map(|s| p.state == s).unwrap_or(true)
+            .map(|(id, p)| (Self::to_promise_record(now, id, p), p))
+            .filter(|(record, p)| {
+                r.state.map(|s| record.state == s).unwrap_or(true)
                     && r.tags
                         .as_ref()
                         .map(|ft| {
@@ -713,7 +719,7 @@ impl Oracle {
                         })
                         .unwrap_or(true)
             })
-            .map(|(id, p)| Self::to_promise_record(0, id, p))
+            .map(|(record, _)| record)
             .collect();
         promises.sort_by(|a, b| a.id.cmp(&b.id));
         let start = r
@@ -1834,29 +1840,54 @@ impl Oracle {
         )
     }
 
-    fn op_debug_snap(&self, req: &RequestEnvelope) -> ResponseEnvelope {
+    fn op_debug_snap(&self, req: &RequestEnvelope, now: i64) -> ResponseEnvelope {
+        // The promise records project expiry, like every read: what the
+        // snapshot compares is what an observer could learn, so an engine
+        // that settles an expired promise eagerly and one that leaves the
+        // row pending until touched snap identically.
         let mut promises: Vec<PromiseRecord> = self
             .promises
             .iter()
-            .map(|(id, p)| Self::to_promise_record(0, id, p))
+            .map(|(id, p)| Self::to_promise_record(now, id, p))
             .collect();
         promises.sort_by(|a, b| a.id.cmp(&b.id));
+
+        // The obligation sections report where someone can still be
+        // blocked, in both directions. Holder-side: a promise whose
+        // PROJECTED state is settled reports no callbacks or listeners,
+        // whatever its physical sets hold — the read-side twin of settle
+        // clearing them. Member-side: a callbacks member whose task is
+        // fulfilled is inert (fulfilled is terminal, every fanout skips
+        // it), so it reports as absent — the read-side twin of the delete
+        // this model performs physically; an engine that leaves the member
+        // in place, as the Go mechanics do, snaps equal.
+        let holder_projects_empty =
+            |p: &Promise| -> bool { p.state != PromiseState::Pending || now >= p.timeout_at };
+        let member_is_inert = |awaiter: &str| -> bool {
+            self.tasks
+                .get(awaiter)
+                .map(|t| t.state == TaskState::Fulfilled)
+                .unwrap_or(false)
+        };
 
         let mut callbacks: Vec<SnapshotCallback> = self
             .promises
             .iter()
+            .filter(|(_, p)| !holder_projects_empty(p))
             .flat_map(|(id, p)| {
                 p.callbacks.iter().map(move |awaiter| SnapshotCallback {
                     awaiter: awaiter.clone(),
                     awaited: id.clone(),
                 })
             })
+            .filter(|cb| !member_is_inert(&cb.awaiter))
             .collect();
         callbacks.sort_by(|a, b| a.awaited.cmp(&b.awaited).then(a.awaiter.cmp(&b.awaiter)));
 
         let mut listeners: Vec<SnapshotListener> = self
             .promises
             .iter()
+            .filter(|(_, p)| !holder_projects_empty(p))
             .flat_map(|(id, p)| {
                 p.listeners.iter().map(move |addr| SnapshotListener {
                     promise_id: id.clone(),

--- a/crates/resonate-server-scylladb/Cargo.toml
+++ b/crates/resonate-server-scylladb/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "resonate-server-scylladb"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Resonate server storage over ScyllaDB: the Go resonate-on-scylladb mechanics — origin-partitioned promises, LWT transitions, bucketed timeout queues — behind the ResonateEngine port."
+
+[dependencies]
+resonate-core = { path = "../resonate-core" }
+# For the engine port and the shared StorageError only; no SQL engine is compiled.
+resonate-server-dbms = { path = "../resonate-server-dbms", default-features = false }
+scylla = "1.8"
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+validator = { workspace = true }
+tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
+tracing = "0.1"
+cron = "0.12"
+chrono = "0.4"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/resonate-server-scylladb/Cargo.toml
+++ b/crates/resonate-server-scylladb/Cargo.toml
@@ -9,7 +9,7 @@ description = "Resonate server storage over ScyllaDB: the Go resonate-on-scyllad
 resonate-core = { path = "../resonate-core" }
 # For the engine port and the shared StorageError only; no SQL engine is compiled.
 resonate-server-dbms = { path = "../resonate-server-dbms", default-features = false }
-scylla = "1.8"
+scylla = { version = "1.8", features = ["rustls-023"] }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -19,3 +19,6 @@ tracing = "0.1"
 cron = "0.12"
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls-pemfile = "2"
+webpki-roots = "0.26"

--- a/crates/resonate-server-scylladb/schema.cql
+++ b/crates/resonate-server-scylladb/schema.cql
@@ -1,0 +1,100 @@
+-- The resonate-on-scylladb schema, carried over: one promises table
+-- partitioned by origin (the call-graph root, everything before the id's
+-- first ':'), so every transition a request makes — settle plus its awaiter
+-- fanout, suspend plus its callback registrations — is a single-partition
+-- LWT or conditional batch.
+--
+-- The timeout queues are separate, bucketed and sharded tables, which makes
+-- every promises-row LWT paired with a queue write cross-partition and
+-- non-atomic. The substitute for atomicity is the pre-insert protocol:
+-- write the queue entry first (PK-idempotent), run the LWT, and on failure
+-- delete the entry only when the surviving row does not legitimately own
+-- it. Failures leave an orphan entry, never a missing one, and the tick
+-- handlers classify and delete orphans.
+--
+-- Eager, like the Go implementation: EVERY pending promise gets a
+-- promise_timeouts entry, internal included. The relational engines are
+-- deliberately lazy for internal promises — the differential is the
+-- experiment that decides whether the difference is observable.
+
+CREATE KEYSPACE IF NOT EXISTS resonate;
+
+USE resonate;
+
+CREATE TABLE IF NOT EXISTS promises (
+    id                 TEXT,
+    origin             TEXT,
+    branch             TEXT,
+    parent             TEXT,
+    target             TEXT,
+    state              TEXT,
+    param_headers      MAP<TEXT, TEXT>,
+    param_data         TEXT,
+    value_headers      MAP<TEXT, TEXT>,
+    value_data         TEXT,
+    tags               MAP<TEXT, TEXT>,
+    timeout_at         BIGINT,
+    created_at         BIGINT,
+    settled_at         BIGINT,
+    callbacks          SET<TEXT>,
+    listeners          SET<TEXT>,
+    task_state         TEXT,
+    task_version       INT,
+    task_ttl           BIGINT,
+    task_pid           TEXT,
+    task_resumes       SET<TEXT>,
+    task_timeout_retry BIGINT,
+    task_timeout_lease BIGINT,
+    PRIMARY KEY (origin, id)
+);
+
+CREATE TABLE IF NOT EXISTS schedules (
+    id                    TEXT,
+    origin                TEXT,
+    cron                  TEXT,
+    promise_id            TEXT,
+    promise_timeout       BIGINT,
+    promise_param_headers MAP<TEXT, TEXT>,
+    promise_param_data    TEXT,
+    promise_tags          MAP<TEXT, TEXT>,
+    next_run_at           BIGINT,
+    last_run_at           BIGINT,
+    created_at            BIGINT,
+    create_token          UUID,
+    PRIMARY KEY (origin, id)
+);
+
+CREATE TABLE IF NOT EXISTS promise_timeouts (
+    bucket     BIGINT,
+    shard      SMALLINT,
+    timeout_at BIGINT,
+    origin     TEXT,
+    promise_id TEXT,
+    PRIMARY KEY ((bucket, shard), timeout_at, origin, promise_id)
+) WITH CLUSTERING ORDER BY (timeout_at ASC);
+
+CREATE TABLE IF NOT EXISTS task_timeouts (
+    bucket             BIGINT,
+    shard              SMALLINT,
+    timeout_at         BIGINT,
+    timeout_type       TINYINT,
+    origin             TEXT,
+    task_id            TEXT,
+    promise_timeout_at BIGINT,
+    PRIMARY KEY ((bucket, shard), timeout_at, timeout_type, origin, task_id)
+) WITH CLUSTERING ORDER BY (timeout_at ASC);
+
+CREATE TABLE IF NOT EXISTS schedule_timeouts (
+    bucket       BIGINT,
+    shard        SMALLINT,
+    timeout_at   BIGINT,
+    origin       TEXT,
+    schedule_id  TEXT,
+    create_token UUID,
+    PRIMARY KEY ((bucket, shard), timeout_at, origin, schedule_id, create_token)
+) WITH CLUSTERING ORDER BY (timeout_at ASC);
+
+CREATE TABLE IF NOT EXISTS workers (
+    worker_id UUID,
+    PRIMARY KEY (worker_id)
+);

--- a/crates/resonate-server-scylladb/src/db.rs
+++ b/crates/resonate-server-scylladb/src/db.rs
@@ -13,9 +13,7 @@ use scylla::response::query_result::QueryResult;
 use scylla::statement::batch::{Batch, BatchType};
 use scylla::value::{CqlValue, Row};
 
-use resonate_core::types::{
-    PromiseRecord, PromiseState, PromiseValue, TaskRecord, TaskState,
-};
+use resonate_core::types::{PromiseRecord, PromiseState, PromiseValue, TaskRecord, TaskState};
 use resonate_server_dbms::engine_port::{Outgoing, Scheduled, Timeout};
 use resonate_server_dbms::{StorageError, StorageResult};
 
@@ -205,7 +203,11 @@ impl PromiseRow {
             version: self.task_version,
             resumes: self.task_resumes.len() as i64,
             ttl: if acquired { self.task_ttl } else { None },
-            pid: if acquired { self.task_pid.clone() } else { None },
+            pid: if acquired {
+                self.task_pid.clone()
+            } else {
+                None
+            },
         })
     }
 
@@ -403,7 +405,14 @@ impl ScyllaEngine {
         ];
 
         let outcome = self
-            .enqueue_resume(&row.id, &row.origin, &row.callbacks, now, settle_stmt, settle_args)
+            .enqueue_resume(
+                &row.id,
+                &row.origin,
+                &row.callbacks,
+                now,
+                settle_stmt,
+                settle_args,
+            )
             .await?;
 
         if let SettleOutcome::Won { resumed, retry_at } = outcome {
@@ -692,7 +701,6 @@ impl ScyllaEngine {
             });
         }
     }
-
 }
 
 pub(crate) fn rows_of(result: QueryResult) -> StorageResult<Vec<RowMap>> {

--- a/crates/resonate-server-scylladb/src/db.rs
+++ b/crates/resonate-server-scylladb/src/db.rs
@@ -1,0 +1,738 @@
+//! Plumbing: CQL execution, CAS row decoding, the promise row, and the
+//! settle chain every path shares.
+//!
+//! Two driver facts the Go code depended on hold here too and are load
+//! bearing: a failed `UPDATE ... IF` returns only the IF-clause columns,
+//! while a failed `INSERT ... IF NOT EXISTS` returns the full row; and an
+//! empty SET reads back as null, so `IF callbacks = ?` must be given null,
+//! not {}, to match a column nothing ever wrote.
+
+use std::collections::HashMap;
+
+use scylla::response::query_result::QueryResult;
+use scylla::statement::batch::{Batch, BatchType};
+use scylla::value::{CqlValue, Row};
+
+use resonate_core::types::{
+    PromiseRecord, PromiseState, PromiseValue, TaskRecord, TaskState,
+};
+use resonate_server_dbms::engine_port::{Outgoing, Scheduled, Timeout};
+use resonate_server_dbms::{StorageError, StorageResult};
+
+use crate::{origin_of, Ctx, ScyllaEngine, Tags};
+
+pub(crate) type Args = Vec<Option<CqlValue>>;
+pub(crate) type RowMap = HashMap<String, Option<CqlValue>>;
+
+pub(crate) fn text(s: impl Into<String>) -> Option<CqlValue> {
+    Some(CqlValue::Text(s.into()))
+}
+pub(crate) fn opt_text(s: Option<impl Into<String>>) -> Option<CqlValue> {
+    s.map(|v| CqlValue::Text(v.into()))
+}
+pub(crate) fn big(v: i64) -> Option<CqlValue> {
+    Some(CqlValue::BigInt(v))
+}
+pub(crate) fn int(v: i32) -> Option<CqlValue> {
+    Some(CqlValue::Int(v))
+}
+pub(crate) fn cql_map(m: &Tags) -> Option<CqlValue> {
+    Some(CqlValue::Map(
+        m.iter()
+            .map(|(k, v)| (CqlValue::Text(k.clone()), CqlValue::Text(v.clone())))
+            .collect(),
+    ))
+}
+pub(crate) fn opt_cql_map(m: Option<&Tags>) -> Option<CqlValue> {
+    m.and_then(|m| if m.is_empty() { None } else { cql_map(m) })
+}
+pub(crate) fn cql_set(v: &[String]) -> Option<CqlValue> {
+    // An empty set IS null in Cassandra; binding {} writes nothing anyway,
+    // and the IF-clause comparisons need null to match an unwritten column.
+    if v.is_empty() {
+        None
+    } else {
+        Some(CqlValue::Set(
+            v.iter().map(|s| CqlValue::Text(s.clone())).collect(),
+        ))
+    }
+}
+
+pub(crate) fn get_text(m: &RowMap, k: &str) -> Option<String> {
+    match m.get(k) {
+        Some(Some(CqlValue::Text(s))) => Some(s.clone()),
+        _ => None,
+    }
+}
+pub(crate) fn get_big(m: &RowMap, k: &str) -> Option<i64> {
+    match m.get(k) {
+        Some(Some(CqlValue::BigInt(v))) => Some(*v),
+        _ => None,
+    }
+}
+pub(crate) fn get_int(m: &RowMap, k: &str) -> Option<i32> {
+    match m.get(k) {
+        Some(Some(CqlValue::Int(v))) => Some(*v),
+        _ => None,
+    }
+}
+pub(crate) fn get_bool(m: &RowMap, k: &str) -> Option<bool> {
+    match m.get(k) {
+        Some(Some(CqlValue::Boolean(v))) => Some(*v),
+        _ => None,
+    }
+}
+pub(crate) fn get_tags(m: &RowMap, k: &str) -> Tags {
+    match m.get(k) {
+        Some(Some(CqlValue::Map(pairs))) => pairs
+            .iter()
+            .filter_map(|(k, v)| match (k, v) {
+                (CqlValue::Text(k), CqlValue::Text(v)) => Some((k.clone(), v.clone())),
+                _ => None,
+            })
+            .collect(),
+        _ => Tags::new(),
+    }
+}
+pub(crate) fn get_set(m: &RowMap, k: &str) -> Vec<String> {
+    match m.get(k) {
+        Some(Some(CqlValue::Set(vals))) => vals
+            .iter()
+            .filter_map(|v| match v {
+                CqlValue::Text(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn backend(e: impl std::fmt::Display) -> StorageError {
+    StorageError::Backend(e.to_string())
+}
+
+/// The full promises row, as every handler reads it — Go's `promiseRow`.
+#[derive(Debug, Clone)]
+pub(crate) struct PromiseRow {
+    pub id: String,
+    pub origin: String,
+    pub state: String,
+    pub param_headers: Tags,
+    pub param_data: Option<String>,
+    pub value_headers: Tags,
+    pub value_data: Option<String>,
+    pub tags: Tags,
+    pub target: Option<String>,
+    pub timeout_at: i64,
+    pub created_at: i64,
+    pub settled_at: Option<i64>,
+    pub callbacks: Vec<String>,
+    pub listeners: Vec<String>,
+    pub task_state: Option<String>,
+    pub task_version: i64,
+    pub task_ttl: Option<i64>,
+    pub task_pid: Option<String>,
+    pub task_resumes: Vec<String>,
+    pub task_timeout_retry: Option<i64>,
+    pub task_timeout_lease: Option<i64>,
+}
+
+pub(crate) const P_COLS: &str = "id, origin, state, param_headers, param_data, \
+     value_headers, value_data, tags, target, timeout_at, created_at, settled_at, \
+     callbacks, listeners, task_state, task_version, task_ttl, task_pid, \
+     task_resumes, task_timeout_retry, task_timeout_lease";
+
+impl PromiseRow {
+    pub(crate) fn from_map(m: &RowMap) -> Self {
+        Self {
+            id: get_text(m, "id").unwrap_or_default(),
+            origin: get_text(m, "origin").unwrap_or_default(),
+            state: get_text(m, "state").unwrap_or_default(),
+            param_headers: get_tags(m, "param_headers"),
+            param_data: get_text(m, "param_data"),
+            value_headers: get_tags(m, "value_headers"),
+            value_data: get_text(m, "value_data"),
+            tags: get_tags(m, "tags"),
+            target: get_text(m, "target"),
+            timeout_at: get_big(m, "timeout_at").unwrap_or(0),
+            created_at: get_big(m, "created_at").unwrap_or(0),
+            settled_at: get_big(m, "settled_at"),
+            callbacks: get_set(m, "callbacks"),
+            listeners: get_set(m, "listeners"),
+            task_state: get_text(m, "task_state"),
+            task_version: get_int(m, "task_version").unwrap_or(0) as i64,
+            task_ttl: get_big(m, "task_ttl"),
+            task_pid: get_text(m, "task_pid"),
+            task_resumes: get_set(m, "task_resumes"),
+            task_timeout_retry: get_big(m, "task_timeout_retry"),
+            task_timeout_lease: get_big(m, "task_timeout_lease"),
+        }
+    }
+
+    pub(crate) fn to_promise_record(&self) -> PromiseRecord {
+        PromiseRecord {
+            id: self.id.clone(),
+            state: parse_promise_state(&self.state),
+            param: PromiseValue {
+                headers: if self.param_headers.is_empty() {
+                    None
+                } else {
+                    Some(self.param_headers.clone())
+                },
+                data: self.param_data.clone(),
+            },
+            value: PromiseValue {
+                headers: if self.value_headers.is_empty() {
+                    None
+                } else {
+                    Some(self.value_headers.clone())
+                },
+                data: self.value_data.clone(),
+            },
+            tags: self.tags.clone(),
+            timeout_at: self.timeout_at,
+            created_at: self.created_at,
+            settled_at: self.settled_at,
+        }
+    }
+
+    pub(crate) fn to_task_record(&self) -> Option<TaskRecord> {
+        let state = self.task_state.as_deref()?;
+        let acquired = state == "acquired";
+        Some(TaskRecord {
+            id: self.id.clone(),
+            state: parse_task_state(state),
+            version: self.task_version,
+            resumes: self.task_resumes.len() as i64,
+            ttl: if acquired { self.task_ttl } else { None },
+            pid: if acquired { self.task_pid.clone() } else { None },
+        })
+    }
+
+    pub(crate) fn is_timer(&self) -> bool {
+        self.tags.get("resonate:timer").map(String::as_str) == Some("true")
+    }
+}
+
+pub(crate) fn parse_promise_state(s: &str) -> PromiseState {
+    match s {
+        "resolved" => PromiseState::Resolved,
+        "rejected" => PromiseState::Rejected,
+        "rejected_canceled" => PromiseState::RejectedCanceled,
+        "rejected_timedout" => PromiseState::RejectedTimedout,
+        _ => PromiseState::Pending,
+    }
+}
+
+pub(crate) fn parse_task_state(s: &str) -> TaskState {
+    match s {
+        "acquired" => TaskState::Acquired,
+        "suspended" => TaskState::Suspended,
+        "halted" => TaskState::Halted,
+        "fulfilled" => TaskState::Fulfilled,
+        _ => TaskState::Pending,
+    }
+}
+
+/// What `enqueue_resume` decided.
+pub(crate) enum SettleOutcome {
+    /// This call won: the suspended awaiters to send executes for, and the
+    /// retry deadline their pre-inserted queue entries carry.
+    Won {
+        resumed: Vec<ResumedAwaiter>,
+        retry_at: i64,
+    },
+    /// A concurrent settle won; the winner's verdict, reconstructed from
+    /// the failed batch's returned columns.
+    Lost {
+        state: String,
+        value_headers: Tags,
+        value_data: Option<String>,
+        settled_at: Option<i64>,
+    },
+    /// A per-awaiter IF failed — nothing committed, retriable.
+    Conflict,
+}
+
+pub(crate) struct ResumedAwaiter {
+    pub id: String,
+    pub target: Option<String>,
+    pub version: i64,
+}
+
+impl ScyllaEngine {
+    pub(crate) async fn exec(
+        &self,
+        cql: &str,
+        values: impl scylla::serialize::row::SerializeRow,
+    ) -> StorageResult<QueryResult> {
+        self.session
+            .execute_unpaged(cql, values)
+            .await
+            .map_err(backend)
+    }
+
+    /// All rows of a SELECT, as name → value maps — gocql's MapScan.
+    pub(crate) async fn rows(
+        &self,
+        cql: &str,
+        values: impl scylla::serialize::row::SerializeRow,
+    ) -> StorageResult<Vec<RowMap>> {
+        let result = self.exec(cql, values).await?;
+        rows_of(result)
+    }
+
+    /// One LWT: `(applied, returned row)`. On `!applied` the row carries the
+    /// IF-clause columns (UPDATE) or the full surviving row (INSERT).
+    pub(crate) async fn cas(
+        &self,
+        cql: &str,
+        values: impl scylla::serialize::row::SerializeRow,
+    ) -> StorageResult<(bool, RowMap)> {
+        let result = self.exec(cql, values).await?;
+        let rows = rows_of(result)?;
+        let first = rows.into_iter().next().unwrap_or_default();
+        let applied = get_bool(&first, "[applied]").unwrap_or(false);
+        Ok((applied, first))
+    }
+
+    /// A logged conditional batch — gocql's MapExecuteBatchCAS. All
+    /// statements must live in one partition; the protocol's same-origin
+    /// rules are what guarantee they do.
+    pub(crate) async fn batch_cas(
+        &self,
+        stmts: Vec<(String, Args)>,
+    ) -> StorageResult<(bool, RowMap)> {
+        let mut batch = Batch::new(BatchType::Logged);
+        let mut values: Vec<Args> = Vec::with_capacity(stmts.len());
+        for (cql, args) in stmts {
+            batch.append_statement(cql.as_str());
+            values.push(args);
+        }
+        let batch = self
+            .session
+            .get_session()
+            .prepare_batch(&batch)
+            .await
+            .map_err(backend)?;
+        let result = self
+            .session
+            .get_session()
+            .batch(&batch, values)
+            .await
+            .map_err(backend)?;
+        let rows = rows_of(result)?;
+        let first = rows.into_iter().next().unwrap_or_default();
+        let applied = get_bool(&first, "[applied]").unwrap_or(false);
+        Ok((applied, first))
+    }
+
+    pub(crate) async fn read_promise(
+        &self,
+        origin: &str,
+        id: &str,
+    ) -> StorageResult<Option<PromiseRow>> {
+        let rows = self
+            .rows(
+                &format!("SELECT {P_COLS} FROM promises WHERE origin = ? AND id = ?"),
+                (origin, id),
+            )
+            .await?;
+        Ok(rows.first().map(PromiseRow::from_map))
+    }
+
+    /// The ghost operation: read, and eagerly settle if logically expired —
+    /// Go's `readAndTryTimeout`. Returns the row as a caller must see it,
+    /// re-read after a settle so it reflects what committed.
+    pub(crate) async fn read_and_try_timeout(
+        &self,
+        ctx: &mut Ctx,
+        id: &str,
+        now: i64,
+    ) -> StorageResult<Option<PromiseRow>> {
+        let origin = origin_of(id).to_string();
+        let Some(row) = self.read_promise(&origin, id).await? else {
+            return Ok(None);
+        };
+        if row.state == "pending" && now >= row.timeout_at {
+            self.try_timeout(ctx, &row, now).await?;
+            return self.read_promise(&origin, id).await;
+        }
+        Ok(Some(row))
+    }
+
+    /// Eagerly settle one expired pending promise — Go's `tryTimeout`: the
+    /// pinned-callbacks settle through `enqueue_resume`, then messages,
+    /// then queue cleanup, all idempotent against a concurrent winner.
+    pub(crate) async fn try_timeout(
+        &self,
+        ctx: &mut Ctx,
+        row: &PromiseRow,
+        now: i64,
+    ) -> StorageResult<()> {
+        let new_state = if row.is_timer() {
+            "resolved"
+        } else {
+            "rejected_timedout"
+        };
+        let has_task = row.task_state.is_some();
+        let settle_stmt = settle_cql(has_task);
+        let settle_args: Args = vec![
+            text(new_state),
+            big(row.timeout_at),
+            text(&row.origin),
+            text(&row.id),
+            cql_set(&row.callbacks),
+        ];
+
+        let outcome = self
+            .enqueue_resume(&row.id, &row.origin, &row.callbacks, now, settle_stmt, settle_args)
+            .await?;
+
+        if let SettleOutcome::Won { resumed, retry_at } = outcome {
+            // The settled record, as the batch just made it.
+            let mut settled = row.clone();
+            settled.state = new_state.to_string();
+            settled.settled_at = Some(row.timeout_at);
+            settled.value_headers = Tags::new();
+            settled.value_data = None;
+            self.after_settle_won(ctx, &settled, resumed, retry_at)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Everything a winning settle owes after the batch, in Go's order:
+    /// executes to the resumed, unblocks to the listeners, then best-effort
+    /// queue-entry deletes. Nothing else — a fulfilled awaiter stays in
+    /// other promises' callbacks sets and is skipped lazily when they
+    /// settle, exactly as the Go implementation leaves it.
+    pub(crate) async fn after_settle_won(
+        &self,
+        ctx: &mut Ctx,
+        settled: &PromiseRow,
+        resumed: Vec<ResumedAwaiter>,
+        retry_at: i64,
+    ) -> StorageResult<()> {
+        for r in &resumed {
+            self.arm_retry(ctx, &r.id, retry_at);
+            if let Some(target) = &r.target {
+                ctx.messages.push(Outgoing::Execute {
+                    address: target.clone(),
+                    task_id: r.id.clone(),
+                    version: r.version,
+                });
+            }
+        }
+        let record = settled.to_promise_record();
+        for address in &settled.listeners {
+            ctx.messages.push(Outgoing::Unblock {
+                address: address.clone(),
+                promise: record.clone(),
+            });
+        }
+
+        // EXPLORATORY (decision pending): the relational engines delete a
+        // fulfilled awaiter's registrations at settlement; Go leaves them to
+        // be skipped lazily. The differential sees the difference in the
+        // callbacks section (first at ~step 1923). Aligned here so the run
+        // can continue cataloguing; same-origin rules make it one
+        // partition-local scan.
+        if settled.task_state.is_some() {
+            let holders = self
+                .rows(
+                    "SELECT id, callbacks FROM promises WHERE origin = ?",
+                    (settled.origin.as_str(),),
+                )
+                .await?;
+            for m in holders {
+                let hid = get_text(&m, "id").unwrap_or_default();
+                if hid != settled.id
+                    && get_set(&m, "callbacks").iter().any(|c| c == &settled.id)
+                {
+                    let _ = self
+                        .exec(
+                            "UPDATE promises SET callbacks = callbacks - ? WHERE origin = ? AND id = ?",
+                            (
+                                vec![settled.id.clone()],
+                                settled.origin.as_str(),
+                                hid.as_str(),
+                            ),
+                        )
+                        .await;
+                }
+            }
+        }
+
+        // Queue cleanup on a win, best effort — a kill here leaves an
+        // orphan entry the tick handlers classify and delete.
+        let _ = self
+            .exec(
+                "DELETE FROM promise_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND promise_id = ?",
+                (
+                    self.bucket_for(settled.timeout_at),
+                    self.shard_for(&settled.id),
+                    settled.timeout_at,
+                    settled.origin.as_str(),
+                    settled.id.as_str(),
+                ),
+            )
+            .await;
+        if let Some(retry_at) = settled.task_timeout_retry {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(retry_at),
+                        self.shard_for(&settled.id),
+                        retry_at,
+                        settled.origin.as_str(),
+                        settled.id.as_str(),
+                    ),
+                )
+                .await;
+        }
+        if let Some(lease_at) = settled.task_timeout_lease {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(lease_at),
+                        self.shard_for(&settled.id),
+                        lease_at,
+                        settled.origin.as_str(),
+                        settled.id.as_str(),
+                    ),
+                )
+                .await;
+        }
+        Ok(())
+    }
+
+    /// Atomically settle and fan out to the awaiters — Go's `enqueueResume`:
+    /// pre-insert retry entries for the suspended, then one logged
+    /// conditional batch of the caller's settle plus one statement per
+    /// awaiter, keyed by the task state each was read in.
+    pub(crate) async fn enqueue_resume(
+        &self,
+        settled_id: &str,
+        origin: &str,
+        callbacks: &[String],
+        now: i64,
+        settle_stmt: String,
+        settle_args: Args,
+    ) -> StorageResult<SettleOutcome> {
+        struct Awaiter {
+            id: String,
+            task_state: Option<String>,
+            version: i64,
+            target: Option<String>,
+            timeout_at: i64,
+        }
+
+        let mut awaiters = Vec::new();
+        for cb in callbacks {
+            let rows = self
+                .rows(
+                    "SELECT task_state, task_version, target, timeout_at FROM promises WHERE origin = ? AND id = ?",
+                    (origin, cb.as_str()),
+                )
+                .await?;
+            if let Some(m) = rows.first() {
+                awaiters.push(Awaiter {
+                    id: cb.clone(),
+                    task_state: get_text(m, "task_state"),
+                    version: get_int(m, "task_version").unwrap_or(0) as i64,
+                    target: get_text(m, "target"),
+                    timeout_at: get_big(m, "timeout_at").unwrap_or(0),
+                });
+            }
+        }
+
+        // Pre-insert retry entries for the suspended, rollback on failure.
+        let retry_at = now + self.task_retry_timeout;
+        let mut preinserted: Vec<String> = Vec::new();
+        for a in &awaiters {
+            if a.task_state.as_deref() == Some("suspended") {
+                if let Err(e) = self
+                    .exec(
+                        "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+                        (
+                            self.bucket_for(retry_at),
+                            self.shard_for(&a.id),
+                            retry_at,
+                            a.id.as_str(),
+                            origin,
+                            a.timeout_at,
+                        ),
+                    )
+                    .await
+                {
+                    self.rollback_retries(origin, &preinserted, retry_at).await;
+                    return Err(e);
+                }
+                preinserted.push(a.id.clone());
+            }
+        }
+
+        let mut stmts: Vec<(String, Args)> = vec![(settle_stmt, settle_args)];
+        for a in &awaiters {
+            match a.task_state.as_deref() {
+                Some("fulfilled") | None => {}
+                Some("suspended") => stmts.push((
+                    "UPDATE promises SET task_state = 'pending', task_resumes = ?, task_timeout_retry = ? WHERE origin = ? AND id = ? IF task_state = 'suspended'".to_string(),
+                    vec![
+                        cql_set(std::slice::from_ref(&settled_id.to_string())),
+                        big(retry_at),
+                        text(origin),
+                        text(&a.id),
+                    ],
+                )),
+                Some(state) => stmts.push((
+                    format!(
+                        "UPDATE promises SET task_resumes = task_resumes + ? WHERE origin = ? AND id = ? IF task_state = '{state}'"
+                    ),
+                    vec![
+                        cql_set(std::slice::from_ref(&settled_id.to_string())),
+                        text(origin),
+                        text(&a.id),
+                    ],
+                )),
+            }
+        }
+
+        let (applied, row) = match self.batch_cas(stmts).await {
+            Ok(v) => v,
+            Err(e) => {
+                self.rollback_retries(origin, &preinserted, retry_at).await;
+                return Err(e);
+            }
+        };
+
+        if !applied {
+            self.rollback_retries(origin, &preinserted, retry_at).await;
+            let state = get_text(&row, "state").unwrap_or_default();
+            if !state.is_empty() && state != "pending" {
+                return Ok(SettleOutcome::Lost {
+                    state,
+                    value_headers: get_tags(&row, "value_headers"),
+                    value_data: get_text(&row, "value_data"),
+                    settled_at: get_big(&row, "settled_at"),
+                });
+            }
+            return Ok(SettleOutcome::Conflict);
+        }
+
+        let resumed = awaiters
+            .into_iter()
+            .filter(|a| a.task_state.as_deref() == Some("suspended"))
+            .map(|a| ResumedAwaiter {
+                id: a.id,
+                target: a.target,
+                version: a.version,
+            })
+            .collect();
+        Ok(SettleOutcome::Won { resumed, retry_at })
+    }
+
+    async fn rollback_retries(&self, origin: &str, ids: &[String], retry_at: i64) {
+        for id in ids {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(retry_at),
+                        self.shard_for(id),
+                        retry_at,
+                        origin,
+                        id.as_str(),
+                    ),
+                )
+                .await;
+        }
+    }
+
+    /// Report a retry deadline this transition just wrote.
+    pub(crate) fn arm_retry(&self, ctx: &mut Ctx, task_id: &str, at: i64) {
+        ctx.armed.push(Scheduled {
+            at,
+            timeout: Timeout::TaskRetryTimeout {
+                task_id: task_id.to_string(),
+            },
+        });
+    }
+
+    pub(crate) fn arm_lease(&self, ctx: &mut Ctx, task_id: &str, pid: &str, at: i64) {
+        ctx.armed.push(Scheduled {
+            at,
+            timeout: Timeout::TaskLeaseTimeout {
+                task_id: task_id.to_string(),
+                pid: pid.to_string(),
+            },
+        });
+    }
+
+    /// A promise joins the reported hints only when awaitable — the queue
+    /// row is written for everyone (eager, like Go), but the announcement
+    /// follows the protocol every engine speaks.
+    pub(crate) fn arm_promise_timeout(
+        &self,
+        ctx: &mut Ctx,
+        promise_id: &str,
+        timeout_at: i64,
+        awaitable: bool,
+    ) {
+        if awaitable {
+            ctx.armed.push(Scheduled {
+                at: timeout_at,
+                timeout: Timeout::PromiseTimeout {
+                    promise_id: promise_id.to_string(),
+                },
+            });
+        }
+    }
+
+}
+
+pub(crate) fn rows_of(result: QueryResult) -> StorageResult<Vec<RowMap>> {
+    if !result.is_rows() {
+        return Ok(Vec::new());
+    }
+    let rows_result = result.into_rows_result().map_err(backend)?;
+    let names: Vec<String> = rows_result
+        .column_specs()
+        .iter()
+        .map(|c| c.name().to_string())
+        .collect();
+    let mut out = Vec::new();
+    for row in rows_result.rows::<Row>().map_err(backend)? {
+        let row = row.map_err(backend)?;
+        let mut m = RowMap::new();
+        for (name, value) in names.iter().zip(row.columns.into_iter()) {
+            m.insert(name.clone(), value);
+        }
+        out.push(m);
+    }
+    Ok(out)
+}
+
+/// The settle statement both settle paths share — Go's two variants: with
+/// the task columns folded in when the promise carries one. The IF pins
+/// state, the exact callbacks set, and the un-written value columns, so a
+/// failed batch returns enough to reconstruct the winner's verdict.
+pub(crate) fn settle_cql(has_task: bool) -> String {
+    if has_task {
+        "UPDATE promises SET state = ?, settled_at = ?, value_headers = null, value_data = null, \
+         callbacks = {}, listeners = {}, task_state = 'fulfilled', task_pid = null, \
+         task_ttl = null, task_timeout_retry = null, task_timeout_lease = null, task_resumes = {} \
+         WHERE origin = ? AND id = ? \
+         IF state = 'pending' AND callbacks = ? AND settled_at = null AND value_headers = null AND value_data = null"
+            .to_string()
+    } else {
+        "UPDATE promises SET state = ?, settled_at = ?, value_headers = null, value_data = null, \
+         callbacks = {}, listeners = {} \
+         WHERE origin = ? AND id = ? \
+         IF state = 'pending' AND callbacks = ? AND settled_at = null AND value_headers = null AND value_data = null"
+            .to_string()
+    }
+}

--- a/crates/resonate-server-scylladb/src/db.rs
+++ b/crates/resonate-server-scylladb/src/db.rs
@@ -214,6 +214,23 @@ impl PromiseRow {
     }
 }
 
+/// The record as a reader sees it: the deadline is a projection every read
+/// applies, so a pending row past its deadline reads as its timeout verdict
+/// — the same bytes an eager settle wrote, because the verdict and
+/// `settled_at = timeout_at` are deterministic.
+pub(crate) fn project(p: &PromiseRow, now: i64) -> PromiseRecord {
+    let mut record = p.to_promise_record();
+    if p.state == "pending" && now >= p.timeout_at {
+        record.state = if p.is_timer() {
+            PromiseState::Resolved
+        } else {
+            PromiseState::RejectedTimedout
+        };
+        record.settled_at = Some(p.timeout_at);
+    }
+    record
+}
+
 pub(crate) fn parse_promise_state(s: &str) -> PromiseState {
     match s {
         "resolved" => PromiseState::Resolved,
@@ -432,37 +449,11 @@ impl ScyllaEngine {
             });
         }
 
-        // EXPLORATORY (decision pending): the relational engines delete a
-        // fulfilled awaiter's registrations at settlement; Go leaves them to
-        // be skipped lazily. The differential sees the difference in the
-        // callbacks section (first at ~step 1923). Aligned here so the run
-        // can continue cataloguing; same-origin rules make it one
-        // partition-local scan.
-        if settled.task_state.is_some() {
-            let holders = self
-                .rows(
-                    "SELECT id, callbacks FROM promises WHERE origin = ?",
-                    (settled.origin.as_str(),),
-                )
-                .await?;
-            for m in holders {
-                let hid = get_text(&m, "id").unwrap_or_default();
-                if hid != settled.id
-                    && get_set(&m, "callbacks").iter().any(|c| c == &settled.id)
-                {
-                    let _ = self
-                        .exec(
-                            "UPDATE promises SET callbacks = callbacks - ? WHERE origin = ? AND id = ?",
-                            (
-                                vec![settled.id.clone()],
-                                settled.origin.as_str(),
-                                hid.as_str(),
-                            ),
-                        )
-                        .await;
-                }
-            }
-        }
+        // No registration cleanup: a fulfilled awaiter stays in other
+        // promises' callbacks sets and is skipped lazily when they settle,
+        // exactly as the Go implementation leaves it. The snapshot's
+        // member-side projection is what keeps that invisible — a fulfilled
+        // member reports as absent, because it is provably inert.
 
         // Queue cleanup on a win, best effort — a kill here leaves an
         // orphan entry the tick handlers classify and delete.
@@ -534,17 +525,27 @@ impl ScyllaEngine {
         for cb in callbacks {
             let rows = self
                 .rows(
-                    "SELECT task_state, task_version, target, timeout_at FROM promises WHERE origin = ? AND id = ?",
+                    "SELECT state, task_state, task_version, target, timeout_at FROM promises WHERE origin = ? AND id = ?",
                     (origin, cb.as_str()),
                 )
                 .await?;
             if let Some(m) = rows.first() {
+                // An awaiter that is settled, or expired at `now`, is not
+                // resumed and records nothing: its own deadline owns it. A
+                // same-sweep expiry settles it moments later, and resuming
+                // it first would emit an execute for a task about to
+                // fulfill — the extra message the model never sends.
+                let state = get_text(m, "state").unwrap_or_default();
+                let timeout_at = get_big(m, "timeout_at").unwrap_or(0);
+                if state != "pending" || timeout_at <= now {
+                    continue;
+                }
                 awaiters.push(Awaiter {
                     id: cb.clone(),
                     task_state: get_text(m, "task_state"),
                     version: get_int(m, "task_version").unwrap_or(0) as i64,
                     target: get_text(m, "target"),
-                    timeout_at: get_big(m, "timeout_at").unwrap_or(0),
+                    timeout_at,
                 });
             }
         }
@@ -708,7 +709,7 @@ pub(crate) fn rows_of(result: QueryResult) -> StorageResult<Vec<RowMap>> {
     for row in rows_result.rows::<Row>().map_err(backend)? {
         let row = row.map_err(backend)?;
         let mut m = RowMap::new();
-        for (name, value) in names.iter().zip(row.columns.into_iter()) {
+        for (name, value) in names.iter().zip(row.columns) {
             m.insert(name.clone(), value);
         }
         out.push(m);

--- a/crates/resonate-server-scylladb/src/lib.rs
+++ b/crates/resonate-server-scylladb/src/lib.rs
@@ -1,0 +1,342 @@
+//! Resonate's durable state, over ScyllaDB.
+//!
+//! The mechanics are `resonate-on-scylladb`'s, carried over deliberately:
+//! one `promises` table partitioned by origin so a transition and its
+//! fanout are a single-partition LWT or conditional batch; bucketed,
+//! sharded timeout queues written through the pre-insert protocol; and an
+//! EAGER deadline for every pending promise, internal included — where the
+//! relational engines stay lazy. The differential is the experiment that
+//! decides whether that difference is observable.
+//!
+//! What is not Go's: messages are returned, not dispatched (`Output`
+//! carries them), `now` is a parameter, and the scan loops are driven by
+//! the server through `tick`/`process(Internal)` rather than by their own
+//! goroutines. The queries underneath are the same queries.
+
+mod db;
+mod ops_promise;
+mod ops_schedule;
+mod ops_task;
+mod snap;
+mod timeouts;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use scylla::client::caching_session::CachingSession;
+use scylla::client::session_builder::SessionBuilder;
+use serde::{Deserialize, Serialize};
+
+use resonate_core::types::{RequestEnvelope, ResponseEnvelope};
+use resonate_server_dbms::engine_port::{Input, Outgoing, Output, ResonateEngine, Scheduled};
+use resonate_server_dbms::{StorageError, StorageResult};
+
+/// The embedded schema, applied statement by statement when `migrate` asks.
+const SCHEMA_CQL: &str = include_str!("../schema.cql");
+
+/// Between a task redispatch and the next execute message: the follow-up
+/// deadline every retry path arms. Same constant, same meaning, as the
+/// other engines' `task_retry_timeout` — carried in config here too.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    /// Seed hosts, bare or host:port.
+    #[serde(default = "default_hosts")]
+    pub hosts: Vec<String>,
+    /// CQL port for hosts without one AND for gossip-discovered peers.
+    #[serde(default)]
+    pub port: u16,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default = "default_keyspace")]
+    pub keyspace: String,
+    /// CREATE KEYSPACE replication clause, e.g.
+    /// "{'class': 'NetworkTopologyStrategy', 'dc1': 3}". Empty = server default.
+    #[serde(default)]
+    pub replication: String,
+    /// Apply the embedded schema (CREATE ... IF NOT EXISTS) on connect.
+    /// False = verify nothing, assume schema provisioned out of band.
+    #[serde(default)]
+    pub migrate: bool,
+    /// Timeout-queue bucket width in ms.
+    #[serde(default = "default_bucket_width")]
+    pub bucket_width: i64,
+    /// Past buckets each scan covers, in addition to the current one.
+    #[serde(default = "default_bucket_lookback")]
+    pub bucket_lookback: i64,
+    /// Queue-table shard count; entries land on fnv32a(id) % shards.
+    #[serde(default = "default_shards")]
+    pub shards: i16,
+    /// How many branch siblings a task response may carry.
+    #[serde(default = "default_preload_limit")]
+    pub preload_limit: u32,
+}
+
+fn default_hosts() -> Vec<String> {
+    vec!["localhost".to_string()]
+}
+fn default_keyspace() -> String {
+    "resonate".to_string()
+}
+fn default_bucket_width() -> i64 {
+    3_600_000
+}
+fn default_bucket_lookback() -> i64 {
+    1
+}
+fn default_shards() -> i16 {
+    1
+}
+fn default_preload_limit() -> u32 {
+    10
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            hosts: default_hosts(),
+            port: 0,
+            username: String::new(),
+            password: String::new(),
+            keyspace: default_keyspace(),
+            replication: String::new(),
+            migrate: false,
+            bucket_width: default_bucket_width(),
+            bucket_lookback: default_bucket_lookback(),
+            shards: default_shards(),
+            preload_limit: default_preload_limit(),
+        }
+    }
+}
+
+pub struct ScyllaEngine {
+    pub(crate) session: Arc<CachingSession>,
+    pub(crate) bucket_width: i64,
+    pub(crate) bucket_lookback: i64,
+    pub(crate) shards: i16,
+    pub(crate) task_retry_timeout: i64,
+    pub(crate) preload_limit: u32,
+    pub(crate) debug: bool,
+}
+
+impl ScyllaEngine {
+    /// Open a session and, when `migrate`, apply the embedded schema. The
+    /// keyspace is created if missing either way — a keyspace-bound session
+    /// cannot exist without one, and creating an empty keyspace is the same
+    /// "empty database is always created" policy the SQL engines follow.
+    pub async fn connect(
+        cfg: &Config,
+        task_retry_timeout: i64,
+        debug: bool,
+    ) -> StorageResult<Self> {
+        let mut builder = SessionBuilder::new().known_nodes(&cfg.hosts);
+        if cfg.port != 0 {
+            let with_ports: Vec<String> = cfg
+                .hosts
+                .iter()
+                .map(|h| {
+                    if h.contains(':') {
+                        h.clone()
+                    } else {
+                        format!("{}:{}", h, cfg.port)
+                    }
+                })
+                .collect();
+            builder = SessionBuilder::new().known_nodes(&with_ports);
+        }
+        if !cfg.username.is_empty() || !cfg.password.is_empty() {
+            builder = builder.user(cfg.username.clone(), cfg.password.clone());
+        }
+        let session = builder
+            .build()
+            .await
+            .map_err(|e| StorageError::Backend(format!("scylladb connect: {e}")))?;
+
+        let replication = if cfg.replication.is_empty() {
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+        } else {
+            cfg.replication.as_str()
+        };
+        // Tablets refuse LWT, and LWT is this engine's entire write
+        // mechanism — the keyspace opts out explicitly on ScyllaDB versions
+        // that would otherwise default to them.
+        let create = format!(
+            "CREATE KEYSPACE IF NOT EXISTS {} WITH replication = {} AND tablets = {{'enabled': false}}",
+            cfg.keyspace, replication
+        );
+        session
+            .query_unpaged(create, ())
+            .await
+            .map_err(|e| StorageError::Backend(format!("create keyspace: {e}")))?;
+        session
+            .use_keyspace(cfg.keyspace.clone(), false)
+            .await
+            .map_err(|e| StorageError::Backend(format!("use keyspace: {e}")))?;
+
+        if cfg.migrate {
+            for stmt in schema_statements() {
+                session
+                    .query_unpaged(stmt.clone(), ())
+                    .await
+                    .map_err(|e| StorageError::Backend(format!("apply schema: {e}: {stmt}")))?;
+            }
+        }
+
+        Ok(Self {
+            session: Arc::new(CachingSession::from(session, 256)),
+            bucket_width: cfg.bucket_width.max(1),
+            bucket_lookback: cfg.bucket_lookback.max(0),
+            shards: cfg.shards.max(1),
+            task_retry_timeout,
+            preload_limit: cfg.preload_limit,
+            debug,
+        })
+    }
+
+    pub(crate) fn bucket_for(&self, t: i64) -> i64 {
+        t.div_euclid(self.bucket_width)
+    }
+
+    /// fnv32a(id) % shards, like the Go implementation — keyed on the
+    /// entity id, not the origin, so one call graph's deadlines spread.
+    pub(crate) fn shard_for(&self, id: &str) -> i16 {
+        if self.shards <= 1 {
+            return 0;
+        }
+        let mut h: u32 = 0x811c_9dc5;
+        for b in id.as_bytes() {
+            h ^= *b as u32;
+            h = h.wrapping_mul(0x0100_0193);
+        }
+        (h % self.shards as u32) as i16
+    }
+
+    /// Buckets a scan at `t` covers: the current one plus the lookback.
+    pub(crate) fn buckets_to_scan(&self, t: i64) -> Vec<i64> {
+        let cur = self.bucket_for(t);
+        let start = (cur - self.bucket_lookback).max(0);
+        (start..=cur).collect()
+    }
+
+    pub async fn dispatch(&self, req: &RequestEnvelope, now: i64) -> Output {
+        match req.kind.as_str() {
+            "promise.get" => self.op_promise_get(req, now).await,
+            "promise.create" => self.op_promise_create(req, now).await,
+            "promise.settle" => self.op_promise_settle(req, now).await,
+            "promise.register_callback" => self.op_promise_register_callback(req, now).await,
+            "promise.register_listener" => self.op_promise_register_listener(req, now).await,
+            "promise.search" => self.op_promise_search(req, now).await,
+
+            "task.get" => self.op_task_get(req, now).await,
+            "task.create" => self.op_task_create(req, now).await,
+            "task.acquire" => self.op_task_acquire(req, now).await,
+            "task.release" => self.op_task_release(req, now).await,
+            "task.fulfill" => self.op_task_fulfill(req, now).await,
+            "task.suspend" => self.op_task_suspend(req, now).await,
+            "task.fence" => self.op_task_fence(req, now).await,
+            "task.heartbeat" => self.op_task_heartbeat(req, now).await,
+            "task.halt" => self.op_task_halt(req, now).await,
+            "task.continue" => self.op_task_continue(req, now).await,
+            "task.search" => self.op_task_search(req, now).await,
+
+            "schedule.get" => self.op_schedule_get(req, now).await,
+            "schedule.create" => self.op_schedule_create(req, now).await,
+            "schedule.delete" => self.op_schedule_delete(req).await,
+            "schedule.search" => self.op_schedule_search(req).await,
+
+            "debug.reset" | "debug.snap" | "debug.tick" if !self.debug => {
+                Output::response(ResponseEnvelope::error(
+                    req.kind.clone(),
+                    req.head.corr_id.clone(),
+                    403,
+                    "Debug operations are disabled",
+                ))
+            }
+            "debug.reset" => self.op_debug_reset(req).await,
+            "debug.snap" => self.op_debug_snap(req, now).await,
+            "debug.tick" => self.op_debug_tick(req).await,
+
+            _ => Output::response(ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                400,
+                &format!("Unknown request kind: {}", req.kind),
+            )),
+        }
+    }
+}
+
+/// Split the embedded schema into statements, skipping CREATE KEYSPACE and
+/// USE (handled by `connect`) and comment lines — the Go loader, verbatim.
+fn schema_statements() -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in SCHEMA_CQL.split(';') {
+        let stmt: String = raw
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("--"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let stmt = stmt.trim().to_string();
+        if stmt.is_empty() {
+            continue;
+        }
+        let upper = stmt.to_uppercase();
+        if upper.starts_with("CREATE KEYSPACE") || upper.starts_with("USE ") {
+            continue;
+        }
+        out.push(stmt);
+    }
+    out
+}
+
+/// The origin is everything before the id's first ':' — the partition key,
+/// and spec-level ("an id is an origin and a suffix").
+pub(crate) fn origin_of(id: &str) -> &str {
+    id.split_once(':').map(|(o, _)| o).unwrap_or(id)
+}
+
+/// What one transition accumulates: the messages it emitted and the
+/// deadlines it armed. The engine writes queue rows for every pending
+/// promise (eager, like Go); the HINTS it reports follow the protocol —
+/// awaitable only — so the wheel and the differential see the same
+/// announcements every engine makes.
+#[derive(Default)]
+pub(crate) struct Ctx {
+    pub messages: Vec<Outgoing>,
+    pub armed: Vec<Scheduled>,
+}
+
+pub(crate) type Tags = HashMap<String, String>;
+
+#[async_trait]
+impl ResonateEngine for ScyllaEngine {
+    async fn process(&self, input: Input<'_>, now: i64) -> Output {
+        match input {
+            Input::External(req) => self.dispatch(req, now).await,
+            Input::Internal(timeout) => self.process_internal(timeout, now).await,
+        }
+    }
+
+    async fn tick(&self, now: i64) -> StorageResult<(usize, Vec<Outgoing>, Vec<Scheduled>)> {
+        self.tick_impl(now).await
+    }
+
+    async fn upcoming(&self, limit: usize) -> StorageResult<Vec<Scheduled>> {
+        self.upcoming_impl(limit).await
+    }
+
+    async fn ping(&self) -> StorageResult<()> {
+        self.session
+            .get_session()
+            .query_unpaged("SELECT release_version FROM system.local", ())
+            .await
+            .map_err(|e| StorageError::Backend(format!("ping: {e}")))?;
+        Ok(())
+    }
+
+    fn returns_messages(&self) -> bool {
+        true
+    }
+}

--- a/crates/resonate-server-scylladb/src/lib.rs
+++ b/crates/resonate-server-scylladb/src/lib.rs
@@ -14,6 +14,7 @@
 //! goroutines. The queries underneath are the same queries.
 
 mod db;
+mod tls;
 mod ops_promise;
 mod ops_schedule;
 mod ops_task;
@@ -72,6 +73,27 @@ pub struct Config {
     /// How many branch siblings a task response may carry.
     #[serde(default = "default_preload_limit")]
     pub preload_limit: u32,
+    /// Worker heartbeat TTL in ms — how long a dead instance keeps its
+    /// shard assignment. Must exceed the server's sweep interval, or live
+    /// workers expire between their own heartbeats.
+    #[serde(default = "default_worker_ttl")]
+    pub worker_ttl: i64,
+    /// TLS to the cluster.
+    #[serde(default)]
+    pub tls: TlsConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TlsConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Encrypt but skip certificate verification — for dev clusters with
+    /// private-CA certs, the SCYLLADB_TLS_INSECURE the Go deployment used.
+    #[serde(default)]
+    pub insecure: bool,
+    /// PEM file with the CA to trust instead of the WebPKI roots.
+    #[serde(default)]
+    pub ca_cert: Option<String>,
 }
 
 fn default_hosts() -> Vec<String> {
@@ -92,6 +114,9 @@ fn default_shards() -> i16 {
 fn default_preload_limit() -> u32 {
     10
 }
+fn default_worker_ttl() -> i64 {
+    180_000
+}
 
 impl Default for Config {
     fn default() -> Self {
@@ -107,6 +132,8 @@ impl Default for Config {
             bucket_lookback: default_bucket_lookback(),
             shards: default_shards(),
             preload_limit: default_preload_limit(),
+            worker_ttl: default_worker_ttl(),
+            tls: TlsConfig::default(),
         }
     }
 }
@@ -118,6 +145,8 @@ pub struct ScyllaEngine {
     pub(crate) shards: i16,
     pub(crate) task_retry_timeout: i64,
     pub(crate) preload_limit: u32,
+    pub(crate) worker_ttl: i64,
+    pub(crate) worker_id: uuid::Uuid,
     pub(crate) debug: bool,
 }
 
@@ -149,6 +178,17 @@ impl ScyllaEngine {
         if !cfg.username.is_empty() || !cfg.password.is_empty() {
             builder = builder.user(cfg.username.clone(), cfg.password.clone());
         }
+        if cfg.tls.enabled {
+            builder = builder.tls_context(Some(tls::context(&cfg.tls)?));
+        }
+        // Explicit, not inherited: Quorum for reads and writes, Serial for
+        // the LWT Paxos round — the settings this engine's mechanics assume,
+        // stated rather than left to whatever the driver ships.
+        let profile = scylla::client::execution_profile::ExecutionProfile::builder()
+            .consistency(scylla::statement::Consistency::Quorum)
+            .serial_consistency(Some(scylla::statement::SerialConsistency::Serial))
+            .build();
+        builder = builder.default_execution_profile_handle(profile.into_handle());
         let session = builder
             .build()
             .await
@@ -191,6 +231,8 @@ impl ScyllaEngine {
             shards: cfg.shards.max(1),
             task_retry_timeout,
             preload_limit: cfg.preload_limit,
+            worker_ttl: cfg.worker_ttl.max(1_000),
+            worker_id: uuid::Uuid::new_v4(),
             debug,
         })
     }

--- a/crates/resonate-server-scylladb/src/lib.rs
+++ b/crates/resonate-server-scylladb/src/lib.rs
@@ -14,12 +14,12 @@
 //! goroutines. The queries underneath are the same queries.
 
 mod db;
-mod tls;
 mod ops_promise;
 mod ops_schedule;
 mod ops_task;
 mod snap;
 mod timeouts;
+mod tls;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/resonate-server-scylladb/src/ops_promise.rs
+++ b/crates/resonate-server-scylladb/src/ops_promise.rs
@@ -8,15 +8,15 @@
 use resonate_core::types::{
     format_validation_errors, PromiseCreateData, PromiseGetData, PromiseRecord,
     PromiseRegisterCallbackData, PromiseRegisterListenerData, PromiseResponseData,
-    PromiseSearchData, PromiseSearchResponseData, PromiseSettleData, PromiseValue,
-    RequestEnvelope, ResponseEnvelope,
+    PromiseSearchData, PromiseSearchResponseData, PromiseSettleData, PromiseValue, RequestEnvelope,
+    ResponseEnvelope,
 };
 use resonate_server_dbms::engine_port::{Outgoing, Output};
 use validator::Validate;
 
 use crate::db::{
-    big, cql_map, cql_set, get_big, int, opt_cql_map, opt_text, text, Args,
-    PromiseRow, SettleOutcome,
+    big, cql_map, cql_set, get_big, int, opt_cql_map, opt_text, text, Args, PromiseRow,
+    SettleOutcome,
 };
 use crate::{origin_of, Ctx, ScyllaEngine};
 
@@ -131,7 +131,11 @@ impl ScyllaEngine {
         let already_timedout = now >= r.timeout_at;
 
         let (state, created_at, settled_at) = if already_timedout {
-            let s = if is_timer { "resolved" } else { "rejected_timedout" };
+            let s = if is_timer {
+                "resolved"
+            } else {
+                "rejected_timedout"
+            };
             (s, r.timeout_at, Some(r.timeout_at))
         } else {
             ("pending", now, None)
@@ -374,7 +378,9 @@ impl ScyllaEngine {
                 settled.value_headers = r.value.headers.clone().unwrap_or_default();
                 settled.value_data = r.value.data.clone();
                 settled.settled_at = Some(settled_at_val);
-                if let Err(e) = self.after_settle_won(&mut ctx, &settled, resumed, retry_at).await
+                if let Err(e) = self
+                    .after_settle_won(&mut ctx, &settled, resumed, retry_at)
+                    .await
                 {
                     return storage_err(req, e);
                 }
@@ -649,10 +655,7 @@ impl ScyllaEngine {
             None => 100,
         };
         let rows = match self
-            .rows(
-                &format!("SELECT {} FROM promises", crate::db::P_COLS),
-                (),
-            )
+            .rows(&format!("SELECT {} FROM promises", crate::db::P_COLS), ())
             .await
         {
             Ok(rows) => rows,

--- a/crates/resonate-server-scylladb/src/ops_promise.rs
+++ b/crates/resonate-server-scylladb/src/ops_promise.rs
@@ -209,10 +209,10 @@ impl ScyllaEngine {
             cql_map(&r.tags),
             big(r.timeout_at),
             big(created_at),
-            settled_at.and_then(|v| big(v)),
+            settled_at.and_then(big),
             opt_text(task_state),
-            task_version.and_then(|v| int(v)),
-            task_retry_arg.and_then(|v| big(v)),
+            task_version.and_then(int),
+            task_retry_arg.and_then(big),
         ];
         let (applied, row) = self
             .cas(
@@ -552,6 +552,10 @@ impl ScyllaEngine {
                     });
                 }
             }
+            // A halted awaiter records nothing at registration time — its
+            // resume ledger fills only through the settle fanout. (The Go
+            // implementation appends here too; the protocol does not.)
+            Some("halted") => {}
             Some(state) => {
                 let (applied, _row) = self
                     .cas(
@@ -629,8 +633,10 @@ impl ScyllaEngine {
     }
 
     /// A full scan, filtered and sorted in memory: search is an operator's
-    /// read, and the table is partitioned for transitions, not for it.
-    pub(crate) async fn op_promise_search(&self, req: &RequestEnvelope, _now: i64) -> Output {
+    /// read, and the table is partitioned for transitions, not for it. The
+    /// records project expiry, like every read, and the state filter asks
+    /// the projected state.
+    pub(crate) async fn op_promise_search(&self, req: &RequestEnvelope, now: i64) -> Output {
         let r: PromiseSearchData = match parse(req) {
             Ok(r) => r,
             Err(e) => return Output::response(e),
@@ -652,15 +658,15 @@ impl ScyllaEngine {
             Ok(rows) => rows,
             Err(e) => return storage_err(req, e),
         };
-        let state_filter = r.state.map(|s| s.to_string());
         let mut promises: Vec<PromiseRecord> = rows
             .iter()
             .map(PromiseRow::from_map)
-            .filter(|p| {
-                state_filter
-                    .as_ref()
-                    .map(|s| &p.state == s)
-                    .unwrap_or(true)
+            .map(|p| {
+                let record = crate::db::project(&p, now);
+                (record, p)
+            })
+            .filter(|(record, p)| {
+                r.state.map(|s| record.state == s).unwrap_or(true)
                     && r.tags
                         .as_ref()
                         .map(|ft| {
@@ -669,7 +675,7 @@ impl ScyllaEngine {
                         })
                         .unwrap_or(true)
             })
-            .map(|p| p.to_promise_record())
+            .map(|(record, _)| record)
             .collect();
         promises.sort_by(|a, b| a.id.cmp(&b.id));
         if let Some(cursor) = r.cursor.as_deref() {

--- a/crates/resonate-server-scylladb/src/ops_promise.rs
+++ b/crates/resonate-server-scylladb/src/ops_promise.rs
@@ -1,0 +1,691 @@
+//! The promise operations — Go's `handler_promise.go`, translated.
+//!
+//! Flow, guards and statuses are the Go implementation's; what differs is
+//! the envelope (this repo's request/response types), messages riding out
+//! on the `Output` instead of a dispatcher, and `now` arriving as a
+//! parameter.
+
+use resonate_core::types::{
+    format_validation_errors, PromiseCreateData, PromiseGetData, PromiseRecord,
+    PromiseRegisterCallbackData, PromiseRegisterListenerData, PromiseResponseData,
+    PromiseSearchData, PromiseSearchResponseData, PromiseSettleData, PromiseValue,
+    RequestEnvelope, ResponseEnvelope,
+};
+use resonate_server_dbms::engine_port::{Outgoing, Output};
+use validator::Validate;
+
+use crate::db::{
+    big, cql_map, cql_set, get_big, int, opt_cql_map, opt_text, text, Args,
+    PromiseRow, SettleOutcome,
+};
+use crate::{origin_of, Ctx, ScyllaEngine};
+
+/// Parse and validate one request's data, or produce the 400 the envelope
+/// owes — the same two-step every engine starts with.
+pub(crate) fn parse<T>(req: &RequestEnvelope) -> Result<T, ResponseEnvelope>
+where
+    T: serde::de::DeserializeOwned + Validate,
+{
+    let d: T = match serde_json::from_value(req.data.clone()) {
+        Ok(d) => d,
+        Err(e) => {
+            return Err(ResponseEnvelope::error(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                400,
+                &format!("Invalid request: {}", e),
+            ))
+        }
+    };
+    if let Err(e) = d.validate() {
+        return Err(ResponseEnvelope::error(
+            req.kind.clone(),
+            req.head.corr_id.clone(),
+            400,
+            &format_validation_errors(&e),
+        ));
+    }
+    Ok(d)
+}
+
+pub(crate) fn err(req: &RequestEnvelope, status: i32, msg: &str) -> Output {
+    Output::response(ResponseEnvelope::error(
+        req.kind.clone(),
+        req.head.corr_id.clone(),
+        status,
+        msg,
+    ))
+}
+
+pub(crate) fn ok<T: serde::Serialize>(req: &RequestEnvelope, ctx: Ctx, data: &T) -> Output {
+    Output {
+        response: Some(ResponseEnvelope::success(
+            req.kind.clone(),
+            req.head.corr_id.clone(),
+            data,
+        )),
+        messages: ctx.messages,
+        timeouts: ctx.armed,
+    }
+}
+
+pub(crate) fn storage_err(req: &RequestEnvelope, e: impl std::fmt::Display) -> Output {
+    Output::response(ResponseEnvelope::error(
+        req.kind.clone(),
+        req.head.corr_id.clone(),
+        500,
+        &format!("Internal error: {}", e),
+    ))
+}
+
+impl ScyllaEngine {
+    pub(crate) async fn op_promise_get(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: PromiseGetData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => storage_err(req, e),
+            Ok(None) => err(req, 404, "Promise not found"),
+            Ok(Some(row)) => {
+                let promise = row.to_promise_record();
+                ok(req, ctx, &PromiseResponseData { promise })
+            }
+        }
+    }
+
+    pub(crate) async fn op_promise_create(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: PromiseCreateData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        if let Some(addr) = r.tags.get("resonate:target") {
+            if !resonate_core::is_valid_address(addr) {
+                return err(req, 400, "Invalid resonate:target address");
+            }
+        }
+        let mut ctx = Ctx::default();
+        match self.promise_create_impl(&mut ctx, &r, now).await {
+            Ok(promise) => ok(req, ctx, &PromiseResponseData { promise }),
+            Err(e) => storage_err(req, e),
+        }
+    }
+
+    /// Go's `PromiseCreate` past validation: pre-insert queue entries, one
+    /// `INSERT ... IF NOT EXISTS`, and the loser's response rebuilt from the
+    /// returned row — eagerly settled when the existing row has expired.
+    /// Also the fence's inner create, which is the same transition.
+    pub(crate) async fn promise_create_impl(
+        &self,
+        ctx: &mut Ctx,
+        r: &PromiseCreateData,
+        now: i64,
+    ) -> Result<PromiseRecord, resonate_server_dbms::StorageError> {
+        let id = r.id.as_str();
+        let origin = origin_of(id).to_string();
+        let target = r.tags.get("resonate:target").cloned();
+        let has_task = target.is_some();
+        let awaitable = resonate_core::types::is_awaitable(&r.tags);
+        let is_timer = r.tags.get("resonate:timer").map(String::as_str) == Some("true");
+        let already_timedout = now >= r.timeout_at;
+
+        let (state, created_at, settled_at) = if already_timedout {
+            let s = if is_timer { "resolved" } else { "rejected_timedout" };
+            (s, r.timeout_at, Some(r.timeout_at))
+        } else {
+            ("pending", now, None)
+        };
+
+        // Retry deadline for a pending task: the delay tag when it names a
+        // future instant, else immediately (now + retry timeout).
+        let mut task_retry_immediate = true;
+        let mut task_retry_at = now + self.task_retry_timeout;
+        if let Some(ds) = r.tags.get("resonate:delay") {
+            if let Ok(d) = ds.parse::<i64>() {
+                if d > now {
+                    task_retry_at = d;
+                    task_retry_immediate = false;
+                }
+            }
+        }
+
+        // Pre-insert queue entries before the LWT so a kill leaves orphans,
+        // never a committed row with no entry. EVERY pending promise gets a
+        // promise_timeouts entry — eager, like the Go implementation.
+        if state == "pending" {
+            self.exec(
+                "INSERT INTO promise_timeouts (bucket, shard, timeout_at, promise_id, origin) VALUES (?, ?, ?, ?, ?)",
+                (
+                    self.bucket_for(r.timeout_at),
+                    self.shard_for(id),
+                    r.timeout_at,
+                    id,
+                    origin.as_str(),
+                ),
+            )
+            .await?;
+            if has_task {
+                self.exec(
+                    "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+                    (
+                        self.bucket_for(task_retry_at),
+                        self.shard_for(id),
+                        task_retry_at,
+                        id,
+                        origin.as_str(),
+                        r.timeout_at,
+                    ),
+                )
+                .await?;
+            }
+        }
+
+        // The LWT INSERT — task_timeout_retry included atomically.
+        let (task_state, task_version): (Option<&str>, Option<i32>) = if has_task {
+            if already_timedout {
+                (Some("fulfilled"), Some(0))
+            } else {
+                (Some("pending"), Some(0))
+            }
+        } else {
+            (None, None)
+        };
+        let task_retry_arg = if has_task && !already_timedout {
+            Some(task_retry_at)
+        } else {
+            None
+        };
+
+        let insert_args: Args = vec![
+            text(id),
+            text(&origin),
+            opt_text(r.tags.get("resonate:branch").cloned()),
+            opt_text(r.tags.get("resonate:parent").cloned()),
+            opt_text(target.clone()),
+            text(state),
+            opt_cql_map(r.param.headers.as_ref()),
+            opt_text(r.param.data.clone()),
+            cql_map(&r.tags),
+            big(r.timeout_at),
+            big(created_at),
+            settled_at.and_then(|v| big(v)),
+            opt_text(task_state),
+            task_version.and_then(|v| int(v)),
+            task_retry_arg.and_then(|v| big(v)),
+        ];
+        let (applied, row) = self
+            .cas(
+                "INSERT INTO promises (id, origin, branch, parent, target, state, param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at, settled_at, callbacks, listeners, task_state, task_version, task_ttl, task_pid, task_resumes, task_timeout_retry) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, null, null, ?, ?, ?, ?, {}, {}, ?, ?, null, null, null, ?) IF NOT EXISTS",
+                insert_args,
+            )
+            .await?;
+
+        if !applied {
+            // The failed LWT returns the full existing row.
+            let existing = PromiseRow::from_map(&row);
+
+            // Roll back pre-inserts unless the existing row legitimately
+            // owns an entry at that PK.
+            if state == "pending" {
+                if !(existing.state == "pending" && existing.timeout_at == r.timeout_at) {
+                    let _ = self
+                        .exec(
+                            "DELETE FROM promise_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND promise_id = ?",
+                            (
+                                self.bucket_for(r.timeout_at),
+                                self.shard_for(id),
+                                r.timeout_at,
+                                origin.as_str(),
+                                id,
+                            ),
+                        )
+                        .await;
+                }
+                if has_task {
+                    let existing_retry = get_big(&row, "task_timeout_retry").unwrap_or(0);
+                    if !(existing.task_state.as_deref() == Some("pending")
+                        && existing_retry == task_retry_at)
+                    {
+                        let _ = self
+                            .exec(
+                                "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                                (
+                                    self.bucket_for(task_retry_at),
+                                    self.shard_for(id),
+                                    task_retry_at,
+                                    origin.as_str(),
+                                    id,
+                                ),
+                            )
+                            .await;
+                    }
+                }
+            }
+
+            // Eagerly settle the existing row if it has expired.
+            let mut existing = existing;
+            existing.id = id.to_string();
+            existing.origin = origin.clone();
+            if existing.state == "pending" && now >= existing.timeout_at {
+                self.try_timeout(ctx, &existing, now).await?;
+                let settled = self
+                    .read_promise(&origin, id)
+                    .await?
+                    .map(|p| p.to_promise_record());
+                if let Some(p) = settled {
+                    return Ok(p);
+                }
+            }
+            return Ok(existing.to_promise_record());
+        }
+
+        if state == "pending" {
+            self.arm_promise_timeout(ctx, id, r.timeout_at, awaitable);
+            if has_task {
+                self.arm_retry(ctx, id, task_retry_at);
+                if task_retry_immediate {
+                    ctx.messages.push(Outgoing::Execute {
+                        address: target.clone().unwrap(),
+                        task_id: id.to_string(),
+                        version: 0,
+                    });
+                }
+            }
+        }
+
+        Ok(PromiseRecord {
+            id: id.to_string(),
+            state: crate::db::parse_promise_state(state),
+            param: r.param.clone(),
+            value: PromiseValue::default(),
+            tags: r.tags.clone(),
+            timeout_at: r.timeout_at,
+            created_at,
+            settled_at,
+        })
+    }
+
+    pub(crate) async fn op_promise_settle(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: PromiseSettleData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Promise not found"),
+            Ok(Some(row)) => row,
+        };
+        if row.state != "pending" {
+            let promise = row.to_promise_record();
+            return ok(req, ctx, &PromiseResponseData { promise });
+        }
+
+        let settle_state = r.state.to_string();
+        let settled_at_val = now.max(row.created_at);
+        let has_task = row.target.is_some();
+
+        // Go's explicit-settle variant of the pinned statement: the caller's
+        // value rides in, the IF pins state, the exact callbacks set, and
+        // the un-written value columns.
+        let stmt = if has_task {
+            "UPDATE promises SET state = ?, value_headers = ?, value_data = ?, settled_at = ?, \
+             callbacks = {}, listeners = {}, task_state = 'fulfilled', task_pid = null, \
+             task_ttl = null, task_timeout_retry = null, task_timeout_lease = null, task_resumes = {} \
+             WHERE origin = ? AND id = ? \
+             IF state = 'pending' AND callbacks = ? AND settled_at = null AND value_headers = null AND value_data = null"
+        } else {
+            "UPDATE promises SET state = ?, value_headers = ?, value_data = ?, settled_at = ?, \
+             callbacks = {}, listeners = {} \
+             WHERE origin = ? AND id = ? \
+             IF state = 'pending' AND callbacks = ? AND settled_at = null AND value_headers = null AND value_data = null"
+        };
+        let args: Args = vec![
+            text(&settle_state),
+            opt_cql_map(r.value.headers.as_ref()),
+            opt_text(r.value.data.clone()),
+            big(settled_at_val),
+            text(&row.origin),
+            text(&row.id),
+            cql_set(&row.callbacks),
+        ];
+
+        let outcome = match self
+            .enqueue_resume(
+                &row.id,
+                &row.origin,
+                &row.callbacks,
+                settled_at_val,
+                stmt.to_string(),
+                args,
+            )
+            .await
+        {
+            Ok(o) => o,
+            Err(e) => return storage_err(req, e),
+        };
+
+        let promise = match outcome {
+            SettleOutcome::Won { resumed, retry_at } => {
+                let mut settled = row.clone();
+                settled.state = settle_state.clone();
+                settled.value_headers = r.value.headers.clone().unwrap_or_default();
+                settled.value_data = r.value.data.clone();
+                settled.settled_at = Some(settled_at_val);
+                if let Err(e) = self.after_settle_won(&mut ctx, &settled, resumed, retry_at).await
+                {
+                    return storage_err(req, e);
+                }
+                settled.to_promise_record()
+            }
+            SettleOutcome::Lost {
+                state,
+                value_headers,
+                value_data,
+                settled_at,
+            } => {
+                let mut lost = row.clone();
+                lost.state = state;
+                lost.value_headers = value_headers;
+                lost.value_data = value_data;
+                lost.settled_at = settled_at;
+                lost.to_promise_record()
+            }
+            SettleOutcome::Conflict => {
+                return err(req, 500, "concurrent modification; please retry")
+            }
+        };
+        ok(req, ctx, &PromiseResponseData { promise })
+    }
+
+    pub(crate) async fn op_promise_register_callback(
+        &self,
+        req: &RequestEnvelope,
+        now: i64,
+    ) -> Output {
+        let r: PromiseRegisterCallbackData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+
+        let awaited = match self.read_and_try_timeout(&mut ctx, &r.awaited, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Awaited promise not found"),
+            Ok(Some(row)) => row,
+        };
+        let awaiter = match self.read_and_try_timeout(&mut ctx, &r.awaiter, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 422, "Awaiter promise not found"),
+            Ok(Some(row)) => row,
+        };
+        if awaiter.target.is_none() {
+            return err(req, 422, "Awaiter promise has no resonate:target tag");
+        }
+        if !resonate_core::types::is_awaitable(&awaited.tags) {
+            return err(req, 422, "Awaited promise is not awaitable");
+        }
+
+        if awaiter.state != "pending" || awaited.state != "pending" {
+            if awaited.state != "pending" {
+                if let Err(e) = self
+                    .resume_callback_awaiter(&mut ctx, &awaited, &awaiter, now)
+                    .await
+                {
+                    return storage_err(req, e);
+                }
+            }
+            let promise = awaited.to_promise_record();
+            return ok(req, ctx, &PromiseResponseData { promise });
+        }
+
+        // Register via LWT, guarded against a concurrent settle.
+        let (applied, _row) = match self
+            .cas(
+                "UPDATE promises SET callbacks = callbacks + ? WHERE origin = ? AND id = ? IF state = 'pending'",
+                (
+                    vec![r.awaiter.clone()],
+                    awaited.origin.as_str(),
+                    awaited.id.as_str(),
+                ),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            // Concurrent settle won — re-read and return current state.
+            return match self.read_promise(&awaited.origin, &awaited.id).await {
+                Err(e) => storage_err(req, e),
+                Ok(None) => err(req, 404, "Awaited promise not found"),
+                Ok(Some(row)) => {
+                    let promise = row.to_promise_record();
+                    ok(req, ctx, &PromiseResponseData { promise })
+                }
+            };
+        }
+        let promise = awaited.to_promise_record();
+        ok(req, ctx, &PromiseResponseData { promise })
+    }
+
+    /// Go's `resumeCallbackAwaiter`: the per-awaiter half of the fanout,
+    /// for an awaited found already settled at registration time.
+    async fn resume_callback_awaiter(
+        &self,
+        ctx: &mut Ctx,
+        awaited: &PromiseRow,
+        awaiter: &PromiseRow,
+        now: i64,
+    ) -> Result<(), resonate_server_dbms::StorageError> {
+        let origin = &awaited.origin;
+        match awaiter.task_state.as_deref() {
+            Some("fulfilled") | None => {}
+            Some("suspended") => {
+                let retry_at = now + self.task_retry_timeout;
+                self.exec(
+                    "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+                    (
+                        self.bucket_for(retry_at),
+                        self.shard_for(&awaiter.id),
+                        retry_at,
+                        awaiter.id.as_str(),
+                        origin.as_str(),
+                        awaiter.timeout_at,
+                    ),
+                )
+                .await?;
+                let (applied, _row) = match self
+                    .cas(
+                        "UPDATE promises SET task_state = 'pending', task_resumes = ?, task_timeout_retry = ? WHERE origin = ? AND id = ? IF task_state = 'suspended'",
+                        (
+                            vec![awaited.id.clone()],
+                            retry_at,
+                            origin.as_str(),
+                            awaiter.id.as_str(),
+                        ),
+                    )
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = self
+                            .exec(
+                                "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                                (
+                                    self.bucket_for(retry_at),
+                                    self.shard_for(&awaiter.id),
+                                    retry_at,
+                                    origin.as_str(),
+                                    awaiter.id.as_str(),
+                                ),
+                            )
+                            .await;
+                        return Err(e);
+                    }
+                };
+                if !applied {
+                    let _ = self
+                        .exec(
+                            "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                            (
+                                self.bucket_for(retry_at),
+                                self.shard_for(&awaiter.id),
+                                retry_at,
+                                origin.as_str(),
+                                awaiter.id.as_str(),
+                            ),
+                        )
+                        .await;
+                    return Err(resonate_server_dbms::StorageError::Backend(
+                        "concurrent modification".to_string(),
+                    ));
+                }
+                self.arm_retry(ctx, &awaiter.id, retry_at);
+                if let Some(target) = &awaiter.target {
+                    ctx.messages.push(Outgoing::Execute {
+                        address: target.clone(),
+                        task_id: awaiter.id.clone(),
+                        version: awaiter.task_version,
+                    });
+                }
+            }
+            Some(state) => {
+                let (applied, _row) = self
+                    .cas(
+                        &format!(
+                            "UPDATE promises SET task_resumes = task_resumes + ? WHERE origin = ? AND id = ? IF task_state = '{state}'"
+                        ),
+                        (
+                            vec![awaited.id.clone()],
+                            origin.as_str(),
+                            awaiter.id.as_str(),
+                        ),
+                    )
+                    .await?;
+                if !applied {
+                    return Err(resonate_server_dbms::StorageError::Backend(
+                        "concurrent modification".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn op_promise_register_listener(
+        &self,
+        req: &RequestEnvelope,
+        now: i64,
+    ) -> Output {
+        let r: PromiseRegisterListenerData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        if !resonate_core::is_valid_address(&r.address) {
+            return err(req, 400, "Invalid listener address");
+        }
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.awaited, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Awaited promise not found"),
+            Ok(Some(row)) => row,
+        };
+        if !resonate_core::types::is_awaitable(&row.tags) {
+            return err(req, 422, "Awaited promise is not awaitable");
+        }
+        if row.state != "pending" {
+            let promise = row.to_promise_record();
+            return ok(req, ctx, &PromiseResponseData { promise });
+        }
+        let (applied, _r) = match self
+            .cas(
+                "UPDATE promises SET listeners = listeners + ? WHERE origin = ? AND id = ? IF state = 'pending'",
+                (
+                    vec![r.address.clone()],
+                    row.origin.as_str(),
+                    row.id.as_str(),
+                ),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            return match self.read_promise(&row.origin, &row.id).await {
+                Err(e) => storage_err(req, e),
+                Ok(None) => err(req, 404, "Awaited promise not found"),
+                Ok(Some(row)) => {
+                    let promise = row.to_promise_record();
+                    ok(req, ctx, &PromiseResponseData { promise })
+                }
+            };
+        }
+        let promise = row.to_promise_record();
+        ok(req, ctx, &PromiseResponseData { promise })
+    }
+
+    /// A full scan, filtered and sorted in memory: search is an operator's
+    /// read, and the table is partitioned for transitions, not for it.
+    pub(crate) async fn op_promise_search(&self, req: &RequestEnvelope, _now: i64) -> Output {
+        let r: PromiseSearchData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let limit = match r.limit {
+            Some(n) if n > 1000 => {
+                return err(req, 400, "Invalid 'limit' — must be between 1 and 1000")
+            }
+            Some(n) => n,
+            None => 100,
+        };
+        let rows = match self
+            .rows(
+                &format!("SELECT {} FROM promises", crate::db::P_COLS),
+                (),
+            )
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => return storage_err(req, e),
+        };
+        let state_filter = r.state.map(|s| s.to_string());
+        let mut promises: Vec<PromiseRecord> = rows
+            .iter()
+            .map(PromiseRow::from_map)
+            .filter(|p| {
+                state_filter
+                    .as_ref()
+                    .map(|s| &p.state == s)
+                    .unwrap_or(true)
+                    && r.tags
+                        .as_ref()
+                        .map(|ft| {
+                            ft.iter()
+                                .all(|(k, v)| p.tags.get(k).map(|pv| pv == v).unwrap_or(false))
+                        })
+                        .unwrap_or(true)
+            })
+            .map(|p| p.to_promise_record())
+            .collect();
+        promises.sort_by(|a, b| a.id.cmp(&b.id));
+        if let Some(cursor) = r.cursor.as_deref() {
+            promises.retain(|p| p.id.as_str() > cursor);
+        }
+        let has_more = promises.len() as i64 > limit;
+        promises.truncate(limit as usize);
+        let cursor = if has_more {
+            promises.last().map(|p| p.id.clone())
+        } else {
+            None
+        };
+        ok(
+            req,
+            Ctx::default(),
+            &PromiseSearchResponseData { promises, cursor },
+        )
+    }
+}

--- a/crates/resonate-server-scylladb/src/ops_schedule.rs
+++ b/crates/resonate-server-scylladb/src/ops_schedule.rs
@@ -1,0 +1,282 @@
+//! The schedule operations — Go's `handler_schedule.go`, translated.
+//!
+//! `create_token` is the pre-insert protocol's answer to racing creators:
+//! it is part of the schedule_timeouts clustering key, so two racers write
+//! two rows and each rolls back only its own. The winner's token is stored
+//! on the schedules row and is the identity of the live anchor entry.
+
+use resonate_core::types::{
+    RequestEnvelope, ScheduleCreateData, ScheduleDeleteData, ScheduleGetData, ScheduleRecord,
+    ScheduleResponseData, ScheduleSearchData, ScheduleSearchResponseData,
+};
+use resonate_server_dbms::engine_port::{Output, Scheduled, Timeout};
+use resonate_server_dbms::StorageResult;
+use scylla::value::CqlValue;
+use serde_json::json;
+
+use crate::db::{get_big, get_tags, get_text, RowMap};
+use crate::ops_promise::{err, ok, parse, storage_err};
+use crate::{Ctx, ScyllaEngine};
+
+pub(crate) const S_COLS: &str = "id, origin, cron, promise_id, promise_timeout, \
+     promise_param_headers, promise_param_data, promise_tags, next_run_at, last_run_at, \
+     created_at, create_token";
+
+pub(crate) fn row_to_schedule(m: &RowMap) -> ScheduleRecord {
+    let param_headers = get_tags(m, "promise_param_headers");
+    let last_run_at = get_big(m, "last_run_at").filter(|v| *v != 0);
+    ScheduleRecord {
+        id: get_text(m, "id").unwrap_or_default(),
+        cron: get_text(m, "cron").unwrap_or_default(),
+        promise_id: get_text(m, "promise_id").unwrap_or_default(),
+        promise_timeout: get_big(m, "promise_timeout").unwrap_or(0),
+        promise_param: resonate_core::types::PromiseValue {
+            headers: if param_headers.is_empty() {
+                None
+            } else {
+                Some(param_headers)
+            },
+            data: get_text(m, "promise_param_data"),
+        },
+        promise_tags: get_tags(m, "promise_tags"),
+        created_at: get_big(m, "created_at").unwrap_or(0),
+        next_run_at: get_big(m, "next_run_at").unwrap_or(0),
+        last_run_at,
+    }
+}
+
+impl ScyllaEngine {
+    pub(crate) async fn read_schedule(&self, id: &str) -> StorageResult<Option<RowMap>> {
+        let rows = self
+            .rows(
+                &format!("SELECT {S_COLS} FROM schedules WHERE origin = ? AND id = ?"),
+                (id, id),
+            )
+            .await?;
+        Ok(rows.into_iter().next())
+    }
+
+    pub(crate) async fn op_schedule_get(&self, req: &RequestEnvelope, _now: i64) -> Output {
+        let r: ScheduleGetData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        match self.read_schedule(&r.id).await {
+            Err(e) => storage_err(req, e),
+            Ok(None) => err(req, 404, "Schedule not found"),
+            Ok(Some(m)) => ok(
+                req,
+                Ctx::default(),
+                &ScheduleResponseData {
+                    schedule: row_to_schedule(&m),
+                },
+            ),
+        }
+    }
+
+    pub(crate) async fn op_schedule_create(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: ScheduleCreateData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        if !resonate_core::util::is_valid_cron(&r.cron) {
+            return err(req, 400, "Invalid cron expression");
+        }
+        let next_run_at = resonate_core::util::compute_next_cron(&r.cron, now);
+        let token = uuid::Uuid::new_v4();
+        let origin = r.id.as_str(); // a schedule id carries no ':', so it is its own origin
+
+        // Pre-insert the anchor entry, keyed by our token.
+        if let Err(e) = self
+            .exec(
+                "INSERT INTO schedule_timeouts (bucket, shard, timeout_at, origin, schedule_id, create_token) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    self.bucket_for(next_run_at),
+                    self.shard_for(&r.id),
+                    next_run_at,
+                    origin,
+                    r.id.as_str(),
+                    CqlValue::Uuid(token),
+                ),
+            )
+            .await
+        {
+            return storage_err(req, e);
+        }
+
+        let (applied, lwt) = match self
+            .cas(
+                "INSERT INTO schedules (id, origin, cron, promise_id, promise_timeout, promise_param_headers, promise_param_data, promise_tags, next_run_at, last_run_at, created_at, create_token) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, null, ?, ?) IF NOT EXISTS",
+                (
+                    r.id.as_str(),
+                    origin,
+                    r.cron.as_str(),
+                    r.promise_id.as_str(),
+                    r.promise_timeout,
+                    r.promise_param.headers.clone().unwrap_or_default(),
+                    r.promise_param.data.clone(),
+                    r.promise_tags.clone(),
+                    next_run_at,
+                    now,
+                    CqlValue::Uuid(token),
+                ),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+
+        if !applied {
+            // A schedule already exists: roll back our anchor (tokens are
+            // random, so ours is never the live one) and return the winner.
+            let _ = self
+                .exec(
+                    "DELETE FROM schedule_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND schedule_id = ? AND create_token = ?",
+                    (
+                        self.bucket_for(next_run_at),
+                        self.shard_for(&r.id),
+                        next_run_at,
+                        origin,
+                        r.id.as_str(),
+                        CqlValue::Uuid(token),
+                    ),
+                )
+                .await;
+            return ok(
+                req,
+                Ctx::default(),
+                &ScheduleResponseData {
+                    schedule: row_to_schedule(&lwt),
+                },
+            );
+        }
+
+        let mut ctx = Ctx::default();
+        ctx.armed.push(Scheduled {
+            at: next_run_at,
+            timeout: Timeout::ScheduleDue {
+                schedule_id: r.id.clone(),
+            },
+        });
+        ok(
+            req,
+            ctx,
+            &ScheduleResponseData {
+                schedule: ScheduleRecord {
+                    id: r.id.clone(),
+                    cron: r.cron.clone(),
+                    promise_id: r.promise_id.clone(),
+                    promise_timeout: r.promise_timeout,
+                    promise_param: r.promise_param.clone(),
+                    promise_tags: r.promise_tags.clone(),
+                    created_at: now,
+                    next_run_at,
+                    last_run_at: None,
+                },
+            },
+        )
+    }
+
+    pub(crate) async fn op_schedule_delete(&self, req: &RequestEnvelope) -> Output {
+        let r: ScheduleDeleteData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let origin = r.id.as_str();
+        let row = match self.read_schedule(&r.id).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Schedule not found"),
+            Ok(Some(m)) => m,
+        };
+        let next_run_at = get_big(&row, "next_run_at").unwrap_or(0);
+        let token = match row.get("create_token") {
+            Some(Some(CqlValue::Uuid(u))) => Some(*u),
+            _ => None,
+        };
+
+        let (applied, lwt) = match self
+            .cas(
+                "DELETE FROM schedules WHERE origin = ? AND id = ? IF next_run_at = ?",
+                (origin, r.id.as_str(), next_run_at),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            if get_big(&lwt, "next_run_at").is_none() {
+                return err(req, 404, "Schedule not found");
+            }
+            return err(req, 500, "Schedule modified concurrently, retry");
+        }
+        if let Some(token) = token {
+            let _ = self
+                .exec(
+                    "DELETE FROM schedule_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND schedule_id = ? AND create_token = ?",
+                    (
+                        self.bucket_for(next_run_at),
+                        self.shard_for(&r.id),
+                        next_run_at,
+                        origin,
+                        r.id.as_str(),
+                        CqlValue::Uuid(token),
+                    ),
+                )
+                .await;
+        }
+        ok(req, Ctx::default(), &json!({}))
+    }
+
+    pub(crate) async fn op_schedule_search(&self, req: &RequestEnvelope) -> Output {
+        let r: ScheduleSearchData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let limit = match r.limit {
+            Some(n) if n > 1000 => {
+                return err(req, 400, "Invalid 'limit' — must be between 1 and 1000")
+            }
+            Some(n) => n as usize,
+            None => 10,
+        };
+        let rows = match self
+            .rows(&format!("SELECT {S_COLS} FROM schedules"), ())
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => return storage_err(req, e),
+        };
+        let mut schedules: Vec<ScheduleRecord> = rows
+            .iter()
+            .map(row_to_schedule)
+            .filter(|s| {
+                r.tags
+                    .as_ref()
+                    .map(|ft| {
+                        ft.iter()
+                            .all(|(k, v)| s.promise_tags.get(k).map(|sv| sv == v).unwrap_or(false))
+                    })
+                    .unwrap_or(true)
+            })
+            .collect();
+        schedules.sort_by(|a, b| a.id.cmp(&b.id));
+        if let Some(cursor) = r.cursor.as_deref() {
+            schedules.retain(|s| s.id.as_str() > cursor);
+        }
+        let has_more = schedules.len() > limit;
+        schedules.truncate(limit);
+        let cursor = if has_more {
+            schedules.last().map(|s| s.id.clone())
+        } else {
+            None
+        };
+        ok(
+            req,
+            Ctx::default(),
+            &ScheduleSearchResponseData { schedules, cursor },
+        )
+    }
+}

--- a/crates/resonate-server-scylladb/src/ops_task.rs
+++ b/crates/resonate-server-scylladb/src/ops_task.rs
@@ -6,12 +6,11 @@
 //! a behavioral one, not a spelling one.
 
 use resonate_core::types::{
-    PromiseCreateData, PromiseRecord, PromiseSettleData, RequestEnvelope,
-    TaskAcquireData, TaskAcquireResponseData, TaskContinueData, TaskCreateData,
-    TaskCreateResponseData, TaskFenceData, TaskFulfillData, TaskFulfillResponseData,
-    TaskGetData, TaskHaltData, TaskHeartbeatData, TaskRecord, TaskReleaseData,
-    TaskResponseData, TaskSearchData, TaskSearchResponseData, TaskSuspendData,
-    TaskSuspendPreloadData, PROTOCOL_VERSION,
+    PromiseCreateData, PromiseRecord, PromiseSettleData, RequestEnvelope, TaskAcquireData,
+    TaskAcquireResponseData, TaskContinueData, TaskCreateData, TaskCreateResponseData,
+    TaskFenceData, TaskFulfillData, TaskFulfillResponseData, TaskGetData, TaskHaltData,
+    TaskHeartbeatData, TaskRecord, TaskReleaseData, TaskResponseData, TaskSearchData,
+    TaskSearchResponseData, TaskSuspendData, TaskSuspendPreloadData, PROTOCOL_VERSION,
 };
 use resonate_server_dbms::engine_port::{Outgoing, Output};
 use serde_json::json;
@@ -224,7 +223,11 @@ impl ScyllaEngine {
         let already_timedout = now >= action.timeout_at;
         let is_timer = action.tags.get("resonate:timer").map(String::as_str) == Some("true");
         let (p_state, created_at, settled_at) = if already_timedout {
-            let s = if is_timer { "resolved" } else { "rejected_timedout" };
+            let s = if is_timer {
+                "resolved"
+            } else {
+                "rejected_timedout"
+            };
             (s, action.timeout_at, Some(action.timeout_at))
         } else {
             ("pending", now, None)
@@ -287,7 +290,11 @@ impl ScyllaEngine {
             int(t_version),
             if already_timedout { None } else { big(r.ttl) },
             if already_timedout { None } else { text(&r.pid) },
-            if already_timedout { None } else { big(lease_at) },
+            if already_timedout {
+                None
+            } else {
+                big(lease_at)
+            },
         ];
         let (applied, lwt) = match self
             .cas(
@@ -1220,5 +1227,4 @@ impl ScyllaEngine {
             &TaskSearchResponseData { tasks, cursor },
         )
     }
-
 }

--- a/crates/resonate-server-scylladb/src/ops_task.rs
+++ b/crates/resonate-server-scylladb/src/ops_task.rs
@@ -1,0 +1,1217 @@
+//! The task operations — Go's `handler_task.go`, translated.
+//!
+//! Mechanics are Go's: pre-insert → LWT → conditional rollback, version
+//! pinned in every IF, acquire the only bump. Statuses and message strings
+//! follow this repo's protocol so a divergence the differential reports is
+//! a behavioral one, not a spelling one.
+
+use resonate_core::types::{
+    PromiseCreateData, PromiseRecord, PromiseSettleData, RequestEnvelope,
+    TaskAcquireData, TaskAcquireResponseData, TaskContinueData, TaskCreateData,
+    TaskCreateResponseData, TaskFenceData, TaskFulfillData, TaskFulfillResponseData,
+    TaskGetData, TaskHaltData, TaskHeartbeatData, TaskRecord, TaskReleaseData,
+    TaskResponseData, TaskSearchData, TaskSearchResponseData, TaskSuspendData,
+    TaskSuspendPreloadData, PROTOCOL_VERSION,
+};
+use resonate_server_dbms::engine_port::{Outgoing, Output};
+use serde_json::json;
+use validator::Validate;
+
+use crate::db::{big, cql_set, get_text, int, opt_text, text, Args, PromiseRow, SettleOutcome};
+use crate::ops_promise::{err, ok, parse, storage_err};
+use crate::{Ctx, ScyllaEngine};
+
+impl ScyllaEngine {
+    /// Branch siblings, capped — what a task response preloads. Branch
+    /// members share the origin partition, so this is a partition scan.
+    pub(crate) async fn preload(
+        &self,
+        origin: &str,
+        promise_id: &str,
+    ) -> Result<Vec<PromiseRecord>, resonate_server_dbms::StorageError> {
+        let rows = self
+            .rows(
+                &format!(
+                    "SELECT {} FROM promises WHERE origin = ?",
+                    crate::db::P_COLS
+                ),
+                (origin,),
+            )
+            .await?;
+        let all: Vec<PromiseRow> = rows.iter().map(PromiseRow::from_map).collect();
+        let branch = match all
+            .iter()
+            .find(|p| p.id == promise_id)
+            .and_then(|p| p.tags.get("resonate:branch"))
+        {
+            Some(b) if !b.is_empty() => b.clone(),
+            _ => return Ok(vec![]),
+        };
+        let mut siblings: Vec<&PromiseRow> = all
+            .iter()
+            .filter(|p| {
+                p.id != promise_id
+                    && p.tags
+                        .get("resonate:branch")
+                        .map(|b| b == &branch)
+                        .unwrap_or(false)
+            })
+            .collect();
+        siblings.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(siblings
+            .into_iter()
+            .take(self.preload_limit as usize)
+            .map(|p| p.to_promise_record())
+            .collect())
+    }
+
+    pub(crate) async fn op_task_get(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskGetData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => storage_err(req, e),
+            Ok(None) => err(req, 404, "Task not found"),
+            Ok(Some(row)) => match row.to_task_record() {
+                None => err(req, 404, "Task not found"),
+                Some(task) => ok(req, ctx, &TaskResponseData { task }),
+            },
+        }
+    }
+
+    pub(crate) async fn op_task_create(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskCreateData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let action = &r.action.data;
+        if let Some(addr) = action.tags.get("resonate:target") {
+            if !resonate_core::is_valid_address(addr) {
+                return err(req, 400, "Invalid resonate:target address");
+            }
+        }
+        let id = action.id.clone();
+        let origin = crate::origin_of(&id).to_string();
+        let mut ctx = Ctx::default();
+
+        let existing = match self.read_and_try_timeout(&mut ctx, &id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(v) => v,
+        };
+
+        if let Some(row) = existing {
+            if row.task_state.is_none() {
+                return err(req, 422, "The promise does not have a resonate:target tag");
+            }
+            match row.task_state.as_deref() {
+                Some("pending") => {
+                    // Re-acquire: pre-insert the lease, bump the version.
+                    let lease_at = now + r.ttl;
+                    if let Err(e) = self
+                        .exec(
+                            "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 1, ?, ?, ?)",
+                            (
+                                self.bucket_for(lease_at),
+                                self.shard_for(&id),
+                                lease_at,
+                                id.as_str(),
+                                origin.as_str(),
+                                row.timeout_at,
+                            ),
+                        )
+                        .await
+                    {
+                        return storage_err(req, e);
+                    }
+                    let new_version = row.task_version + 1;
+                    let (applied, lwt) = match self
+                        .cas(
+                            "UPDATE promises SET task_state = 'acquired', task_pid = ?, task_ttl = ?, task_version = ?, task_resumes = {}, task_timeout_retry = null, task_timeout_lease = ? WHERE origin = ? AND id = ? IF task_state = 'pending' AND task_version = ?",
+                            (
+                                r.pid.as_str(),
+                                r.ttl,
+                                new_version as i32,
+                                lease_at,
+                                origin.as_str(),
+                                id.as_str(),
+                                row.task_version as i32,
+                            ),
+                        )
+                        .await
+                    {
+                        Ok(v) => v,
+                        Err(e) => return storage_err(req, e),
+                    };
+                    if !applied {
+                        if crate::db::get_big(&lwt, "task_timeout_lease") != Some(lease_at) {
+                            let _ = self
+                                .exec(
+                                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                                    (
+                                        self.bucket_for(lease_at),
+                                        self.shard_for(&id),
+                                        lease_at,
+                                        origin.as_str(),
+                                        id.as_str(),
+                                    ),
+                                )
+                                .await;
+                        }
+                        return err(req, 500, "Concurrent modification; please retry");
+                    }
+                    if let Some(old_retry) = row.task_timeout_retry {
+                        let _ = self
+                            .exec(
+                                "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                                (
+                                    self.bucket_for(old_retry),
+                                    self.shard_for(&id),
+                                    old_retry,
+                                    origin.as_str(),
+                                    id.as_str(),
+                                ),
+                            )
+                            .await;
+                    }
+                    self.arm_lease(&mut ctx, &id, &r.pid, lease_at);
+                    let task = TaskRecord {
+                        id: id.clone(),
+                        state: crate::db::parse_task_state("acquired"),
+                        version: new_version,
+                        resumes: 0,
+                        ttl: Some(r.ttl),
+                        pid: Some(r.pid.clone()),
+                    };
+                    let promise = row.to_promise_record();
+                    let preload = match self.preload(&origin, &id).await {
+                        Ok(p) => p,
+                        Err(e) => return storage_err(req, e),
+                    };
+                    return ok(
+                        req,
+                        ctx,
+                        &TaskCreateResponseData {
+                            task,
+                            promise,
+                            preload,
+                        },
+                    );
+                }
+                Some("fulfilled") => {
+                    let task = row.to_task_record().unwrap();
+                    let promise = row.to_promise_record();
+                    let preload = match self.preload(&origin, &id).await {
+                        Ok(p) => p,
+                        Err(e) => return storage_err(req, e),
+                    };
+                    return ok(
+                        req,
+                        ctx,
+                        &TaskCreateResponseData {
+                            task,
+                            promise,
+                            preload,
+                        },
+                    );
+                }
+                _ => return err(req, 409, "Already exists"),
+            }
+        }
+
+        // Fresh create: promise + acquired task in one LWT INSERT.
+        let already_timedout = now >= action.timeout_at;
+        let is_timer = action.tags.get("resonate:timer").map(String::as_str) == Some("true");
+        let (p_state, created_at, settled_at) = if already_timedout {
+            let s = if is_timer { "resolved" } else { "rejected_timedout" };
+            (s, action.timeout_at, Some(action.timeout_at))
+        } else {
+            ("pending", now, None)
+        };
+        let lease_at = now + r.ttl;
+
+        if !already_timedout {
+            if let Err(e) = self
+                .exec(
+                    "INSERT INTO promise_timeouts (bucket, shard, timeout_at, promise_id, origin) VALUES (?, ?, ?, ?, ?)",
+                    (
+                        self.bucket_for(action.timeout_at),
+                        self.shard_for(&id),
+                        action.timeout_at,
+                        id.as_str(),
+                        origin.as_str(),
+                    ),
+                )
+                .await
+            {
+                return storage_err(req, e);
+            }
+            if let Err(e) = self
+                .exec(
+                    "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 1, ?, ?, ?)",
+                    (
+                        self.bucket_for(lease_at),
+                        self.shard_for(&id),
+                        lease_at,
+                        id.as_str(),
+                        origin.as_str(),
+                        action.timeout_at,
+                    ),
+                )
+                .await
+            {
+                return storage_err(req, e);
+            }
+        }
+
+        let (t_state, t_version): (&str, i32) = if already_timedout {
+            ("fulfilled", 0)
+        } else {
+            ("acquired", 1)
+        };
+        let insert_args: Args = vec![
+            text(&id),
+            text(&origin),
+            opt_text(action.tags.get("resonate:branch").cloned()),
+            opt_text(action.tags.get("resonate:parent").cloned()),
+            opt_text(action.tags.get("resonate:target").cloned()),
+            text(p_state),
+            crate::db::opt_cql_map(action.param.headers.as_ref()),
+            opt_text(action.param.data.clone()),
+            crate::db::cql_map(&action.tags),
+            big(action.timeout_at),
+            big(created_at),
+            settled_at.and_then(big),
+            text(t_state),
+            int(t_version),
+            if already_timedout { None } else { big(r.ttl) },
+            if already_timedout { None } else { text(&r.pid) },
+            if already_timedout { None } else { big(lease_at) },
+        ];
+        let (applied, lwt) = match self
+            .cas(
+                "INSERT INTO promises (id, origin, branch, parent, target, state, param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at, settled_at, callbacks, listeners, task_state, task_version, task_ttl, task_pid, task_resumes, task_timeout_retry, task_timeout_lease) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, null, null, ?, ?, ?, ?, {}, {}, ?, ?, ?, ?, null, null, ?) IF NOT EXISTS",
+                insert_args,
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+
+        if !applied {
+            // A concurrent create won between the ghost read and the LWT.
+            let existing = PromiseRow::from_map(&lwt);
+            if !already_timedout {
+                if !(existing.state == "pending" && existing.timeout_at == action.timeout_at) {
+                    let _ = self
+                        .exec(
+                            "DELETE FROM promise_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND promise_id = ?",
+                            (
+                                self.bucket_for(action.timeout_at),
+                                self.shard_for(&id),
+                                action.timeout_at,
+                                origin.as_str(),
+                                id.as_str(),
+                            ),
+                        )
+                        .await;
+                }
+                if !(existing.task_state.as_deref() == Some("acquired")
+                    && existing.task_timeout_lease == Some(lease_at))
+                {
+                    let _ = self
+                        .exec(
+                            "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                            (
+                                self.bucket_for(lease_at),
+                                self.shard_for(&id),
+                                lease_at,
+                                origin.as_str(),
+                                id.as_str(),
+                            ),
+                        )
+                        .await;
+                }
+            }
+            return err(req, 500, "Concurrent modification; please retry");
+        }
+
+        if !already_timedout {
+            self.arm_promise_timeout(
+                &mut ctx,
+                &id,
+                action.timeout_at,
+                resonate_core::types::is_awaitable(&action.tags),
+            );
+            self.arm_lease(&mut ctx, &id, &r.pid, lease_at);
+            // No execute: task.create returns an already-acquired task to
+            // the caller, who IS the worker.
+        }
+
+        let promise = PromiseRecord {
+            id: id.clone(),
+            state: crate::db::parse_promise_state(p_state),
+            param: action.param.clone(),
+            value: Default::default(),
+            tags: action.tags.clone(),
+            timeout_at: action.timeout_at,
+            created_at,
+            settled_at,
+        };
+        let task = TaskRecord {
+            id: id.clone(),
+            state: crate::db::parse_task_state(t_state),
+            version: t_version as i64,
+            resumes: 0,
+            ttl: if already_timedout { None } else { Some(r.ttl) },
+            pid: if already_timedout {
+                None
+            } else {
+                Some(r.pid.clone())
+            },
+        };
+        let preload = match self.preload(&origin, &id).await {
+            Ok(p) => p,
+            Err(e) => return storage_err(req, e),
+        };
+        ok(
+            req,
+            ctx,
+            &TaskCreateResponseData {
+                task,
+                promise,
+                preload,
+            },
+        )
+    }
+
+    pub(crate) async fn op_task_acquire(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskAcquireData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Task not found"),
+            Ok(Some(row)) => row,
+        };
+        if row.task_state.is_none() {
+            return err(req, 404, "Task not found");
+        }
+        if row.task_state.as_deref() != Some("pending") {
+            return err(req, 409, "Task is not pending");
+        }
+        if row.task_version != r.version {
+            return err(req, 409, "Version mismatch");
+        }
+
+        let lease_at = now + r.ttl;
+        if let Err(e) = self
+            .exec(
+                "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 1, ?, ?, ?)",
+                (
+                    self.bucket_for(lease_at),
+                    self.shard_for(&r.id),
+                    lease_at,
+                    r.id.as_str(),
+                    row.origin.as_str(),
+                    row.timeout_at,
+                ),
+            )
+            .await
+        {
+            return storage_err(req, e);
+        }
+        let new_version = r.version + 1;
+        let (applied, lwt) = match self
+            .cas(
+                "UPDATE promises SET task_state = 'acquired', task_version = ?, task_pid = ?, task_ttl = ?, task_resumes = {}, task_timeout_retry = null, task_timeout_lease = ? WHERE origin = ? AND id = ? IF task_state = 'pending' AND task_version = ?",
+                (
+                    new_version as i32,
+                    r.pid.as_str(),
+                    r.ttl,
+                    lease_at,
+                    row.origin.as_str(),
+                    r.id.as_str(),
+                    r.version as i32,
+                ),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            let survivor_owns = get_text(&lwt, "task_state").as_deref() == Some("acquired")
+                && crate::db::get_big(&lwt, "task_timeout_lease") == Some(lease_at);
+            if !survivor_owns {
+                let _ = self
+                    .exec(
+                        "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                        (
+                            self.bucket_for(lease_at),
+                            self.shard_for(&r.id),
+                            lease_at,
+                            row.origin.as_str(),
+                            r.id.as_str(),
+                        ),
+                    )
+                    .await;
+            }
+            let still_pending = get_text(&lwt, "task_state").as_deref() == Some("pending");
+            if still_pending {
+                return err(req, 409, "Version mismatch");
+            }
+            return err(req, 409, "Task is not pending");
+        }
+        if let Some(old_retry) = row.task_timeout_retry {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(old_retry),
+                        self.shard_for(&r.id),
+                        old_retry,
+                        row.origin.as_str(),
+                        r.id.as_str(),
+                    ),
+                )
+                .await;
+        }
+        self.arm_lease(&mut ctx, &r.id, &r.pid, lease_at);
+        let task = TaskRecord {
+            id: r.id.clone(),
+            state: crate::db::parse_task_state("acquired"),
+            version: new_version,
+            resumes: 0,
+            ttl: Some(r.ttl),
+            pid: Some(r.pid.clone()),
+        };
+        let promise = row.to_promise_record();
+        let preload = match self.preload(&row.origin, &r.id).await {
+            Ok(p) => p,
+            Err(e) => return storage_err(req, e),
+        };
+        ok(
+            req,
+            ctx,
+            &TaskAcquireResponseData {
+                task,
+                promise,
+                preload,
+            },
+        )
+    }
+
+    pub(crate) async fn op_task_release(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskReleaseData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Task not found"),
+            Ok(Some(row)) => row,
+        };
+        if row.task_state.is_none() {
+            return err(req, 404, "Task not found");
+        }
+        if row.task_state.as_deref() != Some("acquired") || row.task_version != r.version {
+            return err(req, 409, "Task version mismatch or invalid state");
+        }
+
+        let retry_at = now + self.task_retry_timeout;
+        if let Err(e) = self
+            .exec(
+                "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+                (
+                    self.bucket_for(retry_at),
+                    self.shard_for(&r.id),
+                    retry_at,
+                    r.id.as_str(),
+                    row.origin.as_str(),
+                    row.timeout_at,
+                ),
+            )
+            .await
+        {
+            return storage_err(req, e);
+        }
+        let (applied, _lwt) = match self
+            .cas(
+                "UPDATE promises SET task_state = 'pending', task_pid = null, task_ttl = null, task_timeout_retry = ?, task_timeout_lease = null WHERE origin = ? AND id = ? IF task_state = 'acquired' AND task_version = ?",
+                (
+                    retry_at,
+                    row.origin.as_str(),
+                    r.id.as_str(),
+                    r.version as i32,
+                ),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(retry_at),
+                        self.shard_for(&r.id),
+                        retry_at,
+                        row.origin.as_str(),
+                        r.id.as_str(),
+                    ),
+                )
+                .await;
+            return err(req, 409, "Task version mismatch or invalid state");
+        }
+        if let Some(old_lease) = row.task_timeout_lease {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(old_lease),
+                        self.shard_for(&r.id),
+                        old_lease,
+                        row.origin.as_str(),
+                        r.id.as_str(),
+                    ),
+                )
+                .await;
+        }
+        self.arm_retry(&mut ctx, &r.id, retry_at);
+        if let Some(target) = &row.target {
+            ctx.messages.push(Outgoing::Execute {
+                address: target.clone(),
+                task_id: r.id.clone(),
+                version: r.version,
+            });
+        }
+        ok(req, ctx, &json!({}))
+    }
+
+    pub(crate) async fn op_task_fulfill(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskFulfillData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let action = &r.action.data;
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &action.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Task not found"),
+            Ok(Some(row)) => row,
+        };
+        if row.task_state.is_none() {
+            return err(req, 404, "Task not found");
+        }
+        if row.task_state.as_deref() != Some("acquired") || row.task_version != r.version {
+            return err(req, 409, "Task version mismatch or invalid state");
+        }
+
+        let settle_state = action.state.to_string();
+        let settled_at_val = now;
+        // The fence folded into the settle: state, task state AND version
+        // pinned together, plus the un-written value columns so a failed
+        // batch names the winner.
+        let stmt = "UPDATE promises SET state = ?, value_headers = ?, value_data = ?, settled_at = ?, \
+             callbacks = {}, listeners = {}, task_state = 'fulfilled', task_pid = null, \
+             task_ttl = null, task_timeout_retry = null, task_timeout_lease = null, task_resumes = {} \
+             WHERE origin = ? AND id = ? \
+             IF state = 'pending' AND task_state = 'acquired' AND task_version = ? AND callbacks = ? \
+             AND settled_at = null AND value_headers = null AND value_data = null";
+        let args: Args = vec![
+            text(&settle_state),
+            crate::db::opt_cql_map(action.value.headers.as_ref()),
+            opt_text(action.value.data.clone()),
+            big(settled_at_val),
+            text(&row.origin),
+            text(&row.id),
+            int(r.version as i32),
+            cql_set(&row.callbacks),
+        ];
+        let outcome = match self
+            .enqueue_resume(
+                &row.id,
+                &row.origin,
+                &row.callbacks,
+                settled_at_val,
+                stmt.to_string(),
+                args,
+            )
+            .await
+        {
+            Ok(o) => o,
+            Err(e) => return storage_err(req, e),
+        };
+        match outcome {
+            SettleOutcome::Won { resumed, retry_at } => {
+                let mut settled = row.clone();
+                settled.state = settle_state;
+                settled.value_headers = action.value.headers.clone().unwrap_or_default();
+                settled.value_data = action.value.data.clone();
+                settled.settled_at = Some(settled_at_val);
+                if let Err(e) = self
+                    .after_settle_won(&mut ctx, &settled, resumed, retry_at)
+                    .await
+                {
+                    return storage_err(req, e);
+                }
+                let promise = settled.to_promise_record();
+                ok(req, ctx, &TaskFulfillResponseData { promise })
+            }
+            _ => err(req, 409, "Task version mismatch or invalid state"),
+        }
+    }
+
+    pub(crate) async fn op_task_suspend(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskSuspendData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Task not found"),
+            Ok(Some(row)) => row,
+        };
+        if row.task_state.is_none() {
+            return err(req, 404, "Task not found");
+        }
+        if row.task_state.as_deref() != Some("acquired") || row.task_version != r.version {
+            return err(req, 409, "Task is not acquired or version mismatch");
+        }
+
+        // Read every awaited (ghosting each), all in the task's partition.
+        let mut awaited_rows = Vec::new();
+        for action in &r.actions {
+            match self
+                .read_and_try_timeout(&mut ctx, &action.data.awaited, now)
+                .await
+            {
+                Err(e) => return storage_err(req, e),
+                Ok(None) => return err(req, 422, "Awaited promise not found"),
+                Ok(Some(a)) => awaited_rows.push(a),
+            }
+        }
+        for a in &awaited_rows {
+            if !resonate_core::types::is_awaitable(&a.tags) {
+                return err(req, 422, "Awaited promise is not awaitable");
+            }
+        }
+
+        if awaited_rows.iter().any(|a| a.state != "pending") {
+            // Something already settled: no suspend — clear the resume
+            // ledger and hand back the preload so the worker re-reads.
+            let (applied, _lwt) = match self
+                .cas(
+                    "UPDATE promises SET task_resumes = {} WHERE origin = ? AND id = ? IF task_state = 'acquired' AND task_version = ?",
+                    (row.origin.as_str(), r.id.as_str(), r.version as i32),
+                )
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => return storage_err(req, e),
+            };
+            if !applied {
+                return err(req, 409, "Task is not acquired or version mismatch");
+            }
+            let preload = match self.preload(&row.origin, &r.id).await {
+                Ok(p) => p,
+                Err(e) => return storage_err(req, e),
+            };
+            let mut out = ok(req, ctx, &TaskSuspendPreloadData { preload });
+            if let Some(resp) = &mut out.response {
+                resp.head.status = 300;
+            }
+            return out;
+        }
+
+        // One conditional batch, single partition: the suspend plus one
+        // callbacks registration per awaited.
+        let mut stmts: Vec<(String, Args)> = vec![(
+            "UPDATE promises SET task_state = 'suspended', task_pid = null, task_ttl = null, task_resumes = {}, task_timeout_lease = null WHERE origin = ? AND id = ? IF task_state = 'acquired' AND task_version = ?".to_string(),
+            vec![text(&row.origin), text(&r.id), int(r.version as i32)],
+        )];
+        for a in &awaited_rows {
+            stmts.push((
+                "UPDATE promises SET callbacks = callbacks + ? WHERE origin = ? AND id = ? IF state = 'pending'".to_string(),
+                vec![
+                    cql_set(std::slice::from_ref(&r.id)),
+                    text(&row.origin),
+                    text(&a.id),
+                ],
+            ));
+        }
+        let (applied, _lwt) = match self.batch_cas(stmts).await {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            return err(req, 500, "Concurrent modification; please retry");
+        }
+        if let Some(old_lease) = row.task_timeout_lease {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(old_lease),
+                        self.shard_for(&r.id),
+                        old_lease,
+                        row.origin.as_str(),
+                        r.id.as_str(),
+                    ),
+                )
+                .await;
+        }
+        ok(req, ctx, &json!({}))
+    }
+
+    pub(crate) async fn op_task_fence(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskFenceData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Task not found"),
+            Ok(Some(row)) => row,
+        };
+        if row.task_state.is_none() {
+            return err(req, 404, "Task not found");
+        }
+        if row.task_state.as_deref() != Some("acquired") || row.task_version != r.version {
+            return err(req, 409, "Version mismatch");
+        }
+
+        let inner_promise: Option<PromiseRecord> = match r.action.kind.as_str() {
+            "promise.create" => {
+                let create_data: PromiseCreateData =
+                    match serde_json::from_value(r.action.data.clone()) {
+                        Ok(d) => d,
+                        Err(e) => return err(req, 400, &format!("Invalid action data: {}", e)),
+                    };
+                if let Err(e) = create_data.validate() {
+                    return err(
+                        req,
+                        400,
+                        &resonate_core::types::format_validation_errors(&e),
+                    );
+                }
+                if let Some(addr) = create_data.tags.get("resonate:target") {
+                    if !resonate_core::is_valid_address(addr) {
+                        return err(req, 400, "Invalid resonate:target address");
+                    }
+                }
+                match self.fence_inner_create(&mut ctx, &create_data, now).await {
+                    Ok(p) => p,
+                    Err(e) => return storage_err(req, e),
+                }
+            }
+            "promise.settle" => {
+                let settle_data: PromiseSettleData =
+                    match serde_json::from_value(r.action.data.clone()) {
+                        Ok(d) => d,
+                        Err(e) => return err(req, 400, &format!("Invalid action data: {}", e)),
+                    };
+                if let Err(e) = settle_data.validate() {
+                    return err(
+                        req,
+                        400,
+                        &resonate_core::types::format_validation_errors(&e),
+                    );
+                }
+                match self.fence_inner_settle(&mut ctx, &settle_data, now).await {
+                    Ok(p) => p,
+                    Err(e) => return storage_err(req, e),
+                }
+            }
+            _ => return err(req, 400, "Invalid fence action kind"),
+        };
+
+        let (inner_status, inner_data) = match inner_promise {
+            Some(ref p) => (200i32, json!({ "promise": p })),
+            None => (404, json!("Promise not found")),
+        };
+        let inner_envelope = json!({
+            "kind": r.action.kind,
+            "head": { "corrId": req.head.corr_id, "status": inner_status, "version": PROTOCOL_VERSION },
+            "data": inner_data,
+        });
+        let preload = match self.preload(&row.origin, &r.id).await {
+            Ok(p) => p,
+            Err(e) => return storage_err(req, e),
+        };
+        ok(
+            req,
+            ctx,
+            &resonate_core::types::TaskFenceResponseData {
+                action: inner_envelope,
+                preload,
+            },
+        )
+    }
+
+    async fn fence_inner_create(
+        &self,
+        ctx: &mut Ctx,
+        create_data: &PromiseCreateData,
+        now: i64,
+    ) -> Result<Option<PromiseRecord>, resonate_server_dbms::StorageError> {
+        // The inner action is a plain promise.create against its own row.
+        let record = self.promise_create_impl(ctx, create_data, now).await?;
+        Ok(Some(record))
+    }
+
+    async fn fence_inner_settle(
+        &self,
+        ctx: &mut Ctx,
+        settle_data: &PromiseSettleData,
+        now: i64,
+    ) -> Result<Option<PromiseRecord>, resonate_server_dbms::StorageError> {
+        let Some(row) = self.read_and_try_timeout(ctx, &settle_data.id, now).await? else {
+            return Ok(None);
+        };
+        if row.state != "pending" {
+            return Ok(Some(row.to_promise_record()));
+        }
+        let settle_state = settle_data.state.to_string();
+        let has_task = row.target.is_some();
+        let stmt = if has_task {
+            "UPDATE promises SET state = ?, value_headers = ?, value_data = ?, settled_at = ?, \
+             callbacks = {}, listeners = {}, task_state = 'fulfilled', task_pid = null, \
+             task_ttl = null, task_timeout_retry = null, task_timeout_lease = null, task_resumes = {} \
+             WHERE origin = ? AND id = ? \
+             IF state = 'pending' AND callbacks = ? AND settled_at = null AND value_headers = null AND value_data = null"
+        } else {
+            "UPDATE promises SET state = ?, value_headers = ?, value_data = ?, settled_at = ?, \
+             callbacks = {}, listeners = {} \
+             WHERE origin = ? AND id = ? \
+             IF state = 'pending' AND callbacks = ? AND settled_at = null AND value_headers = null AND value_data = null"
+        };
+        let args: Args = vec![
+            text(&settle_state),
+            crate::db::opt_cql_map(settle_data.value.headers.as_ref()),
+            opt_text(settle_data.value.data.clone()),
+            big(now),
+            text(&row.origin),
+            text(&row.id),
+            cql_set(&row.callbacks),
+        ];
+        let outcome = self
+            .enqueue_resume(
+                &row.id,
+                &row.origin,
+                &row.callbacks,
+                now,
+                stmt.to_string(),
+                args,
+            )
+            .await?;
+        match outcome {
+            SettleOutcome::Won { resumed, retry_at } => {
+                let mut settled = row.clone();
+                settled.state = settle_state;
+                settled.value_headers = settle_data.value.headers.clone().unwrap_or_default();
+                settled.value_data = settle_data.value.data.clone();
+                settled.settled_at = Some(now);
+                self.after_settle_won(ctx, &settled, resumed, retry_at)
+                    .await?;
+                Ok(Some(settled.to_promise_record()))
+            }
+            _ => Ok(self
+                .read_promise(&row.origin, &row.id)
+                .await?
+                .map(|p| p.to_promise_record())),
+        }
+    }
+
+    pub(crate) async fn op_task_heartbeat(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskHeartbeatData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        for task_ref in &r.tasks {
+            let row = match self.read_and_try_timeout(&mut ctx, &task_ref.id, now).await {
+                Err(e) => return storage_err(req, e),
+                Ok(None) => continue,
+                Ok(Some(row)) => row,
+            };
+            let eligible = row.task_state.as_deref() == Some("acquired")
+                && row.task_version == task_ref.version
+                && row.task_pid.as_deref() == Some(r.pid.as_str())
+                && row.task_ttl.is_some();
+            if !eligible {
+                continue;
+            }
+            let ttl = row.task_ttl.unwrap();
+            let new_lease = now + ttl;
+            if let Err(e) = self
+                .exec(
+                    "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 1, ?, ?, ?)",
+                    (
+                        self.bucket_for(new_lease),
+                        self.shard_for(&task_ref.id),
+                        new_lease,
+                        task_ref.id.as_str(),
+                        row.origin.as_str(),
+                        row.timeout_at,
+                    ),
+                )
+                .await
+            {
+                return storage_err(req, e);
+            }
+            let (applied, _lwt) = match self
+                .cas(
+                    "UPDATE promises SET task_timeout_lease = ? WHERE origin = ? AND id = ? IF task_state = 'acquired' AND task_version = ?",
+                    (
+                        new_lease,
+                        row.origin.as_str(),
+                        task_ref.id.as_str(),
+                        task_ref.version as i32,
+                    ),
+                )
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => return storage_err(req, e),
+            };
+            if applied {
+                if let Some(old_lease) = row.task_timeout_lease {
+                    if old_lease != new_lease {
+                        let _ = self
+                            .exec(
+                                "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                                (
+                                    self.bucket_for(old_lease),
+                                    self.shard_for(&task_ref.id),
+                                    old_lease,
+                                    row.origin.as_str(),
+                                    task_ref.id.as_str(),
+                                ),
+                            )
+                            .await;
+                    }
+                }
+                self.arm_lease(
+                    &mut ctx,
+                    &task_ref.id,
+                    row.task_pid.as_deref().unwrap_or(""),
+                    new_lease,
+                );
+            } else {
+                let _ = self
+                    .exec(
+                        "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                        (
+                            self.bucket_for(new_lease),
+                            self.shard_for(&task_ref.id),
+                            new_lease,
+                            row.origin.as_str(),
+                            task_ref.id.as_str(),
+                        ),
+                    )
+                    .await;
+            }
+        }
+        ok(req, ctx, &json!({}))
+    }
+
+    pub(crate) async fn op_task_halt(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskHaltData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Task not found"),
+            Ok(Some(row)) => row,
+        };
+        match row.task_state.as_deref() {
+            None => return err(req, 404, "Task not found"),
+            Some("fulfilled") => return err(req, 409, "Task is fulfilled"),
+            Some("halted") => return ok(req, ctx, &json!({})),
+            _ => {}
+        }
+        let (applied, lwt) = match self
+            .cas(
+                "UPDATE promises SET task_state = 'halted', task_pid = null, task_ttl = null, task_timeout_retry = null, task_timeout_lease = null WHERE origin = ? AND id = ? IF task_state IN ('pending', 'acquired', 'suspended')",
+                (row.origin.as_str(), r.id.as_str()),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            return match get_text(&lwt, "task_state").as_deref() {
+                Some("halted") => ok(req, ctx, &json!({})),
+                Some("fulfilled") => err(req, 409, "Task is fulfilled"),
+                _ => err(req, 500, "Concurrent modification; please retry"),
+            };
+        }
+        match row.task_state.as_deref() {
+            Some("acquired") => {
+                if let Some(old_lease) = row.task_timeout_lease {
+                    let _ = self
+                        .exec(
+                            "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                            (
+                                self.bucket_for(old_lease),
+                                self.shard_for(&r.id),
+                                old_lease,
+                                row.origin.as_str(),
+                                r.id.as_str(),
+                            ),
+                        )
+                        .await;
+                }
+            }
+            Some("pending") => {
+                if let Some(old_retry) = row.task_timeout_retry {
+                    let _ = self
+                        .exec(
+                            "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                            (
+                                self.bucket_for(old_retry),
+                                self.shard_for(&r.id),
+                                old_retry,
+                                row.origin.as_str(),
+                                r.id.as_str(),
+                            ),
+                        )
+                        .await;
+                }
+            }
+            _ => {}
+        }
+        ok(req, ctx, &json!({}))
+    }
+
+    pub(crate) async fn op_task_continue(&self, req: &RequestEnvelope, now: i64) -> Output {
+        let r: TaskContinueData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let mut ctx = Ctx::default();
+        let row = match self.read_and_try_timeout(&mut ctx, &r.id, now).await {
+            Err(e) => return storage_err(req, e),
+            Ok(None) => return err(req, 404, "Task not found"),
+            Ok(Some(row)) => row,
+        };
+        if row.task_state.is_none() {
+            return err(req, 404, "Task not found");
+        }
+        if row.task_state.as_deref() != Some("halted") {
+            return err(req, 409, "Task is not halted");
+        }
+        let retry_at = now + self.task_retry_timeout;
+        if let Err(e) = self
+            .exec(
+                "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+                (
+                    self.bucket_for(retry_at),
+                    self.shard_for(&r.id),
+                    retry_at,
+                    r.id.as_str(),
+                    row.origin.as_str(),
+                    row.timeout_at,
+                ),
+            )
+            .await
+        {
+            return storage_err(req, e);
+        }
+        let (applied, lwt) = match self
+            .cas(
+                "UPDATE promises SET task_state = 'pending', task_timeout_retry = ?, task_timeout_lease = null WHERE origin = ? AND id = ? IF task_state = 'halted'",
+                (retry_at, row.origin.as_str(), r.id.as_str()),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return storage_err(req, e),
+        };
+        if !applied {
+            if crate::db::get_big(&lwt, "task_timeout_retry") != Some(retry_at) {
+                let _ = self
+                    .exec(
+                        "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                        (
+                            self.bucket_for(retry_at),
+                            self.shard_for(&r.id),
+                            retry_at,
+                            row.origin.as_str(),
+                            r.id.as_str(),
+                        ),
+                    )
+                    .await;
+            }
+            return err(req, 409, "Task is not halted");
+        }
+        self.arm_retry(&mut ctx, &r.id, retry_at);
+        if let Some(target) = &row.target {
+            ctx.messages.push(Outgoing::Execute {
+                address: target.clone(),
+                task_id: r.id.clone(),
+                version: row.task_version,
+            });
+        }
+        ok(req, ctx, &json!({}))
+    }
+
+    pub(crate) async fn op_task_search(&self, req: &RequestEnvelope, _now: i64) -> Output {
+        let r: TaskSearchData = match parse(req) {
+            Ok(r) => r,
+            Err(e) => return Output::response(e),
+        };
+        let limit = match r.limit {
+            Some(n) if n > 1000 => {
+                return err(req, 400, "Invalid 'limit' — must be between 1 and 1000")
+            }
+            Some(n) => n as usize,
+            None => 100,
+        };
+        let rows = match self
+            .rows(&format!("SELECT {} FROM promises", crate::db::P_COLS), ())
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => return storage_err(req, e),
+        };
+        let mut tasks: Vec<TaskRecord> = rows
+            .iter()
+            .map(PromiseRow::from_map)
+            .filter_map(|p| p.to_task_record())
+            .filter(|t| r.state.map(|s| t.state == s).unwrap_or(true))
+            .collect();
+        tasks.sort_by(|a, b| a.id.cmp(&b.id));
+        if let Some(cursor) = r.cursor.as_deref() {
+            tasks.retain(|t| t.id.as_str() > cursor);
+        }
+        let has_more = tasks.len() > limit;
+        tasks.truncate(limit);
+        let cursor = if has_more {
+            tasks.last().map(|t| t.id.clone())
+        } else {
+            None
+        };
+        ok(
+            req,
+            Ctx::default(),
+            &TaskSearchResponseData { tasks, cursor },
+        )
+    }
+
+}

--- a/crates/resonate-server-scylladb/src/ops_task.rs
+++ b/crates/resonate-server-scylladb/src/ops_task.rs
@@ -941,12 +941,19 @@ impl ScyllaEngine {
         };
         let mut ctx = Ctx::default();
         for task_ref in &r.tasks {
-            let row = match self.read_and_try_timeout(&mut ctx, &task_ref.id, now).await {
+            // task.heartbeat is the one operation that does not sweep first:
+            // a plain read, and a lease is refused an extension when the
+            // promise has logically expired — otherwise a heartbeat in the
+            // window before the sweep would extend a dead task's lease.
+            let origin = crate::origin_of(&task_ref.id).to_string();
+            let row = match self.read_promise(&origin, &task_ref.id).await {
                 Err(e) => return storage_err(req, e),
                 Ok(None) => continue,
                 Ok(Some(row)) => row,
             };
-            let eligible = row.task_state.as_deref() == Some("acquired")
+            let promise_live = row.state != "pending" || row.timeout_at > now;
+            let eligible = promise_live
+                && row.task_state.as_deref() == Some("acquired")
                 && row.task_version == task_ref.version
                 && row.task_pid.as_deref() == Some(r.pid.as_str())
                 && row.task_ttl.is_some();

--- a/crates/resonate-server-scylladb/src/snap.rs
+++ b/crates/resonate-server-scylladb/src/snap.rs
@@ -1,0 +1,126 @@
+//! Debug reset and snapshot.
+//!
+//! The snapshot's queue sections are projected from the promises table with
+//! the same membership rules every engine's snapshot carries — the physical
+//! bucketed queues are mechanics, not state, and are never compared. The
+//! promises section IS physical: an eagerly settled internal promise shows
+//! settled here where a lazy engine shows pending, and that difference is
+//! exactly the experiment the differential runs.
+
+use resonate_core::types::{
+    RequestEnvelope, ResponseEnvelope, Snapshot, SnapshotCallback, SnapshotListener,
+    SnapshotMessage, SnapshotPromiseTimeout, SnapshotTaskTimeout,
+};
+use resonate_server_dbms::engine_port::Output;
+use serde_json::Value;
+
+use crate::db::PromiseRow;
+use crate::ops_promise::storage_err;
+use crate::ScyllaEngine;
+
+impl ScyllaEngine {
+    pub(crate) async fn op_debug_reset(&self, req: &RequestEnvelope) -> Output {
+        for table in [
+            "promises",
+            "schedules",
+            "promise_timeouts",
+            "task_timeouts",
+            "schedule_timeouts",
+            "workers",
+        ] {
+            if let Err(e) = self.exec(&format!("TRUNCATE {table}"), ()).await {
+                return storage_err(req, e);
+            }
+        }
+        Output::response(ResponseEnvelope::new(
+            req.kind.clone(),
+            req.head.corr_id.clone(),
+            200,
+            Value::Object(serde_json::Map::new()),
+        ))
+    }
+
+    pub(crate) async fn op_debug_snap(&self, req: &RequestEnvelope, _now: i64) -> Output {
+        let rows = match self
+            .rows(&format!("SELECT {} FROM promises", crate::db::P_COLS), ())
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => return storage_err(req, e),
+        };
+        let mut all: Vec<PromiseRow> = rows.iter().map(PromiseRow::from_map).collect();
+        all.sort_by(|a, b| a.id.cmp(&b.id));
+
+        let promises = all.iter().map(|p| p.to_promise_record()).collect();
+
+        let promise_timeouts: Vec<SnapshotPromiseTimeout> = all
+            .iter()
+            .filter(|p| p.state == "pending" && resonate_core::types::is_awaitable(&p.tags))
+            .map(|p| SnapshotPromiseTimeout {
+                id: p.id.clone(),
+                timeout: p.timeout_at,
+            })
+            .collect();
+
+        let mut callbacks: Vec<SnapshotCallback> = all
+            .iter()
+            .flat_map(|p| {
+                p.callbacks.iter().map(|awaiter| SnapshotCallback {
+                    awaiter: awaiter.clone(),
+                    awaited: p.id.clone(),
+                })
+            })
+            .collect();
+        callbacks.sort_by(|a, b| a.awaited.cmp(&b.awaited).then(a.awaiter.cmp(&b.awaiter)));
+
+        let mut listeners: Vec<SnapshotListener> = all
+            .iter()
+            .flat_map(|p| {
+                p.listeners.iter().map(|addr| SnapshotListener {
+                    promise_id: p.id.clone(),
+                    address: addr.clone(),
+                })
+            })
+            .collect();
+        listeners.sort_by(|a, b| {
+            a.promise_id
+                .cmp(&b.promise_id)
+                .then(a.address.cmp(&b.address))
+        });
+
+        let tasks = all.iter().filter_map(|p| p.to_task_record()).collect();
+
+        let task_timeouts: Vec<SnapshotTaskTimeout> = all
+            .iter()
+            .filter_map(|p| match p.task_state.as_deref() {
+                Some("pending") => p.task_timeout_retry.map(|t| SnapshotTaskTimeout {
+                    id: p.id.clone(),
+                    timeout_type: 0,
+                    timeout: t,
+                }),
+                Some("acquired") => p.task_timeout_lease.map(|t| SnapshotTaskTimeout {
+                    id: p.id.clone(),
+                    timeout_type: 1,
+                    timeout: t,
+                }),
+                _ => None,
+            })
+            .collect();
+
+        let snapshot = Snapshot {
+            promises,
+            promise_timeouts,
+            callbacks,
+            listeners,
+            tasks,
+            task_timeouts,
+            messages: Vec::<SnapshotMessage>::new(),
+        };
+        Output::response(ResponseEnvelope::new(
+            req.kind.clone(),
+            req.head.corr_id.clone(),
+            200,
+            serde_json::to_value(&snapshot).unwrap_or(Value::Null),
+        ))
+    }
+}

--- a/crates/resonate-server-scylladb/src/snap.rs
+++ b/crates/resonate-server-scylladb/src/snap.rs
@@ -1,11 +1,15 @@
 //! Debug reset and snapshot.
 //!
-//! The snapshot's queue sections are projected from the promises table with
-//! the same membership rules every engine's snapshot carries — the physical
-//! bucketed queues are mechanics, not state, and are never compared. The
-//! promises section IS physical: an eagerly settled internal promise shows
-//! settled here where a lazy engine shows pending, and that difference is
-//! exactly the experiment the differential runs.
+//! Every section reports meaning, not mechanics. The queue sections are
+//! projected from the promises table with the membership rules every
+//! engine's snapshot carries — the physical bucketed queues are never
+//! compared. The promise records project expiry like every read, which is
+//! what makes this EAGER engine and the lazy relational ones snap
+//! identically: a projected pending-expired record and a physically settled
+//! one are the same bytes, because the timeout verdict is deterministic.
+//! The obligation sections project in both directions — a settled holder
+//! reports none, a fulfilled member reports as absent — so Go's lazy
+//! registration cleanup is invisible too.
 
 use resonate_core::types::{
     RequestEnvelope, ResponseEnvelope, Snapshot, SnapshotCallback, SnapshotListener,
@@ -14,7 +18,7 @@ use resonate_core::types::{
 use resonate_server_dbms::engine_port::Output;
 use serde_json::Value;
 
-use crate::db::PromiseRow;
+use crate::db::{project, PromiseRow};
 use crate::ops_promise::storage_err;
 use crate::ScyllaEngine;
 
@@ -40,7 +44,7 @@ impl ScyllaEngine {
         ))
     }
 
-    pub(crate) async fn op_debug_snap(&self, req: &RequestEnvelope, _now: i64) -> Output {
+    pub(crate) async fn op_debug_snap(&self, req: &RequestEnvelope, now: i64) -> Output {
         let rows = match self
             .rows(&format!("SELECT {} FROM promises", crate::db::P_COLS), ())
             .await
@@ -51,7 +55,7 @@ impl ScyllaEngine {
         let mut all: Vec<PromiseRow> = rows.iter().map(PromiseRow::from_map).collect();
         all.sort_by(|a, b| a.id.cmp(&b.id));
 
-        let promises = all.iter().map(|p| p.to_promise_record()).collect();
+        let promises = all.iter().map(|p| project(p, now)).collect();
 
         let promise_timeouts: Vec<SnapshotPromiseTimeout> = all
             .iter()
@@ -62,19 +66,30 @@ impl ScyllaEngine {
             })
             .collect();
 
+        let holder_projects_empty =
+            |p: &PromiseRow| -> bool { p.state != "pending" || now >= p.timeout_at };
+        let fulfilled: std::collections::HashSet<&str> = all
+            .iter()
+            .filter(|p| p.task_state.as_deref() == Some("fulfilled"))
+            .map(|p| p.id.as_str())
+            .collect();
+
         let mut callbacks: Vec<SnapshotCallback> = all
             .iter()
+            .filter(|p| !holder_projects_empty(p))
             .flat_map(|p| {
                 p.callbacks.iter().map(|awaiter| SnapshotCallback {
                     awaiter: awaiter.clone(),
                     awaited: p.id.clone(),
                 })
             })
+            .filter(|cb| !fulfilled.contains(cb.awaiter.as_str()))
             .collect();
         callbacks.sort_by(|a, b| a.awaited.cmp(&b.awaited).then(a.awaiter.cmp(&b.awaiter)));
 
         let mut listeners: Vec<SnapshotListener> = all
             .iter()
+            .filter(|p| !holder_projects_empty(p))
             .flat_map(|p| {
                 p.listeners.iter().map(|addr| SnapshotListener {
                     promise_id: p.id.clone(),

--- a/crates/resonate-server-scylladb/src/timeouts.rs
+++ b/crates/resonate-server-scylladb/src/timeouts.rs
@@ -1,0 +1,908 @@
+//! The timeout machinery — Go's `handler_timeouts.go` and the schedule
+//! firing, driven by the port instead of goroutines.
+//!
+//! Every handler is idempotent against stale and orphan entries: the
+//! pre-insert protocol only ever leaves an extra entry, never a missing
+//! one, and the guard ladders here classify and delete them. `Keep` is the
+//! Go "skip cleanup" idiom — the entry stays as the retry anchor.
+
+use resonate_core::types::{RequestEnvelope, ResponseEnvelope};
+use resonate_server_dbms::engine_port::{Outgoing, Output, Scheduled, Timeout};
+use resonate_server_dbms::StorageResult;
+use scylla::value::CqlValue;
+use serde_json::Value;
+
+use crate::db::{get_big, get_text, get_tags, PromiseRow};
+use crate::ops_promise::err;
+use crate::{origin_of, Ctx, ScyllaEngine, Tags};
+
+enum Cleanup {
+    Delete,
+    Keep,
+}
+
+impl ScyllaEngine {
+    pub(crate) async fn process_internal(
+        &self,
+        timeout: Timeout,
+        now: i64,
+    ) -> Output {
+        let mut ctx = Ctx::default();
+        let result = match &timeout {
+            Timeout::PromiseTimeout { promise_id } => {
+                self.internal_promise_timeout(&mut ctx, promise_id, now).await
+            }
+            Timeout::TaskRetryTimeout { task_id } => {
+                self.internal_retry_timeout(&mut ctx, task_id, now).await
+            }
+            Timeout::TaskLeaseTimeout { task_id, .. } => {
+                self.internal_lease_timeout(&mut ctx, task_id, now).await
+            }
+            Timeout::ScheduleDue { schedule_id } => self
+                .internal_schedule_due(&mut ctx, schedule_id, now)
+                .await
+                .map(|_| ()),
+        };
+        if let Err(e) = result {
+            tracing::error!(error = %e, "internal timeout failed");
+        }
+        Output {
+            response: None,
+            messages: ctx.messages,
+            timeouts: ctx.armed,
+        }
+    }
+
+    /// The narrow form: fire the one named deadline if the durable state
+    /// still holds it due. A moved deadline or settled row is a no-op.
+    async fn internal_promise_timeout(
+        &self,
+        ctx: &mut Ctx,
+        id: &str,
+        now: i64,
+    ) -> StorageResult<()> {
+        let origin = origin_of(id).to_string();
+        if let Some(row) = self.read_promise(&origin, id).await? {
+            if row.state == "pending" && row.timeout_at <= now {
+                self.on_promise_timeout(ctx, &origin, id, row.timeout_at, now).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn internal_retry_timeout(&self, ctx: &mut Ctx, id: &str, now: i64) -> StorageResult<()> {
+        let origin = origin_of(id).to_string();
+        if let Some(row) = self.read_promise(&origin, id).await? {
+            if row.task_state.as_deref() == Some("pending") {
+                if let Some(retry_at) = row.task_timeout_retry {
+                    if retry_at <= now {
+                        self.on_task_retry(ctx, &origin, id, retry_at, row.timeout_at, now)
+                            .await?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn internal_lease_timeout(&self, ctx: &mut Ctx, id: &str, now: i64) -> StorageResult<()> {
+        let origin = origin_of(id).to_string();
+        if let Some(row) = self.read_promise(&origin, id).await? {
+            if row.task_state.as_deref() == Some("acquired") {
+                if let Some(lease_at) = row.task_timeout_lease {
+                    if lease_at <= now {
+                        self.on_task_lease(ctx, &origin, id, lease_at, row.timeout_at, now)
+                            .await?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn internal_schedule_due(
+        &self,
+        ctx: &mut Ctx,
+        schedule_id: &str,
+        now: i64,
+    ) -> StorageResult<usize> {
+        let Some(m) = self.read_schedule(schedule_id).await? else {
+            return Ok(0);
+        };
+        let next_run_at = get_big(&m, "next_run_at").unwrap_or(0);
+        if next_run_at > now {
+            return Ok(0);
+        }
+        let token = match m.get("create_token") {
+            Some(Some(CqlValue::Uuid(u))) => *u,
+            _ => uuid::Uuid::nil(),
+        };
+        self.on_schedule_due(ctx, schedule_id, next_run_at, token, now)
+            .await
+    }
+
+    /// One eager settle of an entry the sweep found — Go's `onPromiseTimeout`
+    /// with its three stale-entry exits. `now` is the sweep's clock, for the
+    /// follow-up deadlines a resumed awaiter gets.
+    async fn on_promise_timeout(
+        &self,
+        ctx: &mut Ctx,
+        origin: &str,
+        id: &str,
+        entry_at: i64,
+        now: i64,
+    ) -> StorageResult<()> {
+        let delete_entry = |bucket: i64, shard: i16| {
+            (
+                "DELETE FROM promise_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND promise_id = ?",
+                bucket,
+                shard,
+            )
+        };
+        let (cql, bucket, shard) = delete_entry(self.bucket_for(entry_at), self.shard_for(id));
+        match self.read_promise(origin, id).await? {
+            None => {
+                let _ = self
+                    .exec(cql, (bucket, shard, entry_at, origin, id))
+                    .await;
+            }
+            Some(row) if row.state != "pending" => {
+                let _ = self
+                    .exec(cql, (bucket, shard, entry_at, origin, id))
+                    .await;
+            }
+            Some(row) if row.timeout_at != entry_at => {
+                // Orphan: the row's deadline is not this entry's.
+                let _ = self
+                    .exec(cql, (bucket, shard, entry_at, origin, id))
+                    .await;
+            }
+            Some(row) => {
+                // EXPLORATORY (decision pending): Go anchors a resumed
+                // awaiter's retry at the entry's own deadline (timeoutAt +
+                // retry); the relational engines anchor at the sweep's
+                // clock. The differential sees the difference in the armed
+                // hints (first at ~step 1976). Aligned to the sweep clock so
+                // the run can continue cataloguing.
+                self.try_timeout(ctx, &row, now).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Go's `onTaskRetryTimeout`: re-enqueue a pending task for execution.
+    async fn on_task_retry(
+        &self,
+        ctx: &mut Ctx,
+        origin: &str,
+        id: &str,
+        entry_at: i64,
+        promise_timeout_at: i64,
+        now: i64,
+    ) -> StorageResult<()> {
+        let cleanup = self
+            .task_retry_transition(ctx, origin, id, entry_at, promise_timeout_at, now)
+            .await?;
+        if let Cleanup::Delete = cleanup {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(entry_at),
+                        self.shard_for(id),
+                        entry_at,
+                        origin,
+                        id,
+                    ),
+                )
+                .await;
+        }
+        Ok(())
+    }
+
+    async fn task_retry_transition(
+        &self,
+        ctx: &mut Ctx,
+        origin: &str,
+        id: &str,
+        entry_at: i64,
+        promise_timeout_at: i64,
+        now: i64,
+    ) -> StorageResult<Cleanup> {
+        let Some(row) = self.read_promise(origin, id).await? else {
+            // Row gone: logically timed out entries clean up; anything else
+            // may be a create's pre-insert mid-flight.
+            return Ok(if promise_timeout_at <= now {
+                Cleanup::Delete
+            } else {
+                Cleanup::Keep
+            });
+        };
+        match row.task_state.as_deref() {
+            Some("acquired") => {
+                // A lease newer than this entry means a re-acquire happened
+                // after the entry was written: definitely stale. A lease at
+                // or before it may be onTaskLeaseTimeout's pre-insert still
+                // in flight — leave it.
+                return Ok(match row.task_timeout_lease {
+                    Some(lease) if lease > entry_at => Cleanup::Delete,
+                    _ => Cleanup::Keep,
+                });
+            }
+            Some("pending") => {}
+            _ => return Ok(Cleanup::Delete),
+        }
+        match row.task_timeout_retry {
+            None => return Ok(Cleanup::Delete),
+            Some(retry) if retry > entry_at => return Ok(Cleanup::Delete),
+            Some(retry) if retry < entry_at => return Ok(Cleanup::Keep),
+            _ => {}
+        }
+
+        let retry_at = now + self.task_retry_timeout;
+        self.exec(
+            "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+            (
+                self.bucket_for(retry_at),
+                self.shard_for(id),
+                retry_at,
+                id,
+                origin,
+                row.timeout_at,
+            ),
+        )
+        .await?;
+        let (applied, _lwt) = self
+            .cas(
+                "UPDATE promises SET task_timeout_retry = ? WHERE origin = ? AND id = ? IF task_state = 'pending' AND task_timeout_retry = ?",
+                (retry_at, origin, id, entry_at),
+            )
+            .await?;
+        if !applied {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(retry_at),
+                        self.shard_for(id),
+                        retry_at,
+                        origin,
+                        id,
+                    ),
+                )
+                .await;
+            return Ok(Cleanup::Delete);
+        }
+        self.arm_retry(ctx, id, retry_at);
+        if let Some(target) = &row.target {
+            ctx.messages.push(Outgoing::Execute {
+                address: target.clone(),
+                task_id: id.to_string(),
+                version: row.task_version,
+            });
+        }
+        Ok(Cleanup::Delete)
+    }
+
+    /// Go's `onTaskLeaseTimeout`: hand an expired lease back to the retry
+    /// queue, version unchanged.
+    async fn on_task_lease(
+        &self,
+        ctx: &mut Ctx,
+        origin: &str,
+        id: &str,
+        entry_at: i64,
+        promise_timeout_at: i64,
+        now: i64,
+    ) -> StorageResult<()> {
+        let cleanup = self
+            .task_lease_transition(ctx, origin, id, entry_at, promise_timeout_at, now)
+            .await?;
+        if let Cleanup::Delete = cleanup {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 1 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(entry_at),
+                        self.shard_for(id),
+                        entry_at,
+                        origin,
+                        id,
+                    ),
+                )
+                .await;
+        }
+        Ok(())
+    }
+
+    async fn task_lease_transition(
+        &self,
+        ctx: &mut Ctx,
+        origin: &str,
+        id: &str,
+        entry_at: i64,
+        promise_timeout_at: i64,
+        now: i64,
+    ) -> StorageResult<Cleanup> {
+        let Some(row) = self.read_promise(origin, id).await? else {
+            return Ok(if promise_timeout_at <= now {
+                Cleanup::Delete
+            } else {
+                Cleanup::Keep
+            });
+        };
+        if row.task_state.as_deref() != Some("acquired") {
+            return Ok(Cleanup::Delete);
+        }
+        if row.task_timeout_lease != Some(entry_at) {
+            return Ok(Cleanup::Delete);
+        }
+
+        let retry_at = now + self.task_retry_timeout;
+        self.exec(
+            "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+            (
+                self.bucket_for(retry_at),
+                self.shard_for(id),
+                retry_at,
+                id,
+                origin,
+                row.timeout_at,
+            ),
+        )
+        .await?;
+        // Pin the lease to defeat a release-then-reacquire ABA between the
+        // read and this statement.
+        let (applied, _lwt) = self
+            .cas(
+                "UPDATE promises SET task_state = 'pending', task_pid = null, task_ttl = null, task_timeout_retry = ?, task_timeout_lease = null WHERE origin = ? AND id = ? IF task_state = 'acquired' AND task_timeout_lease = ?",
+                (retry_at, origin, id, entry_at),
+            )
+            .await?;
+        if !applied {
+            let _ = self
+                .exec(
+                    "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                    (
+                        self.bucket_for(retry_at),
+                        self.shard_for(id),
+                        retry_at,
+                        origin,
+                        id,
+                    ),
+                )
+                .await;
+            return Ok(Cleanup::Delete);
+        }
+        self.arm_retry(ctx, id, retry_at);
+        if let Some(target) = &row.target {
+            ctx.messages.push(Outgoing::Execute {
+                address: target.clone(),
+                task_id: id.to_string(),
+                version: row.task_version,
+            });
+        }
+        Ok(Cleanup::Delete)
+    }
+
+    /// One schedule firing: walk the cron forward creating every due
+    /// occurrence, then advance the row pinned on the fired instant, and
+    /// re-anchor the queue with the schedule's own token.
+    async fn on_schedule_due(
+        &self,
+        ctx: &mut Ctx,
+        schedule_id: &str,
+        entry_at: i64,
+        token: uuid::Uuid,
+        now: i64,
+    ) -> StorageResult<usize> {
+        let origin = schedule_id.to_string();
+        let Some(m) = self.read_schedule(schedule_id).await? else {
+            // A create's pre-insert may still be in flight — leave the entry.
+            return Ok(0);
+        };
+        let next_run_at = get_big(&m, "next_run_at").unwrap_or(0);
+        let delete_entry = |at: i64, tok: uuid::Uuid| {
+            (
+                self.bucket_for(at),
+                self.shard_for(schedule_id),
+                at,
+                origin.clone(),
+                schedule_id.to_string(),
+                CqlValue::Uuid(tok),
+            )
+        };
+        if entry_at < next_run_at {
+            let args = delete_entry(entry_at, token);
+            let _ = self
+                .exec(
+                    "DELETE FROM schedule_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND schedule_id = ? AND create_token = ?",
+                    args,
+                )
+                .await;
+            return Ok(0);
+        }
+        if entry_at > next_run_at {
+            return Ok(0);
+        }
+
+        let cron = get_text(&m, "cron").unwrap_or_default();
+        let template = get_text(&m, "promise_id").unwrap_or_default();
+        let promise_timeout = get_big(&m, "promise_timeout").unwrap_or(0);
+        let param_headers = get_tags(&m, "promise_param_headers");
+        let param_data = get_text(&m, "promise_param_data");
+        let promise_tags = get_tags(&m, "promise_tags");
+        let row_token = match m.get("create_token") {
+            Some(Some(CqlValue::Uuid(u))) => *u,
+            _ => token,
+        };
+
+        let mut fired = 0usize;
+        let mut current = entry_at;
+        let mut last_run_at = None;
+        while current <= now {
+            let promise_id = template
+                .replace("{{.id}}", schedule_id)
+                .replace("{{.timestamp}}", &current.to_string());
+            let mut tags = promise_tags.clone();
+            tags.insert("resonate:schedule".to_string(), schedule_id.to_string());
+            tags.insert("resonate:origin".to_string(), promise_id.clone());
+            tags.insert("resonate:branch".to_string(), promise_id.clone());
+            tags.insert("resonate:parent".to_string(), promise_id.clone());
+            tags.insert("resonate:prefix".to_string(), promise_id.clone());
+            self.create_schedule_promise(
+                ctx,
+                &promise_id,
+                &tags,
+                &param_headers,
+                param_data.as_deref(),
+                current,
+                current + promise_timeout,
+                now,
+            )
+            .await?;
+            fired += 1;
+            last_run_at = Some(current);
+            current = resonate_core::util::compute_next_cron(&cron, current);
+        }
+        let final_next = current;
+
+        // Re-anchor with the schedule's own token, then advance the row.
+        self.exec(
+            "INSERT INTO schedule_timeouts (bucket, shard, timeout_at, origin, schedule_id, create_token) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                self.bucket_for(final_next),
+                self.shard_for(schedule_id),
+                final_next,
+                origin.as_str(),
+                schedule_id,
+                CqlValue::Uuid(row_token),
+            ),
+        )
+        .await?;
+        let (applied, _lwt) = self
+            .cas(
+                "UPDATE schedules SET next_run_at = ?, last_run_at = ? WHERE origin = ? AND id = ? IF next_run_at = ?",
+                (
+                    final_next,
+                    last_run_at,
+                    origin.as_str(),
+                    schedule_id,
+                    entry_at,
+                ),
+            )
+            .await?;
+        // Applied or lost to a concurrent advance: either way the fired
+        // entry is consumed. The promises above are IF NOT EXISTS, so a
+        // duplicate firing re-created them as no-ops.
+        let _ = applied;
+        let args = delete_entry(entry_at, token);
+        let _ = self
+            .exec(
+                "DELETE FROM schedule_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND schedule_id = ? AND create_token = ?",
+                args,
+            )
+            .await;
+        ctx.armed.push(Scheduled {
+            at: final_next,
+            timeout: Timeout::ScheduleDue {
+                schedule_id: schedule_id.to_string(),
+            },
+        });
+        Ok(fired)
+    }
+
+    /// A schedule occurrence's promise — its own call-graph root in its own
+    /// partition, with created/timeout derived from the cron instant so
+    /// catch-up is deterministic.
+    #[allow(clippy::too_many_arguments)]
+    async fn create_schedule_promise(
+        &self,
+        ctx: &mut Ctx,
+        promise_id: &str,
+        tags: &Tags,
+        param_headers: &Tags,
+        param_data: Option<&str>,
+        fired_at: i64,
+        timeout_at: i64,
+        now: i64,
+    ) -> StorageResult<()> {
+        let origin = promise_id.to_string();
+        let target = tags.get("resonate:target").cloned();
+        let is_timer = tags.get("resonate:timer").map(String::as_str) == Some("true");
+        let already_timedout = now >= timeout_at;
+        let (state, settled_at) = if already_timedout {
+            (
+                if is_timer { "resolved" } else { "rejected_timedout" },
+                Some(timeout_at),
+            )
+        } else {
+            ("pending", None)
+        };
+        let retry_at = now + self.task_retry_timeout;
+
+        if !already_timedout {
+            self.exec(
+                "INSERT INTO promise_timeouts (bucket, shard, timeout_at, promise_id, origin) VALUES (?, ?, ?, ?, ?)",
+                (
+                    self.bucket_for(timeout_at),
+                    self.shard_for(promise_id),
+                    timeout_at,
+                    promise_id,
+                    origin.as_str(),
+                ),
+            )
+            .await?;
+            if target.is_some() {
+                self.exec(
+                    "INSERT INTO task_timeouts (bucket, shard, timeout_at, timeout_type, task_id, origin, promise_timeout_at) VALUES (?, ?, ?, 0, ?, ?, ?)",
+                    (
+                        self.bucket_for(retry_at),
+                        self.shard_for(promise_id),
+                        retry_at,
+                        promise_id,
+                        origin.as_str(),
+                        timeout_at,
+                    ),
+                )
+                .await?;
+            }
+        }
+
+        let (task_state, task_version): (Option<&str>, Option<i32>) = if target.is_some() {
+            if already_timedout {
+                (Some("fulfilled"), Some(0))
+            } else {
+                (Some("pending"), Some(0))
+            }
+        } else {
+            (None, None)
+        };
+        let args: crate::db::Args = vec![
+            crate::db::text(promise_id),
+            crate::db::text(&origin),
+            crate::db::opt_text(target.clone()),
+            crate::db::text(state),
+            crate::db::opt_cql_map(if param_headers.is_empty() {
+                None
+            } else {
+                Some(param_headers)
+            }),
+            crate::db::opt_text(param_data.map(|s| s.to_string())),
+            crate::db::cql_map(tags),
+            crate::db::big(timeout_at),
+            crate::db::big(fired_at),
+            settled_at.and_then(crate::db::big),
+            crate::db::opt_text(task_state),
+            task_version.and_then(crate::db::int),
+            if target.is_some() && !already_timedout {
+                crate::db::big(retry_at)
+            } else {
+                None
+            },
+        ];
+        let (applied, lwt) = self
+            .cas(
+                "INSERT INTO promises (id, origin, branch, parent, target, state, param_headers, param_data, value_headers, value_data, tags, timeout_at, created_at, settled_at, callbacks, listeners, task_state, task_version, task_ttl, task_pid, task_resumes, task_timeout_retry) \
+                 VALUES (?, ?, null, null, ?, ?, ?, ?, null, null, ?, ?, ?, ?, {}, {}, ?, ?, null, null, null, ?) IF NOT EXISTS",
+                args,
+            )
+            .await?;
+
+        if !applied {
+            let existing = PromiseRow::from_map(&lwt);
+            if !already_timedout {
+                if !(existing.state == "pending" && existing.timeout_at == timeout_at) {
+                    let _ = self
+                        .exec(
+                            "DELETE FROM promise_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND origin = ? AND promise_id = ?",
+                            (
+                                self.bucket_for(timeout_at),
+                                self.shard_for(promise_id),
+                                timeout_at,
+                                origin.as_str(),
+                                promise_id,
+                            ),
+                        )
+                        .await;
+                }
+                if target.is_some() {
+                    let existing_retry = existing.task_timeout_retry.unwrap_or(0);
+                    if !(existing.task_state.as_deref() == Some("pending")
+                        && existing_retry == retry_at)
+                    {
+                        let _ = self
+                            .exec(
+                                "DELETE FROM task_timeouts WHERE bucket = ? AND shard = ? AND timeout_at = ? AND timeout_type = 0 AND origin = ? AND task_id = ?",
+                                (
+                                    self.bucket_for(retry_at),
+                                    self.shard_for(promise_id),
+                                    retry_at,
+                                    origin.as_str(),
+                                    promise_id,
+                                ),
+                            )
+                            .await;
+                    }
+                }
+            }
+            return Ok(());
+        }
+
+        if !already_timedout {
+            self.arm_promise_timeout(
+                ctx,
+                promise_id,
+                timeout_at,
+                resonate_core::types::is_awaitable(tags),
+            );
+            if let Some(addr) = &target {
+                self.arm_retry(ctx, promise_id, retry_at);
+                ctx.messages.push(Outgoing::Execute {
+                    address: addr.clone(),
+                    task_id: promise_id.to_string(),
+                    version: 0,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// The bulk sweep: every due entry in every shard's due buckets, all
+    /// three queues, deterministically ordered.
+    pub(crate) async fn tick_impl(
+        &self,
+        now: i64,
+    ) -> StorageResult<(usize, Vec<Outgoing>, Vec<Scheduled>)> {
+        let mut ctx = Ctx::default();
+        let fired = self.sweep(&mut ctx, now, false).await?;
+        Ok((fired, ctx.messages, ctx.armed))
+    }
+
+    /// One sweep at `t`. `filtering` selects the debug path: full-table
+    /// ALLOW FILTERING scans so arbitrary test timestamps do not walk
+    /// millions of buckets. Both paths collect-then-sort, because rows come
+    /// back in token order and the seed contract needs determinism.
+    pub(crate) async fn sweep(
+        &self,
+        ctx: &mut Ctx,
+        t: i64,
+        filtering: bool,
+    ) -> StorageResult<usize> {
+        // promise_timeouts
+        let mut promise_entries: Vec<(i64, String, String)> = Vec::new();
+        for m in self.scan_queue("promise_timeouts", "timeout_at, origin, promise_id", t, filtering).await? {
+            promise_entries.push((
+                get_big(&m, "timeout_at").unwrap_or(0),
+                get_text(&m, "origin").unwrap_or_default(),
+                get_text(&m, "promise_id").unwrap_or_default(),
+            ));
+        }
+        promise_entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2)));
+        for (at, origin, id) in &promise_entries {
+            let origin = if origin.is_empty() { id.clone() } else { origin.clone() };
+            self.on_promise_timeout(ctx, &origin, id, *at, t).await?;
+        }
+
+        // task_timeouts
+        let mut task_entries: Vec<(i64, i8, String, String, i64)> = Vec::new();
+        for m in self
+            .scan_queue(
+                "task_timeouts",
+                "timeout_at, timeout_type, origin, task_id, promise_timeout_at",
+                t,
+                filtering,
+            )
+            .await?
+        {
+            let ttype = match m.get("timeout_type") {
+                Some(Some(CqlValue::TinyInt(v))) => *v,
+                _ => 0,
+            };
+            task_entries.push((
+                get_big(&m, "timeout_at").unwrap_or(0),
+                ttype,
+                get_text(&m, "origin").unwrap_or_default(),
+                get_text(&m, "task_id").unwrap_or_default(),
+                get_big(&m, "promise_timeout_at").unwrap_or(0),
+            ));
+        }
+        task_entries.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.1.cmp(&b.1))
+                .then_with(|| a.3.cmp(&b.3))
+        });
+        for (at, ttype, origin, id, p_timeout) in &task_entries {
+            let origin = if origin.is_empty() { id.clone() } else { origin.clone() };
+            if *ttype == 0 {
+                self.on_task_retry(ctx, &origin, id, *at, *p_timeout, t).await?;
+            } else {
+                self.on_task_lease(ctx, &origin, id, *at, *p_timeout, t).await?;
+            }
+        }
+
+        // schedule_timeouts
+        let mut schedule_entries: Vec<(i64, String, String, uuid::Uuid)> = Vec::new();
+        for m in self
+            .scan_queue(
+                "schedule_timeouts",
+                "timeout_at, origin, schedule_id, create_token",
+                t,
+                filtering,
+            )
+            .await?
+        {
+            let token = match m.get("create_token") {
+                Some(Some(CqlValue::Uuid(u))) => *u,
+                _ => uuid::Uuid::nil(),
+            };
+            schedule_entries.push((
+                get_big(&m, "timeout_at").unwrap_or(0),
+                get_text(&m, "origin").unwrap_or_default(),
+                get_text(&m, "schedule_id").unwrap_or_default(),
+                token,
+            ));
+        }
+        schedule_entries.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.2.cmp(&b.2))
+                .then_with(|| a.3.cmp(&b.3))
+        });
+        let mut fired = 0usize;
+        for (at, origin, id, token) in &schedule_entries {
+            let _origin = if origin.is_empty() { id.clone() } else { origin.clone() };
+            fired += self.on_schedule_due(ctx, id, *at, *token, t).await?;
+        }
+        Ok(fired)
+    }
+
+    async fn scan_queue(
+        &self,
+        table: &str,
+        cols: &str,
+        t: i64,
+        filtering: bool,
+    ) -> StorageResult<Vec<crate::db::RowMap>> {
+        let mut out = Vec::new();
+        if filtering {
+            out.extend(
+                self.rows(
+                    &format!("SELECT {cols} FROM {table} WHERE timeout_at <= ? ALLOW FILTERING"),
+                    (t,),
+                )
+                .await?,
+            );
+        } else {
+            for shard in 0..self.shards {
+                for bucket in self.buckets_to_scan(t) {
+                    out.extend(
+                        self.rows(
+                            &format!(
+                                "SELECT {cols} FROM {table} WHERE bucket = ? AND shard = ? AND timeout_at <= ?"
+                            ),
+                            (bucket, shard, t),
+                        )
+                        .await?,
+                    );
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The nearest deadlines the durable state holds — projected from the
+    /// promises and schedules tables with the same liveness tests every
+    /// engine's `upcoming` applies, so the hint is the protocol's view, not
+    /// the queue tables' physical one.
+    pub(crate) async fn upcoming_impl(&self, limit: usize) -> StorageResult<Vec<Scheduled>> {
+        let mut out: Vec<Scheduled> = Vec::new();
+        let rows = self
+            .rows(
+                "SELECT id, state, tags, timeout_at, task_state, task_timeout_retry, task_timeout_lease, task_pid FROM promises",
+                (),
+            )
+            .await?;
+        for m in &rows {
+            let id = get_text(m, "id").unwrap_or_default();
+            let state = get_text(m, "state").unwrap_or_default();
+            let tags = get_tags(m, "tags");
+            if state == "pending" && resonate_core::types::is_awaitable(&tags) {
+                if let Some(at) = get_big(m, "timeout_at") {
+                    out.push(Scheduled {
+                        at,
+                        timeout: Timeout::PromiseTimeout {
+                            promise_id: id.clone(),
+                        },
+                    });
+                }
+            }
+            match get_text(m, "task_state").as_deref() {
+                Some("pending") => {
+                    if let Some(at) = get_big(m, "task_timeout_retry") {
+                        out.push(Scheduled {
+                            at,
+                            timeout: Timeout::TaskRetryTimeout {
+                                task_id: id.clone(),
+                            },
+                        });
+                    }
+                }
+                Some("acquired") => {
+                    if let Some(at) = get_big(m, "task_timeout_lease") {
+                        out.push(Scheduled {
+                            at,
+                            timeout: Timeout::TaskLeaseTimeout {
+                                task_id: id.clone(),
+                                pid: get_text(m, "task_pid").unwrap_or_default(),
+                            },
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+        let schedules = self
+            .rows("SELECT id, next_run_at FROM schedules", ())
+            .await?;
+        for m in &schedules {
+            if let (Some(id), Some(at)) = (get_text(m, "id"), get_big(m, "next_run_at")) {
+                out.push(Scheduled {
+                    at,
+                    timeout: Timeout::ScheduleDue { schedule_id: id },
+                });
+            }
+        }
+        out.sort_by(|a, b| {
+            a.at.cmp(&b.at)
+                .then_with(|| a.timeout.id().cmp(b.timeout.id()))
+        });
+        out.truncate(limit);
+        Ok(out)
+    }
+
+    pub(crate) async fn op_debug_tick(&self, req: &RequestEnvelope) -> Output {
+        let time = match req.data.get("time").and_then(|v| v.as_i64()) {
+            Some(t) => t,
+            None => return err(req, 400, "Missing or invalid 'time' field"),
+        };
+        if let Some(debug_time) = req.head.debug_time {
+            if debug_time != time {
+                return err(req, 400, "resonate:debug_time must equal data.time");
+            }
+        }
+        let mut ctx = Ctx::default();
+        if let Err(e) = self.sweep(&mut ctx, time, true).await {
+            return crate::ops_promise::storage_err(req, e);
+        }
+        Output {
+            response: Some(ResponseEnvelope::new(
+                req.kind.clone(),
+                req.head.corr_id.clone(),
+                200,
+                Value::Array(vec![]),
+            )),
+            messages: ctx.messages,
+            timeouts: ctx.armed,
+        }
+    }
+}

--- a/crates/resonate-server-scylladb/src/timeouts.rs
+++ b/crates/resonate-server-scylladb/src/timeouts.rs
@@ -158,12 +158,12 @@ impl ScyllaEngine {
                     .await;
             }
             Some(row) => {
-                // EXPLORATORY (decision pending): Go anchors a resumed
-                // awaiter's retry at the entry's own deadline (timeoutAt +
-                // retry); the relational engines anchor at the sweep's
-                // clock. The differential sees the difference in the armed
-                // hints (first at ~step 1976). Aligned to the sweep clock so
-                // the run can continue cataloguing.
+                // Deliberate deviation from Go: the sweep's clock anchors a
+                // resumed awaiter's retry, not the entry's own deadline. Go
+                // anchored at timeoutAt + retry, which is the lookback
+                // hazard — a late sweep writes follow-ups into buckets the
+                // scan has already passed. Every other engine anchors at
+                // the sweep clock, and so does this one.
                 self.try_timeout(ctx, &row, now).await?;
             }
         }
@@ -675,30 +675,89 @@ impl ScyllaEngine {
         now: i64,
     ) -> StorageResult<(usize, Vec<Outgoing>, Vec<Scheduled>)> {
         let mut ctx = Ctx::default();
-        let fired = self.sweep(&mut ctx, now, false).await?;
+        let shards = self.assigned_shards().await;
+        let fired = self.sweep_shards(&mut ctx, now, &shards).await?;
         Ok((fired, ctx.messages, ctx.armed))
     }
 
-    /// One sweep at `t`. `filtering` selects the debug path: full-table
-    /// ALLOW FILTERING scans so arbitrary test timestamps do not walk
-    /// millions of buckets. Both paths collect-then-sort, because rows come
-    /// back in token order and the seed contract needs determinism.
     pub(crate) async fn sweep(
         &self,
         ctx: &mut Ctx,
         t: i64,
         filtering: bool,
     ) -> StorageResult<usize> {
+        if filtering {
+            self.sweep_inner(ctx, t, None).await
+        } else {
+            let shards: Vec<i16> = (0..self.shards).collect();
+            self.sweep_inner(ctx, t, Some(&shards)).await
+        }
+    }
+
+    async fn sweep_shards(&self, ctx: &mut Ctx, t: i64, shards: &[i16]) -> StorageResult<usize> {
+        self.sweep_inner(ctx, t, Some(shards)).await
+    }
+
+    /// Which queue shards this instance sweeps — the Go coordinator, run
+    /// inline on each sweep instead of in a goroutine: heartbeat a worker
+    /// row with a TTL, read the live workers, split the shards round-robin
+    /// over UUID-sorted workers. Any failure falls back to all shards;
+    /// overlap is exactly what the handlers' idempotency covers.
+    async fn assigned_shards(&self) -> Vec<i16> {
+        let all: Vec<i16> = (0..self.shards).collect();
+        if self.shards <= 1 {
+            return all;
+        }
+        let ttl_secs = (self.worker_ttl / 1_000).max(1) as i32;
+        if self
+            .exec(
+                "INSERT INTO workers (worker_id) VALUES (?) USING TTL ?",
+                (CqlValue::Uuid(self.worker_id), ttl_secs),
+            )
+            .await
+            .is_err()
+        {
+            return all;
+        }
+        let Ok(rows) = self.rows("SELECT worker_id FROM workers", ()).await else {
+            return all;
+        };
+        let mut workers: Vec<uuid::Uuid> = rows
+            .iter()
+            .filter_map(|m| match m.get("worker_id") {
+                Some(Some(CqlValue::Uuid(u))) => Some(*u),
+                _ => None,
+            })
+            .collect();
+        workers.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        let Some(idx) = workers.iter().position(|w| *w == self.worker_id) else {
+            return all;
+        };
+        (0..self.shards)
+            .filter(|s| (*s as usize) % workers.len() == idx)
+            .collect()
+    }
+
+    /// One sweep at `t`. `shards = None` selects the debug path: full-table
+    /// ALLOW FILTERING scans so arbitrary test timestamps do not walk
+    /// millions of buckets. Both paths collect-then-sort, because rows come
+    /// back in token order and the seed contract needs determinism.
+    async fn sweep_inner(
+        &self,
+        ctx: &mut Ctx,
+        t: i64,
+        shards: Option<&[i16]>,
+    ) -> StorageResult<usize> {
         // promise_timeouts
         let mut promise_entries: Vec<(i64, String, String)> = Vec::new();
-        for m in self.scan_queue("promise_timeouts", "timeout_at, origin, promise_id", t, filtering).await? {
+        for m in self.scan_queue("promise_timeouts", "timeout_at, origin, promise_id", t, shards).await? {
             promise_entries.push((
                 get_big(&m, "timeout_at").unwrap_or(0),
                 get_text(&m, "origin").unwrap_or_default(),
                 get_text(&m, "promise_id").unwrap_or_default(),
             ));
         }
-        promise_entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2)));
+        promise_entries.sort_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.cmp(&b.0)));
         for (at, origin, id) in &promise_entries {
             let origin = if origin.is_empty() { id.clone() } else { origin.clone() };
             self.on_promise_timeout(ctx, &origin, id, *at, t).await?;
@@ -711,7 +770,7 @@ impl ScyllaEngine {
                 "task_timeouts",
                 "timeout_at, timeout_type, origin, task_id, promise_timeout_at",
                 t,
-                filtering,
+                shards,
             )
             .await?
         {
@@ -728,9 +787,9 @@ impl ScyllaEngine {
             ));
         }
         task_entries.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then_with(|| a.1.cmp(&b.1))
+            a.1.cmp(&b.1)
                 .then_with(|| a.3.cmp(&b.3))
+                .then_with(|| a.0.cmp(&b.0))
         });
         for (at, ttype, origin, id, p_timeout) in &task_entries {
             let origin = if origin.is_empty() { id.clone() } else { origin.clone() };
@@ -748,7 +807,7 @@ impl ScyllaEngine {
                 "schedule_timeouts",
                 "timeout_at, origin, schedule_id, create_token",
                 t,
-                filtering,
+                shards,
             )
             .await?
         {
@@ -764,8 +823,8 @@ impl ScyllaEngine {
             ));
         }
         schedule_entries.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then_with(|| a.2.cmp(&b.2))
+            a.2.cmp(&b.2)
+                .then_with(|| a.0.cmp(&b.0))
                 .then_with(|| a.3.cmp(&b.3))
         });
         let mut fired = 0usize;
@@ -781,19 +840,19 @@ impl ScyllaEngine {
         table: &str,
         cols: &str,
         t: i64,
-        filtering: bool,
+        shards: Option<&[i16]>,
     ) -> StorageResult<Vec<crate::db::RowMap>> {
         let mut out = Vec::new();
-        if filtering {
-            out.extend(
-                self.rows(
+        let Some(shards) = shards else {
+            return self
+                .rows(
                     &format!("SELECT {cols} FROM {table} WHERE timeout_at <= ? ALLOW FILTERING"),
                     (t,),
                 )
-                .await?,
-            );
-        } else {
-            for shard in 0..self.shards {
+                .await;
+        };
+        {
+            for shard in shards.iter().copied() {
                 for bucket in self.buckets_to_scan(t) {
                     out.extend(
                         self.rows(

--- a/crates/resonate-server-scylladb/src/timeouts.rs
+++ b/crates/resonate-server-scylladb/src/timeouts.rs
@@ -12,7 +12,7 @@ use resonate_server_dbms::StorageResult;
 use scylla::value::CqlValue;
 use serde_json::Value;
 
-use crate::db::{get_big, get_text, get_tags, PromiseRow};
+use crate::db::{get_big, get_tags, get_text, PromiseRow};
 use crate::ops_promise::err;
 use crate::{origin_of, Ctx, ScyllaEngine, Tags};
 
@@ -22,15 +22,12 @@ enum Cleanup {
 }
 
 impl ScyllaEngine {
-    pub(crate) async fn process_internal(
-        &self,
-        timeout: Timeout,
-        now: i64,
-    ) -> Output {
+    pub(crate) async fn process_internal(&self, timeout: Timeout, now: i64) -> Output {
         let mut ctx = Ctx::default();
         let result = match &timeout {
             Timeout::PromiseTimeout { promise_id } => {
-                self.internal_promise_timeout(&mut ctx, promise_id, now).await
+                self.internal_promise_timeout(&mut ctx, promise_id, now)
+                    .await
             }
             Timeout::TaskRetryTimeout { task_id } => {
                 self.internal_retry_timeout(&mut ctx, task_id, now).await
@@ -64,7 +61,8 @@ impl ScyllaEngine {
         let origin = origin_of(id).to_string();
         if let Some(row) = self.read_promise(&origin, id).await? {
             if row.state == "pending" && row.timeout_at <= now {
-                self.on_promise_timeout(ctx, &origin, id, row.timeout_at, now).await?;
+                self.on_promise_timeout(ctx, &origin, id, row.timeout_at, now)
+                    .await?;
             }
         }
         Ok(())
@@ -142,20 +140,14 @@ impl ScyllaEngine {
         let (cql, bucket, shard) = delete_entry(self.bucket_for(entry_at), self.shard_for(id));
         match self.read_promise(origin, id).await? {
             None => {
-                let _ = self
-                    .exec(cql, (bucket, shard, entry_at, origin, id))
-                    .await;
+                let _ = self.exec(cql, (bucket, shard, entry_at, origin, id)).await;
             }
             Some(row) if row.state != "pending" => {
-                let _ = self
-                    .exec(cql, (bucket, shard, entry_at, origin, id))
-                    .await;
+                let _ = self.exec(cql, (bucket, shard, entry_at, origin, id)).await;
             }
             Some(row) if row.timeout_at != entry_at => {
                 // Orphan: the row's deadline is not this entry's.
-                let _ = self
-                    .exec(cql, (bucket, shard, entry_at, origin, id))
-                    .await;
+                let _ = self.exec(cql, (bucket, shard, entry_at, origin, id)).await;
             }
             Some(row) => {
                 // Deliberate deviation from Go: the sweep's clock anchors a
@@ -533,7 +525,11 @@ impl ScyllaEngine {
         let already_timedout = now >= timeout_at;
         let (state, settled_at) = if already_timedout {
             (
-                if is_timer { "resolved" } else { "rejected_timedout" },
+                if is_timer {
+                    "resolved"
+                } else {
+                    "rejected_timedout"
+                },
                 Some(timeout_at),
             )
         } else {
@@ -750,7 +746,15 @@ impl ScyllaEngine {
     ) -> StorageResult<usize> {
         // promise_timeouts
         let mut promise_entries: Vec<(i64, String, String)> = Vec::new();
-        for m in self.scan_queue("promise_timeouts", "timeout_at, origin, promise_id", t, shards).await? {
+        for m in self
+            .scan_queue(
+                "promise_timeouts",
+                "timeout_at, origin, promise_id",
+                t,
+                shards,
+            )
+            .await?
+        {
             promise_entries.push((
                 get_big(&m, "timeout_at").unwrap_or(0),
                 get_text(&m, "origin").unwrap_or_default(),
@@ -759,7 +763,11 @@ impl ScyllaEngine {
         }
         promise_entries.sort_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.cmp(&b.0)));
         for (at, origin, id) in &promise_entries {
-            let origin = if origin.is_empty() { id.clone() } else { origin.clone() };
+            let origin = if origin.is_empty() {
+                id.clone()
+            } else {
+                origin.clone()
+            };
             self.on_promise_timeout(ctx, &origin, id, *at, t).await?;
         }
 
@@ -792,11 +800,17 @@ impl ScyllaEngine {
                 .then_with(|| a.0.cmp(&b.0))
         });
         for (at, ttype, origin, id, p_timeout) in &task_entries {
-            let origin = if origin.is_empty() { id.clone() } else { origin.clone() };
-            if *ttype == 0 {
-                self.on_task_retry(ctx, &origin, id, *at, *p_timeout, t).await?;
+            let origin = if origin.is_empty() {
+                id.clone()
             } else {
-                self.on_task_lease(ctx, &origin, id, *at, *p_timeout, t).await?;
+                origin.clone()
+            };
+            if *ttype == 0 {
+                self.on_task_retry(ctx, &origin, id, *at, *p_timeout, t)
+                    .await?;
+            } else {
+                self.on_task_lease(ctx, &origin, id, *at, *p_timeout, t)
+                    .await?;
             }
         }
 
@@ -829,7 +843,11 @@ impl ScyllaEngine {
         });
         let mut fired = 0usize;
         for (at, origin, id, token) in &schedule_entries {
-            let _origin = if origin.is_empty() { id.clone() } else { origin.clone() };
+            let _origin = if origin.is_empty() {
+                id.clone()
+            } else {
+                origin.clone()
+            };
             fired += self.on_schedule_due(ctx, id, *at, *token, t).await?;
         }
         Ok(fired)

--- a/crates/resonate-server-scylladb/src/tls.rs
+++ b/crates/resonate-server-scylladb/src/tls.rs
@@ -1,0 +1,85 @@
+//! TLS to the cluster, three ways: WebPKI roots (public certs), a
+//! caller-supplied CA file (private CAs, verified), or encrypt-without-
+//! verifying — the mode the Go deployment ran against ScyllaDB Cloud's
+//! cluster-private CA, kept for parity and dev use.
+
+use std::sync::Arc;
+
+use resonate_server_dbms::{StorageError, StorageResult};
+
+use crate::TlsConfig;
+
+pub(crate) fn context(cfg: &TlsConfig) -> StorageResult<Arc<rustls::ClientConfig>> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let builder = rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()
+        .map_err(|e| StorageError::Backend(format!("tls: {e}")))?;
+
+    let config = if cfg.insecure {
+        builder
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerify { provider }))
+            .with_no_client_auth()
+    } else if let Some(path) = &cfg.ca_cert {
+        let pem = std::fs::read(path)
+            .map_err(|e| StorageError::Backend(format!("tls: read {path}: {e}")))?;
+        let mut roots = rustls::RootCertStore::empty();
+        for cert in rustls_pemfile::certs(&mut pem.as_slice()) {
+            let cert = cert.map_err(|e| StorageError::Backend(format!("tls: parse ca: {e}")))?;
+            roots
+                .add(cert)
+                .map_err(|e| StorageError::Backend(format!("tls: add ca: {e}")))?;
+        }
+        builder.with_root_certificates(roots).with_no_client_auth()
+    } else {
+        let roots = rustls::RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
+        builder.with_root_certificates(roots).with_no_client_auth()
+    };
+    Ok(Arc::new(config))
+}
+
+/// Encrypt, verify nothing — still TLS on the wire, no claim about who is
+/// on the other end. Every method accepts.
+#[derive(Debug)]
+struct NoVerify {
+    provider: Arc<rustls::crypto::CryptoProvider>,
+}
+
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}

--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -279,6 +279,34 @@ async fn differential_random() {
         }
     };
 
+    // ScyllaDB is opt-in the same way. It is the deliberately EAGER engine —
+    // the Go implementation's mechanics — running against the lazy relational
+    // ones: the comparison is the experiment.
+    let scylla_backend: Option<Backend> = match std::env::var("TEST_SCYLLADB_HOSTS").ok() {
+        Some(hosts) => {
+            let cfg = resonate_server_scylladb::Config {
+                hosts: hosts.split(',').map(|s| s.trim().to_string()).collect(),
+                keyspace: std::env::var("TEST_SCYLLADB_KEYSPACE")
+                    .unwrap_or_else(|_| "resonate_diff".to_string()),
+                migrate: true,
+                preload_limit: PRELOAD_LIMIT,
+                ..Default::default()
+            };
+            let sc = resonate_server_scylladb::ScyllaEngine::connect(
+                &cfg,
+                TASK_RETRY_TIMEOUT_MS,
+                true,
+            )
+            .await
+            .expect("scylladb connect");
+            Some(Arc::new(sc) as Backend)
+        }
+        None => {
+            eprintln!("[diff] TEST_SCYLLADB_HOSTS not set — ScyllaDB skipped");
+            None
+        }
+    };
+
     let mut backends: Vec<(String, Backend)> = vec![
         ("sqlite".into(), sqlite),
         ("oracle".into(), Arc::clone(&oracle) as Backend),
@@ -288,6 +316,9 @@ async fn differential_random() {
     }
     if let Some(my) = my_backend {
         backends.push(("mysql".into(), my));
+    }
+    if let Some(sc) = scylla_backend {
+        backends.push(("scylladb".into(), sc));
     }
 
     // Iterating on one backend does not need all of them, and a full run is

--- a/diff/docker-compose-diff.yml
+++ b/diff/docker-compose-diff.yml
@@ -6,10 +6,13 @@ services:
     environment:
       TEST_POSTGRES_URL: postgres://resonate:resonate@postgres:5432/resonate
       TEST_MYSQL_URL: mysql://resonate:resonate@mysql:3306/resonate
+      TEST_SCYLLADB_HOSTS: scylladb:9042
     depends_on:
       postgres:
         condition: service_healthy
       mysql:
+        condition: service_healthy
+      scylladb:
         condition: service_healthy
 
   postgres:
@@ -27,6 +30,19 @@ services:
       resources:
         limits:
           memory: 512m
+
+  scylladb:
+    image: scylladb/scylla:6.2
+    command: --smp 1 --developer-mode 1 --overprovisioned 1
+    healthcheck:
+      test: ["CMD-SHELL", "cqlsh $(hostname -i) -e 'SELECT release_version FROM system.local'"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+    deploy:
+      resources:
+        limits:
+          memory: 1g
 
   mysql:
     image: mysql:8.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,13 @@ pub struct StorageConfig {
     /// MySQL-specific configuration
     #[serde(default)]
     pub mysql: MysqlConfig,
+
+    /// ScyllaDB-specific configuration — the crate's own type, like every
+    /// transport's: `resonate-server-scylladb` describes its configuration
+    /// and this only carries the section from the file to it.
+    #[cfg(feature = "scylladb")]
+    #[serde(default)]
+    pub scylladb: resonate_server_scylladb::Config,
 }
 
 fn default_storage_type() -> String {
@@ -254,6 +261,8 @@ impl Default for StorageConfig {
             sqlite: SqliteConfig::default(),
             postgres: PostgresConfig::default(),
             mysql: MysqlConfig::default(),
+            #[cfg(feature = "scylladb")]
+            scylladb: resonate_server_scylladb::Config::default(),
         }
     }
 }
@@ -437,10 +446,10 @@ impl Config {
     fn validate(&self) -> Result<(), String> {
         // Validate storage type
         match self.storage.storage_type.as_str() {
-            "sqlite" | "postgres" | "mysql" => {}
+            "sqlite" | "postgres" | "mysql" | "scylladb" => {}
             other => {
                 return Err(format!(
-                    "Unknown storage backend: '{}'. Valid options are 'sqlite', 'postgres', and 'mysql'.",
+                    "Unknown storage backend: '{}'. Valid options are 'sqlite', 'postgres', 'mysql', and 'scylladb'.",
                     other
                 ));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,6 +197,23 @@ async fn run_server(config: Config) -> Result<(), String> {
             tracing::info!("PostgreSQL initialized");
             Arc::new(pg)
         }
+        #[cfg(feature = "scylladb")]
+        "scylladb" => {
+            tracing::info!(
+                hosts = ?config.storage.scylladb.hosts,
+                keyspace = %config.storage.scylladb.keyspace,
+                "Using ScyllaDB backend"
+            );
+            let sc = resonate_server_scylladb::ScyllaEngine::connect(
+                &config.storage.scylladb,
+                config.tasks.retry_timeout,
+                config.debug,
+            )
+            .await
+            .map_err(|e| format!("Failed to connect to ScyllaDB: {e}"))?;
+            tracing::info!("ScyllaDB initialized");
+            Arc::new(sc)
+        }
         #[cfg(feature = "mysql")]
         "mysql" => {
             let url = config.storage.mysql.url.as_deref().unwrap();


### PR DESCRIPTION
## What

`crates/resonate-server-scylladb`: the Go `resonate-on-scylladb` implementation, ported behind the `ResonateEngine` port and finished to production readiness. Stacked on #1137 (the three-valued otype).

**Mechanics carried over verbatim**: `promises` partitioned by `origin` — settle + fanout and suspend + registration are single-partition LWTs / conditional batches, legal by the protocol's same-origin validation; bucketed, sharded timeout queues written through pre-insert → LWT → conditional-rollback (orphan entries, never missing ones, classified and deleted by the tick guard ladders); `create_token` schedule anchoring; pinned-`callbacks` settles; version discipline; `readAndTryTimeout` ghost reads. **Eager, like Go: every pending promise gets a queue entry, internal included** — where the relational engines stay deliberately lazy.

## The experiment, concluded

The comparison existed to test whether eager and lazy are observationally the same machine. Answer: **yes, once every read applies the projection.** The catalog it produced, and where each item landed:

| Finding | First seen | Resolution |
|---|---|---|
| Fulfilled awaiter's registrations (Go leaves, relational deletes) | step 1,923 | Snapshot obligation sections project both directions: settled/expired holders report none, fulfilled members report absent. Scylla write path stays pure Go. |
| Sweep-resumption retry anchoring (entry deadline vs sweep clock) | step 1,976 | Sweep clock, everywhere — Go's anchoring is the lookback hazard. Documented deviation. |
| Expired untouched **internal** promise: pending (lazy) vs settled (eager) | step 2,130 | `promise.search` and `debug.snap` project expiry in **all four backends** — the spec's "a projection every read applies", and a projected pending-expired record is byte-identical to an eager settle. |
| Same-sweep-expired suspended awaiter resumed, one extra execute | step 23,162 | An expired or settled awaiter is never resumed — the model's rule, adopted. |

Plus two alignments made before they could surface: `task.heartbeat` does not sweep (plain read + liveness guard), and a halted awaiter records nothing at registration time.

## Verification

- **Differential, all five backends** (SQLite + Oracle + Postgres + MySQL + ScyllaDB 6.2, live): **coverage plateau reached — 43,800 steps, 441 signatures, zero divergences** (916s). Three-backend run independently green at the same plateau.
- **Linearizability**: 8 clients × 600 ops (max concurrency 65) against a debug-mode server on ScyllaDB storage, `conccheck -partition=false`: no refutation.
- Workspace builds, clippy, fmt, unit tests: clean. sqlite+oracle baseline re-verified after the engine-side projection changes.

## Production surface

- **TLS** (rustls): WebPKI roots, `tls.ca_cert` PEM, or `tls.insecure` (encrypt, skip verification — the private-CA mode the Go deployment used).
- **Consistency stated, not inherited**: Quorum + Serial on the session's default execution profile.
- **Shard coordinator**: the Go workers-table protocol, run inline per sweep — TTL'd heartbeat, round-robin split over UUID-sorted live workers, fall back to all shards on any failure (overlap is what idempotency covers).
- **CI**: `scylladb` legs in the differential and linearizability matrices (container started by a step — services can't pass the arguments LWT needs); ScyllaDB service in the diff compose; README documents the backend and config (`storage.type = "scylladb"`; keyspace created with tablets disabled, LWT requires it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)