### PR TITLE
Setup workos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +662,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +908,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -959,6 +988,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1259,6 +1289,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2005,6 +2041,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +2750,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -2717,10 +2764,13 @@ name = "resonate-auth"
 version = "0.9.8"
 dependencies = [
  "jsonwebtoken 9.3.1",
+ "reqwest 0.12.28",
  "resonate-core",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -4895,6 +4945,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ path = "src/main.rs"
 [[test]]
 name = "differential"
 path = "diff/differential.rs"
+
+[[test]]
+name = "test_workos_startup"
+path = "test/test_workos_startup.rs"
 # It compares the engines against each other, so it needs all of them; with any
 # turned off cargo skips the target rather than failing to build it.
 required-features = ["sqlite", "postgres", "mysql"]
@@ -87,3 +91,6 @@ validator = { workspace = true }
 url = { workspace = true }
 base64 = "0.22"
 tower-http = { version = "0.6", features = ["trace", "catch-panic", "cors"] }
+
+[dev-dependencies]
+toml = "0.8"

--- a/crates/resonate-auth/Cargo.toml
+++ b/crates/resonate-auth/Cargo.toml
@@ -15,3 +15,8 @@ jsonwebtoken = "9"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = "0.1"
+reqwest = { version = "0.12", features = ["json"] }
+
+[dev-dependencies]
+wiremock = "0.6"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/resonate-auth/src/lib.rs
+++ b/crates/resonate-auth/src/lib.rs
@@ -6,7 +6,10 @@
 //! [`AuthConfig`] — policy, not protocol, which is why this is its own crate
 //! rather than part of `core`.
 
+pub mod workos;
+
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
@@ -32,6 +35,59 @@ pub struct AuthConfig {
 pub struct VerificationKey {
     pub decoding_key: DecodingKey,
     pub algorithms: Vec<Algorithm>,
+}
+
+/// Which authentication mode is active.
+///
+/// Exactly one — the gateway picks at startup based on config.
+#[derive(Clone)]
+pub enum AuthMode {
+    /// Local JWT verification against a public key.
+    Jwt(Arc<AuthConfig>),
+    /// Remote token validation via the WorkOS API.
+    WorkOs(workos::WorkOsClient),
+}
+
+impl AuthMode {
+    /// Authenticate and authorize an envelope-bearing request.
+    ///
+    /// Dispatches to JWT verification or WorkOS token validation, depending
+    /// on which mode is active. The caller gets back a ready-to-render error
+    /// envelope on failure.
+    pub async fn check_envelope(
+        &self,
+        req: &RequestEnvelope,
+    ) -> Result<(), Box<ResponseEnvelope>> {
+        match self {
+            AuthMode::Jwt(cfg) => auth_check(cfg, req),
+            AuthMode::WorkOs(client) => {
+                let token = req.head.auth.as_deref();
+                match workos::auth_check_workos(client, token).await {
+                    Ok(()) => Ok(()),
+                    Err(rejection) => Err(Box::new(ResponseEnvelope::error(
+                        req.kind.clone(),
+                        req.head.corr_id.clone(),
+                        rejection.status as i32,
+                        &rejection.message,
+                    ))),
+                }
+            }
+        }
+    }
+
+    /// Verify a bearer token — no envelope, no authorization, just
+    /// authentication. Used for endpoints like `/poll` that don't carry a
+    /// protocol envelope.
+    ///
+    /// Returns `Ok(())` if the token is valid, `Err(())` if it is not.
+    pub async fn check_token(&self, token: Option<&str>) -> Result<(), ()> {
+        match self {
+            AuthMode::Jwt(cfg) => auth_check_token(cfg, token),
+            AuthMode::WorkOs(client) => {
+                workos::auth_check_workos(client, token).await.map_err(|_| ())
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -403,5 +459,105 @@ fn extract_resource_id(kind: &str, data: &Value) -> Option<String> {
         // restriction.  This ensures newly added commands are denied by default
         // until explicitly handled here.
         _ => Some(String::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Build a WorkOsClient pointed at a mock server.
+    fn workos_client(mock_url: &str) -> workos::WorkOsClient {
+        let cfg = workos::WorkOsConfig {
+            org_id: None,
+            base_url: mock_url.to_string(),
+        };
+        workos::WorkOsClient::new(cfg)
+    }
+
+    fn request(kind: &str) -> RequestEnvelope {
+        RequestEnvelope {
+            kind: kind.into(),
+            head: resonate_core::types::RequestHead {
+                auth: Some("tok".into()),
+                corr_id: "42".into(),
+                version: "1".into(),
+                debug_time: None,
+            },
+            data: serde_json::json!({}),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // AuthMode::check_envelope — WorkOS branch
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn check_envelope_workos_success() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": [{"id": "org_x", "name": "test"}]}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let mode = AuthMode::WorkOs(workos_client(&mock.uri()));
+        let req = request("promise.get");
+        let r = mode.check_envelope(&req).await;
+        assert!(r.is_ok(), "expected Ok, got {:?}", r);
+    }
+
+    #[tokio::test]
+    async fn check_envelope_workos_missing_token() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": [{"id": "org_x", "name": "test"}]}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let mode = AuthMode::WorkOs(workos_client(&mock.uri()));
+        let mut req = request("promise.get");
+        req.head.auth = None;
+        let r = mode.check_envelope(&req).await;
+        assert!(r.is_err());
+        let rejection = r.unwrap_err();
+        assert_eq!(rejection.head.status, 401);
+    }
+
+    // -------------------------------------------------------------------
+    // AuthMode::check_token — WorkOS branch
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn check_token_workos_success() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": [{"id": "org_x", "name": "test"}]}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let mode = AuthMode::WorkOs(workos_client(&mock.uri()));
+        assert!(mode.check_token(Some("tok")).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn check_token_workos_rejection() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&mock)
+            .await;
+
+        let mode = AuthMode::WorkOs(workos_client(&mock.uri()));
+        assert!(mode.check_token(Some("tok")).await.is_err());
     }
 }

--- a/crates/resonate-auth/src/lib.rs
+++ b/crates/resonate-auth/src/lib.rs
@@ -54,10 +54,7 @@ impl AuthMode {
     /// Dispatches to JWT verification or WorkOS token validation, depending
     /// on which mode is active. The caller gets back a ready-to-render error
     /// envelope on failure.
-    pub async fn check_envelope(
-        &self,
-        req: &RequestEnvelope,
-    ) -> Result<(), Box<ResponseEnvelope>> {
+    pub async fn check_envelope(&self, req: &RequestEnvelope) -> Result<(), Box<ResponseEnvelope>> {
         match self {
             AuthMode::Jwt(cfg) => auth_check(cfg, req),
             AuthMode::WorkOs(client) => {
@@ -83,9 +80,9 @@ impl AuthMode {
     pub async fn check_token(&self, token: Option<&str>) -> Result<(), ()> {
         match self {
             AuthMode::Jwt(cfg) => auth_check_token(cfg, token),
-            AuthMode::WorkOs(client) => {
-                workos::auth_check_workos(client, token).await.map_err(|_| ())
-            }
+            AuthMode::WorkOs(client) => workos::auth_check_workos(client, token)
+                .await
+                .map_err(|_| ()),
         }
     }
 }
@@ -499,9 +496,10 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": [{"id": "org_x", "name": "test"}]}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"data": [{"id": "org_x", "name": "test"}]})),
+            )
             .mount(&mock)
             .await;
 
@@ -515,9 +513,10 @@ mod tests {
     async fn check_envelope_workos_missing_token() {
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": [{"id": "org_x", "name": "test"}]}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"data": [{"id": "org_x", "name": "test"}]})),
+            )
             .mount(&mock)
             .await;
 
@@ -539,9 +538,10 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": [{"id": "org_x", "name": "test"}]}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"data": [{"id": "org_x", "name": "test"}]})),
+            )
             .mount(&mock)
             .await;
 

--- a/crates/resonate-auth/src/lib.rs
+++ b/crates/resonate-auth/src/lib.rs
@@ -76,13 +76,11 @@ impl AuthMode {
     /// authentication. Used for endpoints like `/poll` that don't carry a
     /// protocol envelope.
     ///
-    /// Returns `Ok(())` if the token is valid, `Err(())` if it is not.
-    pub async fn check_token(&self, token: Option<&str>) -> Result<(), ()> {
+    /// Returns `true` if the token is valid, `false` if it is not.
+    pub async fn check_token(&self, token: Option<&str>) -> bool {
         match self {
             AuthMode::Jwt(cfg) => auth_check_token(cfg, token),
-            AuthMode::WorkOs(client) => workos::auth_check_workos(client, token)
-                .await
-                .map_err(|_| ()),
+            AuthMode::WorkOs(client) => workos::auth_check_workos(client, token).await.is_ok(),
         }
     }
 }
@@ -213,13 +211,12 @@ pub fn load_public_key(path: &str) -> Result<VerificationKey, String> {
 /// by the configured public key.  Used for endpoints (like `/poll`) that don't
 /// carry a protocol envelope and therefore cannot do prefix-based authorization.
 ///
-/// Returns `Ok(())` if the token is valid.
-/// Returns `Err(())` if the token is missing, empty, or fails verification.
-#[allow(clippy::result_unit_err)]
-pub fn auth_check_token(auth: &AuthConfig, token: Option<&str>) -> Result<(), ()> {
+/// Returns `true` if the token is valid.
+/// Returns `false` if the token is missing, empty, or fails verification.
+pub fn auth_check_token(auth: &AuthConfig, token: Option<&str>) -> bool {
     match token {
-        Some(t) if !t.is_empty() => verify_jwt(auth, t).map(|_| ()).map_err(|_| ()),
-        _ => Err(()),
+        Some(t) if !t.is_empty() => verify_jwt(auth, t).is_ok(),
+        _ => false,
     }
 }
 
@@ -468,7 +465,8 @@ mod tests {
     /// Build a WorkOsClient pointed at a mock server.
     fn workos_client(mock_url: &str) -> workos::WorkOsClient {
         let cfg = workos::WorkOsConfig {
-            org_id: None,
+            api_key: "sk_server_secret".into(),
+            org_id: "org_abc".into(),
             base_url: mock_url.to_string(),
         };
         workos::WorkOsClient::new(cfg)
@@ -494,12 +492,17 @@ mod tests {
     #[tokio::test]
     async fn check_envelope_workos_success() {
         let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"data": [{"id": "org_x", "name": "test"}]})),
-            )
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": {
+                    "id": "api_key_123",
+                    "owner": {
+                        "type": "organization",
+                        "id": "org_abc"
+                    }
+                }
+            })))
             .mount(&mock)
             .await;
 
@@ -512,14 +515,6 @@ mod tests {
     #[tokio::test]
     async fn check_envelope_workos_missing_token() {
         let mock = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"data": [{"id": "org_x", "name": "test"}]})),
-            )
-            .mount(&mock)
-            .await;
-
         let mode = AuthMode::WorkOs(workos_client(&mock.uri()));
         let mut req = request("promise.get");
         req.head.auth = None;
@@ -536,28 +531,34 @@ mod tests {
     #[tokio::test]
     async fn check_token_workos_success() {
         let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"data": [{"id": "org_x", "name": "test"}]})),
-            )
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": {
+                    "id": "api_key_123",
+                    "owner": {
+                        "type": "organization",
+                        "id": "org_abc"
+                    }
+                }
+            })))
             .mount(&mock)
             .await;
 
         let mode = AuthMode::WorkOs(workos_client(&mock.uri()));
