### PR TITLE
auth priority

### DIFF
--- a/crates/resonate-gateway-http/src/routes.rs
+++ b/crates/resonate-gateway-http/src/routes.rs
@@ -152,8 +152,21 @@ fn into_response(resp: ResponseEnvelope) -> (axum::http::StatusCode, Json<Respon
     (code, Json(resp))
 }
 
+/// The bearer token from the `Authorization` header, when one is present.
+///
+/// Exact `Bearer ` prefix, the same shape the SDKs send. A missing header or
+/// a non-bearer scheme yields `None`; an empty value yields `Some("")`, which
+/// verification rejects downstream.
+fn bearer_token(headers: &axum::http::HeaderMap) -> Option<&str> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+}
+
 async fn handle_api(
     State(api_state): State<ApiState>,
+    headers: axum::http::HeaderMap,
     body: axum::body::Bytes,
 ) -> (axum::http::StatusCode, Json<ResponseEnvelope>) {
     let server = &api_state.server;
@@ -164,7 +177,7 @@ async fn handle_api(
     // rejection reads, and this renders it — which is the only part that is
     // HTTP's. `salvage_context` digs out what it can from bytes that would not
     // parse, so even that answer can be correlated.
-    let req: RequestEnvelope = match types::parse_and_validate(&body) {
+    let mut req: RequestEnvelope = match types::parse_and_validate(&body) {
         Ok(req) => req,
         Err(invalid) => {
             let (kind, corr_id) = types::salvage_context(&body);
@@ -172,6 +185,15 @@ async fn handle_api(
             return into_response(invalid.to_response(kind, corr_id));
         }
     };
+
+    // Auth: envelope first, HTTP header second. The SDKs send the token in
+    // both places, so the envelope normally wins; the header is the fallback
+    // for callers that carry only a bearer token and no `head.auth`.
+    if req.head.auth.is_none() {
+        if let Some(token) = bearer_token(&headers) {
+            req.head.auth = Some(token.to_string());
+        }
+    }
 
     let kind = req.kind.clone();
     let corr_id = req.head.corr_id.clone();
@@ -271,10 +293,7 @@ async fn handle_poll(
 ) -> Response {
     // Authenticate when auth is configured.
     if let Some(mode) = &poll_state.auth {
-        let token = headers
-            .get(axum::http::header::AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "));
+        let token = bearer_token(&headers);
 
         if !mode.check_token(token).await {
             tracing::warn!(group = %group, id = %id, "Poll connection rejected: unauthorized");
@@ -338,5 +357,31 @@ impl Drop for PollGuard {
         tokio::spawn(async move {
             registry.deregister(&group, conn_id).await;
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bearer_token;
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::HeaderMap;
+
+    #[test]
+    fn bearer_token_extracts_exact_prefix() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer abc123".parse().unwrap());
+        assert_eq!(bearer_token(&headers), Some("abc123"));
+    }
+
+    #[test]
+    fn bearer_token_rejects_non_bearer_schemes() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Basic abc123".parse().unwrap());
+        assert_eq!(bearer_token(&headers), None);
+    }
+
+    #[test]
+    fn bearer_token_is_none_when_absent() {
+        assert_eq!(bearer_token(&HeaderMap::new()), None);
     }
 }


### PR DESCRIPTION
## Why

The SDKs dual-authenticate: they put the token in the JSON envelope's `head.auth` **and** set an `Authorization: Bearer` header on every request. The server only ever read the envelope, so a caller that carries just the header — curl, a proxy, a header-only client — was rejected as unauthorized even though the token was sitting right there on the request.

This makes the server's HTTP transport accept both, with the envelope taking precedence.

## What

One change in the worker endpoint, one shared helper, and the poll endpoint switched over to it:

- **Envelope first, header second.** `handle_api` now reads the `Authorization` header, and when `head.auth` is absent it copies the bearer token into the envelope before the existing `check_envelope` path runs. When both are present the envelope wins; when the envelope has none, the header is the fallback. The rest of the auth path — JWT verification, WorkOS validation, prefix authorization — is untouched, so both modes pick up the fallback automatically.
- **`bearer_token` helper.** Extracts the token from `Authorization: Bearer …` (exact `Bearer ` prefix). A missing header or a non-bearer scheme yields `None`.
- **Poll endpoint DRY'd.** `handle_poll` already read the header and now uses the same `bearer_token` helper instead of its own inline copy. Behavior is unchanged.

## Behavior changes

- Header-only requests to the worker endpoint (`POST /`) that previously 401'd now authenticate, when auth is configured and the token is valid.
- Requests that already sent `head.auth` behave exactly as before — the header is only consulted when the envelope has no token.
- No change to the `/poll` SSE endpoint's authentication behavior.

## Known follow-up

The web console's RPC route (`resonate-gateway-web`) is still envelope-only and does not fall back to the header. It's a separate gateway, not the worker transport, so it's left as-is here.

## Test plan

- [x] `cargo build -p resonate-gateway-http`
- [x] `cargo test -p resonate-gateway-http` — 3 new tests cover `bearer_token` (exact-prefix extraction, non-bearer rejection, absent header)