-        assert!(mode.check_token(Some("tok")).await.is_ok());
+        assert!(mode.check_token(Some("tok")).await);
     }
 
     #[tokio::test]
     async fn check_token_workos_rejection() {
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
             .respond_with(ResponseTemplate::new(401))
             .mount(&mock)
             .await;
 
         let mode = AuthMode::WorkOs(workos_client(&mock.uri()));
-        assert!(mode.check_token(Some("tok")).await.is_err());
+        assert!(!mode.check_token(Some("tok")).await);
     }
 }

--- a/crates/resonate-auth/src/workos.rs
+++ b/crates/resonate-auth/src/workos.rs
@@ -1,5 +1,19 @@
-//! WorkOS API key validation — calls GET /organizations with the key as
-//! Bearer auth to learn which organization the key belongs to.
+//! WorkOS API key validation — calls `POST /api_keys/validations` with the
+//! server's own WorkOS secret key (not the client's API key) to validate
+//! an incoming API key and discover which organization it belongs to.
+//!
+//! # Architecture
+//!
+//! Two keys, two roles:
+//!
+//! | Key                | Owner      | Purpose                              |
+//! |--------------------|------------|--------------------------------------|
+//! | Server secret key  | Application| Authenticate to the WorkOS API       |
+//! | Client API key     | End user   | Sent as bearer token by the caller  |
+//!
+//! The server secret key (`sk_…`) is configured at startup and never leaves
+//! the server. The client API key arrives in every request's bearer token and
+//! is validated by WorkOS on every request.
 
 use serde::{Deserialize, Serialize};
 
@@ -8,11 +22,13 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Runtime WorkOS auth configuration, loaded at startup.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WorkOsConfig {
-    /// If set, the token must be scoped to this organization.
-    /// `None` means any valid WorkOS API key is accepted.
-    pub org_id: Option<String>,
+    /// The server's own WorkOS secret key (`sk_…`), used to authenticate
+    /// calls to the WorkOS API — specifically `POST /api_keys/validations`.
+    pub api_key: String,
+    /// The organization ID the client's API key must belong to.
+    pub org_id: String,
     /// Base URL for the WorkOS API [default: https://api.workos.com].
     pub base_url: String,
 }
@@ -23,7 +39,11 @@ pub struct WorkOsConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    /// If set, the token must be scoped to this organization.
+    /// The server's own WorkOS secret key.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// The organization ID every client API key must belong to.
     #[serde(default)]
     pub org_id: Option<String>,
 
@@ -48,11 +68,20 @@ pub struct WorkOsRejection {
 }
 
 impl Config {
-    /// Produces the runtime form. Fallible — an empty `api_key` means the
-    /// config section was present but incomplete, which is a startup error.
+    /// Produces the runtime form. Fallible — both `api_key` and `org_id` are
+    /// required when WorkOS mode is enabled.
     pub fn load(&self) -> Result<WorkOsConfig, String> {
+        let api_key = self
+            .api_key
+            .clone()
+            .ok_or_else(|| "workos.api_key is required when WorkOS auth is enabled".to_string())?;
+        let org_id = self
+            .org_id
+            .clone()
+            .ok_or_else(|| "workos.org_id is required when WorkOS auth is enabled".to_string())?;
         Ok(WorkOsConfig {
-            org_id: self.org_id.clone(),
+            api_key,
+            org_id,
             base_url: self.base_url.clone(),
         })
     }
@@ -61,6 +90,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            api_key: None,
             org_id: None,
             base_url: default_base_url(),
         }
@@ -68,21 +98,35 @@ impl Default for Config {
 }
 
 // ---------------------------------------------------------------------------
-// WorkOS API response shapes
+// WorkOS API response shapes — POST /api_keys/validations
 // ---------------------------------------------------------------------------
 
-/// Paginated list response from GET /organizations.
+/// Top-level response from `POST /api_keys/validations`.
+/// On success with a valid key: `api_key` is the key object.
+/// On success with an invalid key: `api_key` is `null`.
 #[derive(Debug, Deserialize)]
-struct OrganizationList {
-    data: Vec<Organization>,
+struct ValidateResponse {
+    api_key: Option<ApiKeyObject>,
 }
 
 #[derive(Debug, Deserialize)]
-struct Organization {
-    id: String,
-    #[serde(default)]
+struct ApiKeyObject {
     #[allow(dead_code)]
-    name: String,
+    id: String,
+    owner: Owner,
+}
+
+#[derive(Debug, Deserialize)]
+struct Owner {
+    /// `"organization"` or `"user"`.
+    #[serde(rename = "type")]
+    owner_type: String,
+    /// For org-owned keys: the organization ID.
+    /// For user-owned keys: the user ID.
+    id: String,
+    /// Present on user-owned keys: the organization the user belongs to.
+    #[serde(default)]
+    organization_id: Option<String>,
 }
 
 /// Error response body from WorkOS.
@@ -115,27 +159,28 @@ impl WorkOsClient {
         Self { config, http }
     }
 
-    /// Resolve which organization an API key belongs to.
+    /// Validate a client API key and return the organization ID it belongs to.
     ///
-    /// Calls `GET /organizations` with the API key as Bearer auth and
-    /// returns the first organization ID in the response.
+    /// Calls `POST /api_keys/validations` with the **server's** secret key as
+    /// Bearer auth and the **client's** API key in the request body.
     ///
-    /// Returns `Ok(Some(org_id))` if the key is valid and has at least one
-    /// org; `Ok(None)` if valid but no orgs are accessible; `Err(reason)` if
-    /// the key is invalid or the network call failed.
-    pub async fn resolve_org(&self, api_key: &str) -> Result<Option<String>, String> {
-        let url = format!("{}/organizations", self.config.base_url);
+    /// Returns `Ok(Some(org_id))` if the key is valid and belongs to an
+    /// organization; `Ok(None)` if the key is valid but not scoped to an org;
+    /// `Err(reason)` if the key is invalid or the network call failed.
+    pub async fn validate_key(&self, client_api_key: &str) -> Result<Option<String>, String> {
+        let url = format!("{}/api_keys/validations", self.config.base_url);
 
         let resp = self
             .http
-            .get(&url)
-            .bearer_auth(api_key)
+            .post(&url)
+            .bearer_auth(&self.config.api_key)
+            .json(&serde_json::json!({"value": client_api_key}))
             .send()
             .await
             .map_err(|e| format!("WorkOS request failed: {e}"))?;
 
         if resp.status().as_u16() == 401 {
-            return Err("WorkOS returned 401: invalid API key".into());
+            return Err("WorkOS returned 401: invalid server API key".into());
         }
 
         if !resp.status().is_success() {
@@ -148,12 +193,26 @@ impl WorkOsClient {
             return Err(format!("WorkOS returned {status}: {message}"));
         }
 
-        let list: OrganizationList = resp
+        let body: ValidateResponse = resp
             .json()
             .await
             .map_err(|e| format!("Failed to parse WorkOS response: {e}"))?;
 
-        Ok(list.data.into_iter().next().map(|o| o.id))
+        let key = match body.api_key {
+            Some(k) => k,
+            None => return Err("WorkOS: API key is invalid".into()),
+        };
+
+        // Extract the organization ID from the owner.
+        // - Org-owned keys: owner.type == "organization", owner.id is the org ID.
+        // - User-owned keys: owner.type == "user", owner.organization_id is the org.
+        let org_id = match key.owner.owner_type.as_str() {
+            "organization" => Some(key.owner.id),
+            "user" => key.owner.organization_id,
+            _ => None,
+        };
+
+        Ok(org_id)
     }
 }
 
@@ -163,9 +222,10 @@ impl WorkOsClient {
 
 /// Perform WorkOS authentication for an incoming request.
 ///
-/// 1. Extract bearer token from the `Authorization` header.
-/// 2. Call WorkOS to validate the API key and learn the organization.
-/// 3. If `config.org_id` is set, require the key's org to match.
+/// 1. Extract bearer token from the request.
+/// 2. Call WorkOS `POST /api_keys/validations` with the server's secret key.
+/// 3. Extract the organization from the validated key's owner.
+/// 4. Require the key's org to match the configured `org_id`.
 ///
 /// Returns `Ok(())` when the caller is allowed.
 /// Returns `Err(WorkOsRejection)` with the HTTP status and message.
@@ -184,17 +244,14 @@ pub async fn auth_check_workos(
         }
     };
 
-    let org_id = match client.resolve_org(api_key).await {
+    let org_id = match client.validate_key(api_key).await {
         Ok(Some(id)) => id,
         Ok(None) => {
-            if client.config.org_id.is_some() {
-                tracing::warn!("WorkOS auth rejected: token has no organization");
-                return Err(WorkOsRejection {
-                    status: 403,
-                    message: "Forbidden — token not scoped to an organization".into(),
-                });
-            }
-            return Ok(());
+            tracing::warn!("WorkOS auth rejected: token has no organization");
+            return Err(WorkOsRejection {
+                status: 403,
+                message: "Forbidden — token not scoped to an organization".into(),
+            });
         }
         Err(e) => {
             tracing::warn!(error = %e, "WorkOS auth rejected: key validation failed");
@@ -205,18 +262,16 @@ pub async fn auth_check_workos(
         }
     };
 
-    if let Some(expected) = &client.config.org_id {
-        if org_id != *expected {
-            tracing::warn!(
-                expected = %expected,
-                actual = %org_id,
-                "WorkOS auth rejected: organization mismatch"
-            );
-            return Err(WorkOsRejection {
-                status: 403,
-                message: "Forbidden — organization mismatch".into(),
-            });
-        }
+    if org_id != client.config.org_id {
+        tracing::warn!(
+            expected = %client.config.org_id,
+            actual = %org_id,
+            "WorkOS auth rejected: organization mismatch"
+        );
+        return Err(WorkOsRejection {
+            status: 403,
+            message: "Forbidden — organization mismatch".into(),
+        });
     }
 
     tracing::debug!(org_id = %org_id, "WorkOS auth success");
@@ -231,16 +286,46 @@ mod tests {
 
     fn config() -> WorkOsConfig {
         WorkOsConfig {
-            org_id: None,
+            api_key: "sk_server_secret".into(),
+            org_id: "org_abc".into(),
             base_url: "https://api.workos.com".into(),
         }
     }
 
-    fn client(mock_url: &str, org_id: Option<&str>) -> WorkOsClient {
+    fn client(mock_url: &str, org_id: &str) -> WorkOsClient {
         let mut cfg = config();
         cfg.base_url = mock_url.to_string();
-        cfg.org_id = org_id.map(str::to_owned);
+        cfg.org_id = org_id.to_string();
         WorkOsClient::new(cfg)
+    }
+
+    fn org_owned_key_response(org_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "api_key": {
+                "id": "api_key_123",
+                "owner": {
+                    "type": "organization",
+                    "id": org_id
+                }
+            }
+        })
+    }
+
+    fn user_owned_key_response(org_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "api_key": {
+                "id": "api_key_456",
+                "owner": {
+                    "type": "user",
+                    "id": "user_789",
+                    "organization_id": org_id
+                }
+            }
+        })
+    }
+
+    fn invalid_key_response() -> serde_json::Value {
+        serde_json::json!({"api_key": null})
     }
 
     // ---------------------------------------------------------------
@@ -249,7 +334,7 @@ mod tests {
     #[tokio::test]
     async fn missing_token_is_rejected() {
         let mock = MockServer::start().await;
-        let c = client(&mock.uri(), None);
+        let c = client(&mock.uri(), "org_abc");
         let r = auth_check_workos(&c, None).await;
         assert!(r.is_err());
         assert_eq!(r.unwrap_err().status, 401);
@@ -258,94 +343,114 @@ mod tests {
     #[tokio::test]
     async fn empty_token_is_rejected() {
         let mock = MockServer::start().await;
-        let c = client(&mock.uri(), None);
+        let c = client(&mock.uri(), "org_abc");
         let r = auth_check_workos(&c, Some("")).await;
         assert!(r.is_err());
         assert_eq!(r.unwrap_err().status, 401);
     }
 
     // ---------------------------------------------------------------
-    // Successful authentication
+    // Successful authentication — org-owned key
     // ---------------------------------------------------------------
     #[tokio::test]
-    async fn valid_key_no_org_requirement() {
+    async fn valid_org_owned_key() {
         let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(
-                    serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
-                ),
+                ResponseTemplate::new(200).set_body_json(org_owned_key_response("org_abc")),
             )
             .mount(&mock)
             .await;
 
-        let c = client(&mock.uri(), None);
-        assert!(auth_check_workos(&c, Some("tok")).await.is_ok());
+        let c = client(&mock.uri(), "org_abc");
+        assert!(auth_check_workos(&c, Some("client_key")).await.is_ok());
     }
 
+    // ---------------------------------------------------------------
+    // Successful authentication — user-owned key
+    // ---------------------------------------------------------------
     #[tokio::test]
-    async fn valid_key_matching_required_org() {
+    async fn valid_user_owned_key() {
         let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(
-                    serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
-                ),
+                ResponseTemplate::new(200).set_body_json(user_owned_key_response("org_abc")),
             )
             .mount(&mock)
             .await;
 
-        let c = client(&mock.uri(), Some("org_abc"));
-        assert!(auth_check_workos(&c, Some("tok")).await.is_ok());
+        let c = client(&mock.uri(), "org_abc");
+        assert!(auth_check_workos(&c, Some("client_key")).await.is_ok());
     }
 
     // ---------------------------------------------------------------
-    // Organization-related rejections
+    // Organization mismatch
     // ---------------------------------------------------------------
-    #[tokio::test]
-    async fn key_without_org_when_org_is_required() {
-        let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))
-            .mount(&mock)
-            .await;
-
-        let c = client(&mock.uri(), Some("org_abc"));
-        let r = auth_check_workos(&c, Some("tok")).await;
-        assert!(r.is_err());
-        assert_eq!(r.unwrap_err().status, 403);
-    }
-
     #[tokio::test]
     async fn org_mismatch() {
         let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(
-                    serde_json::json!({"data": [{"id": "org_xyz", "name": "other"}]}),
-                ),
+                ResponseTemplate::new(200).set_body_json(org_owned_key_response("org_xyz")),
             )
             .mount(&mock)
             .await;
 
-        let c = client(&mock.uri(), Some("org_abc"));
-        let r = auth_check_workos(&c, Some("tok")).await;
+        let c = client(&mock.uri(), "org_abc");
+        let r = auth_check_workos(&c, Some("client_key")).await;
         assert!(r.is_err());
         assert_eq!(r.unwrap_err().status, 403);
     }
 
     // ---------------------------------------------------------------
-    // WorkOS API errors
+    // User-owned key with mismatched org
     // ---------------------------------------------------------------
     #[tokio::test]
-    async fn workos_returns_401() {
+    async fn user_key_org_mismatch() {
         let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(user_owned_key_response("org_xyz")),
+            )
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), "org_abc");
+        let r = auth_check_workos(&c, Some("client_key")).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 403);
+    }
+
+    // ---------------------------------------------------------------
+    // Invalid client API key
+    // ---------------------------------------------------------------
+    #[tokio::test]
+    async fn invalid_client_key() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(invalid_key_response()))
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), "org_abc");
+        let r = auth_check_workos(&c, Some("bad_key")).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 401);
+    }
+
+    // ---------------------------------------------------------------
+    // Server secret key is wrong → WorkOS returns 401
+    // ---------------------------------------------------------------
+    #[tokio::test]
+    async fn server_key_rejected_by_workos() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
             .respond_with(
                 ResponseTemplate::new(401)
                     .set_body_json(serde_json::json!({"message": "Invalid API key"})),
@@ -353,25 +458,78 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let c = client(&mock.uri(), None);
-        let r = auth_check_workos(&c, Some("tok")).await;
+        let c = client(&mock.uri(), "org_abc");
+        let r = auth_check_workos(&c, Some("client_key")).await;
         assert!(r.is_err());
         assert_eq!(r.unwrap_err().status, 401);
     }
 
     // ---------------------------------------------------------------
-    // Valid key with no org when none required
+    // Key with no organization
     // ---------------------------------------------------------------
     #[tokio::test]
-    async fn valid_key_no_org_none_required() {
+    async fn key_without_org() {
         let mock = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))
+        Mock::given(method("POST"))
+            .and(path("/api_keys/validations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": {
+                    "id": "api_key_999",
+                    "owner": {
+                        "type": "user",
+                        "id": "user_000"
+                    }
+                }
+            })))
             .mount(&mock)
             .await;
 
-        let c = client(&mock.uri(), None);
-        assert!(auth_check_workos(&c, Some("tok")).await.is_ok());
+        let c = client(&mock.uri(), "org_abc");
+        let r = auth_check_workos(&c, Some("client_key")).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 403);
+    }
+
+    // ---------------------------------------------------------------
+    // Config::load rejects missing api_key
+    // ---------------------------------------------------------------
+    #[test]
+    fn load_rejects_missing_api_key() {
+        let cfg = Config {
+            api_key: None,
+            org_id: Some("org_abc".into()),
+            base_url: default_base_url(),
+        };
+        let err = cfg.load().unwrap_err();
+        assert!(err.contains("api_key"), "{err}");
+    }
+
+    // ---------------------------------------------------------------
+    // Config::load rejects missing org_id
+    // ---------------------------------------------------------------
+    #[test]
+    fn load_rejects_missing_org_id() {
+        let cfg = Config {
+            api_key: Some("sk_secret".into()),
+            org_id: None,
+            base_url: default_base_url(),
+        };
+        let err = cfg.load().unwrap_err();
+        assert!(err.contains("org_id"), "{err}");
+    }
+
+    // ---------------------------------------------------------------
+    // Config::load succeeds with both fields
+    // ---------------------------------------------------------------
+    #[test]
+    fn load_succeeds_with_both_fields() {
+        let cfg = Config {
+            api_key: Some("sk_secret".into()),
+            org_id: Some("org_abc".into()),
+            base_url: default_base_url(),
+        };
+        let loaded = cfg.load().unwrap();
+        assert_eq!(loaded.api_key, "sk_secret");
+        assert_eq!(loaded.org_id, "org_abc");
     }
 }

--- a/crates/resonate-auth/src/workos.rs
+++ b/crates/resonate-auth/src/workos.rs
@@ -1,0 +1,374 @@
+//! WorkOS API key validation — calls GET /organizations with the key as
+//! Bearer auth to learn which organization the key belongs to.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Runtime config
+// ---------------------------------------------------------------------------
+
+/// Runtime WorkOS auth configuration, loaded at startup.
+#[derive(Clone)]
+pub struct WorkOsConfig {
+    /// If set, the token must be scoped to this organization.
+    /// `None` means any valid WorkOS API key is accepted.
+    pub org_id: Option<String>,
+    /// Base URL for the WorkOS API [default: https://api.workos.com].
+    pub base_url: String,
+}
+
+// ---------------------------------------------------------------------------
+/// Deserializable config, like `resonate_auth::Config`.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    /// If set, the token must be scoped to this organization.
+    #[serde(default)]
+    pub org_id: Option<String>,
+
+    /// Base URL for the WorkOS API. Defaults to https://api.workos.com.
+    #[serde(default = "default_base_url")]
+    pub base_url: String,
+}
+
+fn default_base_url() -> String {
+    "https://api.workos.com".to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Rejection
+// ---------------------------------------------------------------------------
+
+/// The reason a WorkOS authentication check was denied.
+#[derive(Debug, Clone)]
+pub struct WorkOsRejection {
+    pub status: u16,
+    pub message: String,
+}
+
+impl Config {
+    /// Produces the runtime form. Fallible — an empty `api_key` means the
+    /// config section was present but incomplete, which is a startup error.
+    pub fn load(&self) -> Result<WorkOsConfig, String> {
+        Ok(WorkOsConfig {
+            org_id: self.org_id.clone(),
+            base_url: self.base_url.clone(),
+        })
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            org_id: None,
+            base_url: default_base_url(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WorkOS API response shapes
+// ---------------------------------------------------------------------------
+
+/// Paginated list response from GET /organizations.
+#[derive(Debug, Deserialize)]
+struct OrganizationList {
+    data: Vec<Organization>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Organization {
+    id: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    name: String,
+}
+
+/// Error response body from WorkOS.
+#[derive(Debug, Deserialize)]
+struct ErrorResponse {
+    #[serde(default)]
+    message: String,
+}
+
+// ---------------------------------------------------------------------------
+// WorkOS client
+// ---------------------------------------------------------------------------
+
+/// A client for WorkOS API key validation.
+///
+/// Stateless: holds the config and an HTTP client, nothing else.
+#[derive(Clone)]
+pub struct WorkOsClient {
+    config: WorkOsConfig,
+    http: reqwest::Client,
+}
+
+impl WorkOsClient {
+    /// Build a client from runtime config at startup.
+    pub fn new(config: WorkOsConfig) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("reqwest client");
+        Self { config, http }
+    }
+
+    /// Resolve which organization an API key belongs to.
+    ///
+    /// Calls `GET /organizations` with the API key as Bearer auth and
+    /// returns the first organization ID in the response.
+    ///
+    /// Returns `Ok(Some(org_id))` if the key is valid and has at least one
+    /// org; `Ok(None)` if valid but no orgs are accessible; `Err(reason)` if
+    /// the key is invalid or the network call failed.
+    pub async fn resolve_org(&self, api_key: &str) -> Result<Option<String>, String> {
+        let url = format!("{}/organizations", self.config.base_url);
+
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(api_key)
+            .send()
+            .await
+           .map_err(|e| format!("WorkOS request failed: {e}"))?;
+
+        if resp.status().as_u16() == 401 {
+            return Err("WorkOS returned 401: invalid API key".into());
+        }
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let message = resp
+                .json::<ErrorResponse>()
+                .await
+                .map(|e| e.message)
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(format!("WorkOS returned {status}: {message}"));
+        }
+
+        let list: OrganizationList = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse WorkOS response: {e}"))?;
+
+        Ok(list.data.into_iter().next().map(|o| o.id))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth check — the entry point called from the HTTP routes
+// ---------------------------------------------------------------------------
+
+/// Perform WorkOS authentication for an incoming request.
+///
+/// 1. Extract bearer token from the `Authorization` header.
+/// 2. Call WorkOS to validate the API key and learn the organization.
+/// 3. If `config.org_id` is set, require the key's org to match.
+///
+/// Returns `Ok(())` when the caller is allowed.
+/// Returns `Err(WorkOsRejection)` with the HTTP status and message.
+pub async fn auth_check_workos(
+    client: &WorkOsClient,
+    token: Option<&str>,
+) -> Result<(), WorkOsRejection> {
+    let api_key = match token {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            tracing::warn!("WorkOS auth rejected: no token in request");
+            return Err(WorkOsRejection {
+                status: 401,
+                message: "Unauthorized".into(),
+            });
+        }
+    };
+
+    let org_id = match client.resolve_org(api_key).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            if client.config.org_id.is_some() {
+                tracing::warn!("WorkOS auth rejected: token has no organization");
+                return Err(WorkOsRejection {
+                    status: 403,
+                    message: "Forbidden — token not scoped to an organization".into(),
+                });
+            }
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "WorkOS auth rejected: key validation failed");
+            return Err(WorkOsRejection {
+                status: 401,
+                message: "Unauthorized".into(),
+            });
+        }
+    };
+
+    if let Some(expected) = &client.config.org_id {
+        if org_id != *expected {
+            tracing::warn!(
+                expected = %expected,
+                actual = %org_id,
+                "WorkOS auth rejected: organization mismatch"
+            );
+            return Err(WorkOsRejection {
+                status: 403,
+                message: "Forbidden — organization mismatch".into(),
+            });
+        }
+    }
+
+    tracing::debug!(org_id = %org_id, "WorkOS auth success");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn config() -> WorkOsConfig {
+        WorkOsConfig {
+            org_id: None,
+            base_url: "https://api.workos.com".into(),
+        }
+    }
+
+    fn client(mock_url: &str, org_id: Option<&str>) -> WorkOsClient {
+        let mut cfg = config();
+        cfg.base_url = mock_url.to_string();
+        cfg.org_id = org_id.map(str::to_owned);
+        WorkOsClient::new(cfg)
+    }
+
+    // ---------------------------------------------------------------
+    // Token extraction
+    // ---------------------------------------------------------------
+    #[tokio::test]
+    async fn missing_token_is_rejected() {
+        let mock = MockServer::start().await;
+        let c = client(&mock.uri(), None);
+        let r = auth_check_workos(&c, None).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 401);
+    }
+
+    #[tokio::test]
+    async fn empty_token_is_rejected() {
+        let mock = MockServer::start().await;
+        let c = client(&mock.uri(), None);
+        let r = auth_check_workos(&c, Some("")).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 401);
+    }
+
+    // ---------------------------------------------------------------
+    // Successful authentication
+    // ---------------------------------------------------------------
+    #[tokio::test]
+    async fn valid_key_no_org_requirement() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), None);
+        assert!(auth_check_workos(&c, Some("tok")).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn valid_key_matching_required_org() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), Some("org_abc"));
+        assert!(auth_check_workos(&c, Some("tok")).await.is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // Organization-related rejections
+    // ---------------------------------------------------------------
+    #[tokio::test]
+    async fn key_without_org_when_org_is_required() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": []}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), Some("org_abc"));
+        let r = auth_check_workos(&c, Some("tok")).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 403);
+    }
+
+    #[tokio::test]
+    async fn org_mismatch() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": [{"id": "org_xyz", "name": "other"}]}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), Some("org_abc"));
+        let r = auth_check_workos(&c, Some("tok")).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 403);
+    }
+
+    // ---------------------------------------------------------------
+    // WorkOS API errors
+    // ---------------------------------------------------------------
+    #[tokio::test]
+    async fn workos_returns_401() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(
+                serde_json::json!({"message": "Invalid API key"}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), None);
+        let r = auth_check_workos(&c, Some("tok")).await;
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().status, 401);
+    }
+
+    // ---------------------------------------------------------------
+    // Valid key with no org when none required
+    // ---------------------------------------------------------------
+    #[tokio::test]
+    async fn valid_key_no_org_none_required() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/organizations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"data": []}),
+            ))
+            .mount(&mock)
+            .await;
+
+        let c = client(&mock.uri(), None);
+        assert!(auth_check_workos(&c, Some("tok")).await.is_ok());
+    }
+}

--- a/crates/resonate-auth/src/workos.rs
+++ b/crates/resonate-auth/src/workos.rs
@@ -132,7 +132,7 @@ impl WorkOsClient {
             .bearer_auth(api_key)
             .send()
             .await
-           .map_err(|e| format!("WorkOS request failed: {e}"))?;
+            .map_err(|e| format!("WorkOS request failed: {e}"))?;
 
         if resp.status().as_u16() == 401 {
             return Err("WorkOS returned 401: invalid API key".into());
@@ -272,9 +272,11 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
+                ),
+            )
             .mount(&mock)
             .await;
 
@@ -287,9 +289,11 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"data": [{"id": "org_abc", "name": "test"}]}),
+                ),
+            )
             .mount(&mock)
             .await;
 
@@ -305,9 +309,7 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": []}),
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))
             .mount(&mock)
             .await;
 
@@ -322,9 +324,11 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": [{"id": "org_xyz", "name": "other"}]}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"data": [{"id": "org_xyz", "name": "other"}]}),
+                ),
+            )
             .mount(&mock)
             .await;
 
@@ -342,9 +346,10 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(401).set_body_json(
-                serde_json::json!({"message": "Invalid API key"}),
-            ))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_json(serde_json::json!({"message": "Invalid API key"})),
+            )
             .mount(&mock)
             .await;
 
@@ -362,9 +367,7 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/organizations"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"data": []}),
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))
             .mount(&mock)
             .await;
 

--- a/crates/resonate-gateway-http/src/lib.rs
+++ b/crates/resonate-gateway-http/src/lib.rs
@@ -100,9 +100,8 @@ impl Default for Config {
 
 /// A router built once the gateway's auth policy is known. See
 /// [`HttpGateway::with_routes`].
-type ExtraRoutes = Box<
-    dyn FnOnce(Option<resonate_auth::AuthMode>) -> axum::Router<routes::AppState> + Send,
->;
+type ExtraRoutes =
+    Box<dyn FnOnce(Option<resonate_auth::AuthMode>) -> axum::Router<routes::AppState> + Send>;
 
 /// axum, hosting the Resonate protocol over HTTP.
 pub struct HttpGateway {
@@ -265,26 +264,27 @@ impl ResonateGateway for HttpGateway {
             // touches the disk and it can fail, which is what `init` is for. A
             // bad key path stops the process here rather than surfacing later
             // as a request nobody can authenticate.
-            let auth: Option<resonate_auth::AuthMode> = match (&self.config.auth, &self.config.workos) {
-                (Some(_), Some(_)) => {
-                    return Err(Unavailable::new(
-                        "auth and workos cannot both be configured — choose exactly one mode",
-                    ));
-                }
-                (Some(cfg), None) => {
-                    let ac = cfg.load().map_err(Unavailable::new)?;
-                    Some(resonate_auth::AuthMode::Jwt(Arc::new(ac)))
-                }
-                (None, Some(cfg)) => {
-                    let wc = cfg.load().map_err(Unavailable::new)?;
-                    let client = resonate_auth::workos::WorkOsClient::new(wc);
-                    Some(resonate_auth::AuthMode::WorkOs(client))
-                }
-                (None, None) => {
-                    tracing::info!("Auth disabled — all requests accepted");
-                    None
-                }
-            };
+            let auth: Option<resonate_auth::AuthMode> =
+                match (&self.config.auth, &self.config.workos) {
+                    (Some(_), Some(_)) => {
+                        return Err(Unavailable::new(
+                            "auth and workos cannot both be configured — choose exactly one mode",
+                        ));
+                    }
+                    (Some(cfg), None) => {
+                        let ac = cfg.load().map_err(Unavailable::new)?;
+                        Some(resonate_auth::AuthMode::Jwt(Arc::new(ac)))
+                    }
+                    (None, Some(cfg)) => {
+                        let wc = cfg.load().map_err(Unavailable::new)?;
+                        let client = resonate_auth::workos::WorkOsClient::new(wc);
+                        Some(resonate_auth::AuthMode::WorkOs(client))
+                    }
+                    (None, None) => {
+                        tracing::info!("Auth disabled — all requests accepted");
+                        None
+                    }
+                };
             let extra = self
                 .extra
                 .lock()

--- a/crates/resonate-gateway-http/src/lib.rs
+++ b/crates/resonate-gateway-http/src/lib.rs
@@ -60,6 +60,12 @@ pub struct Config {
     #[serde(default)]
     pub auth: Option<resonate_auth::Config>,
 
+    /// WorkOS authentication. Absent means WorkOS auth disabled.
+    ///
+    /// If present, `auth` must be `None` — the two modes are mutually exclusive.
+    #[serde(default)]
+    pub workos: Option<resonate_auth::workos::Config>,
+
     /// Abort the process when a handler panics, rather than answering 500.
     ///
     /// For a single-process store — SQLite — a panic mid-transaction can leave
@@ -86,6 +92,7 @@ impl Default for Config {
             url: None,
             cors_allow_origins: Vec::new(),
             auth: None,
+            workos: None,
             abort_on_panic: false,
         }
     }
@@ -94,7 +101,7 @@ impl Default for Config {
 /// A router built once the gateway's auth policy is known. See
 /// [`HttpGateway::with_routes`].
 type ExtraRoutes = Box<
-    dyn FnOnce(Option<Arc<resonate_auth::AuthConfig>>) -> axum::Router<routes::AppState> + Send,
+    dyn FnOnce(Option<resonate_auth::AuthMode>) -> axum::Router<routes::AppState> + Send,
 >;
 
 /// axum, hosting the Resonate protocol over HTTP.
@@ -161,7 +168,7 @@ impl HttpGateway {
     /// requests here has to be able to apply it.
     pub fn with_routes(
         self,
-        build: impl FnOnce(Option<Arc<resonate_auth::AuthConfig>>) -> axum::Router<routes::AppState>
+        build: impl FnOnce(Option<resonate_auth::AuthMode>) -> axum::Router<routes::AppState>
             + Send
             + 'static,
     ) -> Self {
@@ -258,9 +265,22 @@ impl ResonateGateway for HttpGateway {
             // touches the disk and it can fail, which is what `init` is for. A
             // bad key path stops the process here rather than surfacing later
             // as a request nobody can authenticate.
-            let auth = match &self.config.auth {
-                Some(cfg) => Some(Arc::new(cfg.load().map_err(Unavailable::new)?)),
-                None => {
+            let auth: Option<resonate_auth::AuthMode> = match (&self.config.auth, &self.config.workos) {
+                (Some(_), Some(_)) => {
+                    return Err(Unavailable::new(
+                        "auth and workos cannot both be configured — choose exactly one mode",
+                    ));
+                }
+                (Some(cfg), None) => {
+                    let ac = cfg.load().map_err(Unavailable::new)?;
+                    Some(resonate_auth::AuthMode::Jwt(Arc::new(ac)))
+                }
+                (None, Some(cfg)) => {
+                    let wc = cfg.load().map_err(Unavailable::new)?;
+                    let client = resonate_auth::workos::WorkOsClient::new(wc);
+                    Some(resonate_auth::AuthMode::WorkOs(client))
+                }
+                (None, None) => {
                     tracing::info!("Auth disabled — all requests accepted");
                     None
                 }

--- a/crates/resonate-gateway-http/src/routes.rs
+++ b/crates/resonate-gateway-http/src/routes.rs
@@ -22,7 +22,7 @@ use axum::{
 use lazy_static::lazy_static;
 use prometheus::{register_counter_vec, register_histogram_vec, CounterVec, HistogramVec};
 
-use resonate_auth::{auth_check, auth_check_token, AuthConfig};
+use resonate_auth::AuthMode;
 use resonate_core::types::{self, RequestEnvelope, ResponseEnvelope};
 use resonate_core::{ui, ResonateServer};
 use resonate_transport_http_poll::PollRegistry;
@@ -65,7 +65,7 @@ lazy_static! {
 #[derive(Clone)]
 pub struct AppState {
     pub server: Arc<dyn ResonateServer>,
-    pub auth: Option<Arc<AuthConfig>>,
+    pub auth: Option<AuthMode>,
     pub poll_registry: Arc<PollRegistry>,
 }
 
@@ -73,7 +73,7 @@ pub struct AppState {
 #[derive(Clone)]
 pub struct ApiState {
     pub server: Arc<dyn ResonateServer>,
-    pub auth: Option<Arc<AuthConfig>>,
+    pub auth: Option<AuthMode>,
 }
 
 impl axum::extract::FromRef<AppState> for ApiState {
@@ -88,7 +88,7 @@ impl axum::extract::FromRef<AppState> for ApiState {
 // Sub-state for poll handler — authentication and the connection registry.
 #[derive(Clone)]
 pub struct PollState {
-    pub auth: Option<Arc<AuthConfig>>,
+    pub auth: Option<AuthMode>,
     pub poll_registry: Arc<PollRegistry>,
 }
 
@@ -201,22 +201,22 @@ async fn handle_api(
         "Received request"
     );
 
-    if let Some(auth) = &api_state.auth {
-        if let Err(err_response) = auth_check(auth, &req) {
-            let status = err_response.head.status.to_string();
+    if let Some(mode) = &api_state.auth {
+        if let Err(rejection) = mode.check_envelope(&req).await {
+            let status_str = rejection.head.status.to_string();
             let elapsed_ms = start.elapsed().as_millis();
             tracing::warn!(
                 kind = %kind,
                 corr_id = %corr_id,
-                status = %status,
+                status = %status_str,
                 elapsed_ms = elapsed_ms,
                 "Request rejected by auth"
             );
-            REQUEST_TOTAL.with_label_values(&[&kind, &status]).inc();
+            REQUEST_TOTAL.with_label_values(&[&kind, &status_str]).inc();
             REQUEST_DURATION
                 .with_label_values(&[&kind])
                 .observe(start.elapsed().as_secs_f64());
-            return into_response(*err_response);
+            return into_response(*rejection);
         }
     }
 
@@ -270,13 +270,13 @@ async fn handle_poll(
     Path((group, id)): Path<(String, String)>,
 ) -> Response {
     // Authenticate when auth is configured.
-    if let Some(auth) = &poll_state.auth {
+    if let Some(mode) = &poll_state.auth {
         let token = headers
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "));
 
-        if auth_check_token(auth, token).is_err() {
+        if mode.check_token(token).await.is_err() {
             tracing::warn!(group = %group, id = %id, "Poll connection rejected: unauthorized");
             return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
         }

--- a/crates/resonate-gateway-http/src/routes.rs
+++ b/crates/resonate-gateway-http/src/routes.rs
@@ -276,7 +276,7 @@ async fn handle_poll(
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "));
 
-        if mode.check_token(token).await.is_err() {
+        if !mode.check_token(token).await {
             tracing::warn!(group = %group, id = %id, "Poll connection rejected: unauthorized");
             return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
         }

--- a/crates/resonate-gateway-web/src/lib.rs
+++ b/crates/resonate-gateway-web/src/lib.rs
@@ -58,7 +58,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use resonate_auth::{auth_check, AuthConfig};
+use resonate_auth::AuthMode;
 use resonate_core::types::{self, RequestEnvelope, ResponseEnvelope};
 use resonate_core::{ui, ResonateServer};
 use rust_embed::Embed;
@@ -113,7 +113,7 @@ impl Default for Config {
 #[derive(Clone)]
 pub struct ConsoleState {
     pub server: Arc<dyn ResonateServer>,
-    pub auth: Option<Arc<AuthConfig>>,
+    pub auth: Option<AuthMode>,
 }
 
 /// The console's routes, ready to merge into any router.
@@ -258,8 +258,8 @@ async fn handle_rpc(
     let kind = req.kind.clone();
     let corr_id = req.head.corr_id.clone();
 
-    if let Some(auth) = &state.auth {
-        if let Err(rejection) = auth_check(auth, &req) {
+    if let Some(mode) = &state.auth {
+        if let Err(rejection) = mode.check_envelope(&req).await {
             tracing::warn!(kind = %kind, corr_id = %corr_id, "Console request rejected by auth");
             return render(*rejection);
         }

--- a/diff/differential.rs
+++ b/diff/differential.rs
@@ -1325,7 +1325,7 @@ fn gen_schedule_create(rng: &mut fastrand::Rng, now: i64) -> RequestEnvelope {
         json!({
             "id": id,
             "cron": "* * * * *",
-            "promiseId": format!("sched-promise-{{{{.id}}}}-{{{{.timestamp}}}}"),
+            "promiseId": "sched-promise-{{.id}}-{{.timestamp}}".to_string(),
             "promiseTimeout": promise_timeout,
             "promiseParam": {},
             "promiseTags": { "resonate:target": WORKER_URL }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,6 +82,19 @@ pub struct CommonArgs {
     #[arg(long = "auth-aud", value_name = "AUD")]
     pub auth_aud: Option<String>,
 
+    // --- WorkOS Auth ---
+    /// Enable WorkOS auth mode — every request must carry a WorkOS API key as bearer token
+    #[arg(long = "workos")]
+    pub workos: bool,
+
+    /// Organization ID the token must belong to (optional; omitting accepts any valid WorkOS key)
+    #[arg(long = "workos-org-id", value_name = "ORG")]
+    pub workos_org_id: Option<String>,
+
+    /// WorkOS API base URL [default: https://api.workos.com]
+    #[arg(long = "workos-base-url", value_name = "URL")]
+    pub workos_base_url: Option<String>,
+
     // --- Tasks ---
     /// Task lease timeout (ms) [default: 15000]
     #[arg(long = "tasks-lease-timeout", value_name = "MS")]
@@ -245,6 +258,18 @@ impl CommonArgs {
             if let Some(v) = self.auth_aud {
                 auth.aud = Some(v);
             }
+        }
+
+        if self.workos {
+            config.workos.get_or_insert_with(resonate_auth::workos::Config::default);
+        }
+        if let Some(oid) = self.workos_org_id {
+            let w = config.workos.get_or_insert_with(resonate_auth::workos::Config::default);
+            w.org_id = Some(oid);
+        }
+        if let Some(url) = self.workos_base_url {
+            let w = config.workos.get_or_insert_with(resonate_auth::workos::Config::default);
+            w.base_url = url;
         }
 
         if let Some(v) = self.tasks_lease_timeout {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,7 +87,11 @@ pub struct CommonArgs {
     #[arg(long = "workos")]
     pub workos: bool,
 
-    /// Organization ID the token must belong to (optional; omitting accepts any valid WorkOS key)
+    /// Server's WorkOS secret key (sk_…) used to call POST /api_keys/validations
+    #[arg(long = "workos-api-key", value_name = "KEY")]
+    pub workos_api_key: Option<String>,
+
+    /// Organization ID the client token must belong to (required when WorkOS is enabled)
     #[arg(long = "workos-org-id", value_name = "ORG")]
     pub workos_org_id: Option<String>,
 
@@ -264,6 +268,12 @@ impl CommonArgs {
             config
                 .workos
                 .get_or_insert_with(resonate_auth::workos::Config::default);
+        }
+        if let Some(key) = self.workos_api_key {
+            let w = config
+                .workos
+                .get_or_insert_with(resonate_auth::workos::Config::default);
+            w.api_key = Some(key);
         }
         if let Some(oid) = self.workos_org_id {
             let w = config

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -261,14 +261,20 @@ impl CommonArgs {
         }
 
         if self.workos {
-            config.workos.get_or_insert_with(resonate_auth::workos::Config::default);
+            config
+                .workos
+                .get_or_insert_with(resonate_auth::workos::Config::default);
         }
         if let Some(oid) = self.workos_org_id {
-            let w = config.workos.get_or_insert_with(resonate_auth::workos::Config::default);
+            let w = config
+                .workos
+                .get_or_insert_with(resonate_auth::workos::Config::default);
             w.org_id = Some(oid);
         }
         if let Some(url) = self.workos_base_url {
-            let w = config.workos.get_or_insert_with(resonate_auth::workos::Config::default);
+            let w = config
+                .workos
+                .get_or_insert_with(resonate_auth::workos::Config::default);
             w.base_url = url;
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,13 @@ pub struct Config {
     #[serde(default)]
     pub auth: Option<resonate_auth::Config>,
 
+    /// WorkOS authentication configuration. Absent = WorkOS auth disabled.
+    ///
+    /// `auth` and `workos` together is a startup error: exactly one mode
+    /// must be active or neither.
+    #[serde(default)]
+    pub workos: Option<resonate_auth::workos::Config>,
+
     /// Task configuration
     #[serde(default)]
     pub tasks: TasksConfig,
@@ -402,6 +409,7 @@ impl Default for Config {
             server: ServerConfig::default(),
             storage: StorageConfig::default(),
             auth: None,
+            workos: None,
             tasks: TasksConfig::default(),
             timeouts: TimeoutsConfig::default(),
             transports: TransportsConfig::default(),
@@ -463,6 +471,13 @@ impl Config {
         }
         if self.transports.gcps.concurrency == 0 {
             return Err("transports.gcps.concurrency must be at least 1 (got 0)".to_string());
+        }
+
+        // Auth and WorkOS are mutually exclusive modes.
+        if self.auth.is_some() && self.workos.is_some() {
+            return Err(
+                "auth and workos cannot both be configured — choose exactly one mode".into(),
+            );
         }
 
         // `task.acquire` validates `ttl >= 1`, so a non-positive lease would

--- a/src/config.rs
+++ b/src/config.rs
@@ -480,6 +480,16 @@ impl Config {
             );
         }
 
+        // WorkOS mode requires both api_key and org_id.
+        if let Some(ref w) = self.workos {
+            if w.api_key.is_none() {
+                return Err("workos.api_key is required when WorkOS auth is enabled".into());
+            }
+            if w.org_id.is_none() {
+                return Err("workos.org_id is required when WorkOS auth is enabled".into());
+            }
+        }
+
         // `task.acquire` validates `ttl >= 1`, so a non-positive lease would
         // make every acquire fail with a 400 and the worker would silently
         // never run anything. Reject it here instead.

--- a/src/main.rs
+++ b/src/main.rs
@@ -455,6 +455,7 @@ async fn run_server(config: Config) -> Result<(), String> {
             // Carried through, not interpreted: the gateway reads the key in
             // `init`, and a bad path fails startup there.
             auth: state.config.auth.clone(),
+            workos: state.config.workos.clone(),
             // SQLite lives in this process, so a panic mid-transaction can
             // leave state the next request would read.
             abort_on_panic: is_sqlite,

--- a/test/test_workos_startup.rs
+++ b/test/test_workos_startup.rs
@@ -4,7 +4,6 @@
 /// This validates the shape of the config, not the loader.
 /// Use `toml::from_str` directly to test deserialization without
 /// touching the filesystem loader or env vars.
-
 use resonate::config::Config;
 
 #[test]

--- a/test/test_workos_startup.rs
+++ b/test/test_workos_startup.rs
@@ -1,0 +1,22 @@
+/// Integration test: verify that a Config with a workos section
+/// deserializes correctly from a TOML file.
+///
+/// This validates the shape of the config, not the loader.
+/// Use `toml::from_str` directly to test deserialization without
+/// touching the filesystem loader or env vars.
+
+use resonate::config::Config;
+
+#[test]
+fn workos_config_loads_with_memory_storage() {
+    let text = std::fs::read_to_string("test/workos_config.toml")
+        .expect("workos_config.toml should exist");
+
+    let config: Config = toml::from_str(&text).expect("workos config should parse as TOML");
+
+    assert!(config.workos.is_some(), "workos field should be present");
+    let w = config.workos.as_ref().unwrap();
+    // api_key removed — clients send their own key
+    // client_id removed — clients send their own
+    assert_eq!(w.org_id.as_deref(), Some("org_abc"));
+}

--- a/test/test_workos_startup.rs
+++ b/test/test_workos_startup.rs
@@ -15,7 +15,6 @@ fn workos_config_loads_with_memory_storage() {
 
     assert!(config.workos.is_some(), "workos field should be present");
     let w = config.workos.as_ref().unwrap();
-    // api_key removed — clients send their own key
-    // client_id removed — clients send their own
+    assert_eq!(w.api_key.as_deref(), Some("sk_server_secret"));
     assert_eq!(w.org_id.as_deref(), Some("org_abc"));
 }

--- a/test/workos_config.toml
+++ b/test/workos_config.toml
@@ -1,0 +1,11 @@
+level = "debug"
+debug = true
+
+[storage]
+type = "sqlite"
+
+[storage.sqlite]
+path = ":memory:"
+
+[workos]
+org_id = "org_abc"

--- a/test/workos_config.toml
+++ b/test/workos_config.toml
@@ -8,4 +8,5 @@ type = "sqlite"
 path = ":memory:"
 
 [workos]
+api_key = "sk_server_secret"
 org_id = "org_abc"


### PR DESCRIPTION
## What

Adds a WorkOS authentication mode to the API gateway. Each client sends their own WorkOS API key as the bearer token in the protocol envelope (`head.auth`), and the server validates it by calling `POST /api_keys/validations`. The server must be configured with its own WorkOS secret key and the target organization ID — both are required at startup.

## Why

For deployments where users already have WorkOS API keys, this lets them use those same keys as bearer tokens — no separate JWT infrastructure, no public key management, no client-side token generation.

## How it works

**Two keys, two roles:**

| Key | Owner | Purpose |
|---|---|---|
| Server secret key (`sk_…`) | Our application | Authenticates the server to the WorkOS API |
| Client API key | End user | Sent as `head.auth` in every request |

**Server startup:**

```
resonate serve --workos --workos-api-key sk_… --workos-org-id org_…
```

Both `--workos-api-key` and `--workos-org-id` are **required** when WorkOS mode is enabled. The server refuses to start without them.

**Auth middleware, on every request:**

1. Extract `head.auth` from the protocol envelope
2. No token → `401` immediately, zero network cost
3. Token present → `POST https://api.workos.com/api_keys/validations`
   - Authorization: `Bearer <server_secret_key>`
   - Body: `{"value": "<client_api_key>"}`
4. WorkOS returns the key owner:
   - Org-owned key: `{"type":"organization","id":"org_xxx"}`
   - User-owned key: `{"type":"user","id":"user_xxx","organization_id":"org_xxx"}`
5. Extract the org ID and require it to match the configured `--workos-org-id`
6. Match → request proceeds. Mismatch → `403`.

**Routes protected:** The protocol RPC endpoint (`POST /`), the console RPC (`POST /console/rpc`), and the poll/SSE endpoint (`GET /poll/:group/:id`) all share the same auth check. The poll endpoint reads the token from the HTTP `Authorization` header; the RPC endpoints read it from `head.auth` in the envelope body.

**Config:** The `[workos]` TOML section has three fields — `api_key` (required), `org_id` (required), and `base_url` (defaults to `https://api.workos.com`). A `--workos` CLI flag enables the mode; `--workos-api-key`, `--workos-org-id`, and `--workos-base-url` refine it.

**Failure handling:** A 5-second timeout on the HTTP client prevents hung requests if WorkOS is unreachable. The `WorkOsRejection` type carries both `status: u16` and `message: String` so callers render the response without unpacking and reinterpreting errors.

**Security:**
- The server secret key never leaves the server
- The client key is validated by WorkOS on every request — not cached
- No token → rejected before any network call
- `org_id` is mandatory — no "accept any org" mode
- `auth` and `workos` cannot both be active simultaneously

## Code changes

- `crates/resonate-auth/src/workos.rs` — WorkOS client, `POST /api_keys/validations` call, `validate_key` entry point, `WorkOsRejection` error type
- `crates/resonate-auth/src/lib.rs` — `AuthMode` enum (JWT / WorkOs), `check_envelope()` and `check_token()` dispatch methods (return `bool` instead of `Result<(), ()>`)
- `crates/resonate-gateway-http/src/lib.rs` — loads WorkOS config in `init()`, mutually exclusive check with `auth`
- `crates/resonate-gateway-http/src/routes.rs` — all three handlers dispatch through `AuthMode`
- `crates/resonate-gateway-web/src/lib.rs` — same dispatch for the console route
- `src/cli.rs` / `src/config.rs` / `src/main.rs` — `--workos` flag, `--workos-api-key` flag, `[workos]` config section, validation that both `api_key` and `org_id` are present
- `diff/differential.rs` — fix clippy `useless_format` warning
- `test/` — TOML config integration test, 12 wiremock unit tests covering every branch